### PR TITLE
Remove saved color persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,43 +2,17 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>Éditeur de baronnies – Mode pixel</title>
+  <title>Carte des baronnies</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header class="app-header">
-    <h1>Éditeur de baronnies – Mode pixel</h1>
+    <h1>Carte des baronnies</h1>
     <div id="controls" class="controls-row">
-      <button id="toggleEdit" class="control-btn">Mode&nbsp;édition</button>
       <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
-      <button id="exportJson" class="control-btn">Exporter JSON</button>
-      <button id="saveToFile" class="control-btn">Enregistrer</button>
       <label class="file-label control-btn">
         Importer JSON
         <input type="file" id="jsonFileInput" accept=".json">
-      </label>
-      <button id="deleteBarony" class="control-btn">Supprimer</button>
-      <button id="mergeBarony" class="control-btn">Fusionner</button>
-      <button id="toggleMap" class="control-btn">Changer fond</button>
-    </div>
-    <div id="tools" class="tools-row">
-      <button id="brushTool" class="tool-btn" title="Pinceau">
-        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M2 15 L14 3 L17 6 L5 18 Z" fill="currentColor"></path></svg>
-      </button>
-      <button id="eraserTool" class="tool-btn" title="Gomme">
-        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M3 15 L8 10 L15 17 L10 17 Z" fill="currentColor"></path><path d="M8 10 L11 7 L17 13 L15 15 Z" fill="currentColor"></path></svg>
-      </button>
-      <button id="bucketTool" class="tool-btn" title="Pot de peinture">
-        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M5 5 L15 5 L17 9 L3 9 Z" fill="currentColor"></path><path d="M7 9 L7 15 L13 15 L13 9 Z" fill="currentColor"></path></svg>
-      </button>
-      <button id="newBarony" class="tool-btn" title="Nouvelle baronnie">
-        <svg width="20" height="20" viewBox="0 0 20 20">
-          <rect x="9" y="2" width="2" height="16" fill="currentColor"></rect>
-          <rect x="2" y="9" width="16" height="2" fill="currentColor"></rect>
-        </svg>
-      </button>
-      <label for="brushSize" class="brush-size-label">Taille&nbsp;
-        <input type="range" id="brushSize" min="1" max="10" value="1">
       </label>
     </div>
   </header>
@@ -49,16 +23,8 @@
         <canvas id="pixelCanvas" class="pixel-canvas"></canvas>
       </div>
     </div>
-    <aside id="infoPanel" class="info-panel" style="display: none;">
-      <h2>Baronnie sélectionnée</h2>
-      <label for="editId">Numéro&nbsp;:</label>
-      <input type="text" id="editId">
-      <label for="editName">Nom&nbsp;:</label>
-      <input type="text" id="editName">
-      <button id="updateBarony" class="control-btn">Mettre à jour</button>
-    </aside>
   </main>
   <script src="pixelData.js"></script>
-  <script src="script.js"></script>
+  <script src="viewer.js"></script>
 </body>
 </html>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Éditeur de baronnies – Mode pixel</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <h1>Éditeur de baronnies – Mode pixel</h1>
+    <div id="controls" class="controls-row">
+      <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
+      <button id="exportJson" class="control-btn">Exporter JSON</button>
+      <button id="saveToFile" class="control-btn">Enregistrer</button>
+      <label class="file-label control-btn">
+        Importer JSON
+        <input type="file" id="jsonFileInput" accept=".json">
+      </label>
+      <button id="deleteBarony" class="control-btn">Supprimer</button>
+      <button id="mergeBarony" class="control-btn">Fusionner</button>
+      <button id="toggleMap" class="control-btn">Changer fond</button>
+    </div>
+    <div id="tools" class="tools-row">
+      <button id="brushTool" class="tool-btn" title="Pinceau">
+        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M2 15 L14 3 L17 6 L5 18 Z" fill="currentColor"></path></svg>
+      </button>
+      <button id="eraserTool" class="tool-btn" title="Gomme">
+        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M3 15 L8 10 L15 17 L10 17 Z" fill="currentColor"></path><path d="M8 10 L11 7 L17 13 L15 15 Z" fill="currentColor"></path></svg>
+      </button>
+      <button id="bucketTool" class="tool-btn" title="Pot de peinture">
+        <svg width="20" height="20" viewBox="0 0 20 20"><path d="M5 5 L15 5 L17 9 L3 9 Z" fill="currentColor"></path><path d="M7 9 L7 15 L13 15 L13 9 Z" fill="currentColor"></path></svg>
+      </button>
+      <button id="newBarony" class="tool-btn" title="Nouvelle baronnie">
+        <svg width="20" height="20" viewBox="0 0 20 20">
+          <rect x="9" y="2" width="2" height="16" fill="currentColor"></rect>
+          <rect x="2" y="9" width="16" height="2" fill="currentColor"></rect>
+        </svg>
+      </button>
+      <label for="brushSize" class="brush-size-label">Taille&nbsp;
+        <input type="range" id="brushSize" min="1" max="10" value="1">
+      </label>
+    </div>
+  </header>
+  <main>
+    <div id="mapContainer" class="map-container">
+      <div id="panZoomGroup" class="panzoom-group">
+        <img id="baseMap" src="Asgaria.png" alt="Carte d’Asgaria" class="base-map">
+        <canvas id="pixelCanvas" class="pixel-canvas"></canvas>
+      </div>
+    </div>
+    <aside id="infoPanel" class="info-panel" style="display: none;">
+      <h2>Baronnie sélectionnée</h2>
+      <label for="editId">Numéro&nbsp;:</label>
+      <input type="text" id="editId">
+      <label for="editName">Nom&nbsp;:</label>
+      <input type="text" id="editName">
+      <button id="updateBarony" class="control-btn">Mettre à jour</button>
+    </aside>
+  </main>
+  <script>window.defaultEditMode = true;</script>
+  <script src="pixelData.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/viewer.js
+++ b/viewer.js
@@ -1,0 +1,200 @@
+(() => {
+  const originalWidth = 1724;
+  const originalHeight = 1291;
+
+  let pixelData;
+  const saved = localStorage.getItem('baronnies_pixels');
+  if (saved) {
+    try {
+      pixelData = JSON.parse(saved);
+    } catch {
+      pixelData = window.pixelData || {};
+    }
+  } else {
+    pixelData = window.pixelData || {};
+  }
+
+  const pixelMap = Array.from({ length: originalHeight }, () => new Array(originalWidth).fill(0));
+  function rebuildPixelMap() {
+    for (let y = 0; y < originalHeight; y++) pixelMap[y].fill(0);
+    Object.entries(pixelData).forEach(([id, coords]) => {
+      coords.forEach(([x, y]) => {
+        if (y >= 0 && y < originalHeight && x >= 0 && x < originalWidth) {
+          pixelMap[y][x] = String(id);
+        }
+      });
+    });
+  }
+  rebuildPixelMap();
+
+  function hslToRgb(h, s, l) {
+    s /= 100;
+    l /= 100;
+    const k = n => (n + h / 30) % 12;
+    const a = s * Math.min(l, 1 - l);
+    const f = n => {
+      const color = l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+      return Math.round(255 * color);
+    };
+    return [f(0), f(8), f(4)];
+  }
+  function generateColor(id) {
+    const num = parseInt(id, 10);
+    const hue = (num * 137) % 360;
+    const [r, g, b] = hslToRgb(hue, 65, 65);
+    // Couleurs translucides par défaut (alpha 100)
+    return [r, g, b, 100];
+  }
+
+  let colorMap = {};
+  function initColorMap() {
+    colorMap = {};
+    Object.keys(pixelData).forEach(id => {
+      if (!colorMap[id]) {
+        colorMap[id] = generateColor(id);
+      }
+    });
+  }
+  initColorMap();
+
+  function randomizeColors() {
+    colorMap = {};
+    Object.keys(pixelData).forEach(id => {
+      const hue = Math.floor(Math.random() * 360);
+      const [r, g, b] = hslToRgb(hue, 65, 65);
+      colorMap[id] = [r, g, b, 100];
+    });
+    drawAll();
+  }
+
+  const baseMap = document.getElementById('baseMap');
+  const pixelCanvas = document.getElementById('pixelCanvas');
+  const panZoomGroup = document.getElementById('panZoomGroup');
+  const mapContainer = document.getElementById('mapContainer');
+  const importInput = document.getElementById('jsonFileInput');
+  const randomBtn = document.getElementById('randomColors');
+
+  const ctx = pixelCanvas.getContext('2d');
+  pixelCanvas.width = originalWidth;
+  pixelCanvas.height = originalHeight;
+  ctx.imageSmoothingEnabled = false;
+
+  let scale = 1;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  function applyTransform() {
+    panZoomGroup.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+  }
+  function fitToContainer() {
+    const contW = mapContainer.clientWidth;
+    const contH = mapContainer.clientHeight;
+    scale = Math.min(contW / originalWidth, contH / originalHeight);
+    offsetX = (contW - originalWidth * scale) / 2;
+    offsetY = (contH - originalHeight * scale) / 2;
+    applyTransform();
+  }
+
+  function drawAll() {
+    const imageData = ctx.createImageData(originalWidth, originalHeight);
+    const data = imageData.data;
+    let idx = 0;
+    for (let y = 0; y < originalHeight; y++) {
+      for (let x = 0; x < originalWidth; x++) {
+        const id = pixelMap[y][x];
+        if (id && colorMap[id]) {
+          const col = colorMap[id];
+          data[idx++] = col[0];
+          data[idx++] = col[1];
+          data[idx++] = col[2];
+          data[idx++] = col[3];
+        } else {
+          data[idx++] = 0;
+          data[idx++] = 0;
+          data[idx++] = 0;
+          data[idx++] = 0;
+        }
+      }
+    }
+    ctx.putImageData(imageData, 0, 0);
+  }
+
+  function importJson(file) {
+    const reader = new FileReader();
+    reader.onload = ev => {
+      try {
+        pixelData = JSON.parse(ev.target.result);
+        localStorage.setItem('baronnies_pixels', JSON.stringify(pixelData));
+        rebuildPixelMap();
+        initColorMap();
+        drawAll();
+      } catch (err) {
+        alert('Fichier JSON invalide.');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  function handleWheel(e) {
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 1.1 : 0.9;
+    const rect = panZoomGroup.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) / scale;
+    const my = (e.clientY - rect.top) / scale;
+    const prevScale = scale;
+    scale *= factor;
+    scale = Math.max(0.2, Math.min(scale, 10));
+    offsetX -= mx * (scale - prevScale);
+    offsetY -= my * (scale - prevScale);
+    applyTransform();
+  }
+
+  let panning = false;
+  let panStartX = 0;
+  let panStartY = 0;
+  function handlePanStart(e) {
+    panning = true;
+    panStartX = e.clientX;
+    panStartY = e.clientY;
+  }
+  function handlePanMove(e) {
+    if (!panning) return;
+    const dx = e.clientX - panStartX;
+    const dy = e.clientY - panStartY;
+    offsetX += dx;
+    offsetY += dy;
+    panStartX = e.clientX;
+    panStartY = e.clientY;
+    applyTransform();
+  }
+  function handlePanEnd() {
+    panning = false;
+  }
+
+  if (importInput) importInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (file) importJson(file);
+  });
+  if (randomBtn) randomBtn.addEventListener('click', randomizeColors);
+
+  mapContainer.addEventListener('wheel', handleWheel, { passive: false });
+  mapContainer.addEventListener('mousedown', handlePanStart);
+  mapContainer.addEventListener('mousemove', handlePanMove);
+  window.addEventListener('mouseup', handlePanEnd);
+  window.addEventListener('resize', () => {
+    fitToContainer();
+    drawAll();
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (baseMap.complete) {
+      fitToContainer();
+      drawAll();
+    } else {
+      baseMap.onload = () => {
+        fitToContainer();
+        drawAll();
+      };
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- stop saving colorMap to `localStorage`
- remove `saveColors()` from editor and viewer scripts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688bbadc788c832daa05c5359e96cc8d