### PR TITLE
Store map pixel data in DB

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,6 @@
     <h1>Carte des baronnies</h1>
     <div id="controls" class="controls-row">
       <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
-      <label class="file-label control-btn">
-        Importer JSON
-        <input type="file" id="jsonFileInput" accept=".json">
-      </label>
     </div>
   </header>
   <main>

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const sqlite3 = require('sqlite3');
+const zlib = require('zlib');
 const path = require('path');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
@@ -53,6 +54,10 @@ CREATE TABLE IF NOT EXISTS baronies (
   FOREIGN KEY(religion_pop_id) REFERENCES religions(id),
   FOREIGN KEY(duchy_id) REFERENCES duchies(id),
   FOREIGN KEY(culture_id) REFERENCES cultures(id)
+);
+CREATE TABLE IF NOT EXISTS barony_pixels (
+  barony_id INTEGER PRIMARY KEY REFERENCES baronies(id),
+  data BLOB
 );
 `;
 
@@ -137,6 +142,50 @@ app.delete('/api/baronies/:id', (req,res)=>{
   db.run('DELETE FROM baronies WHERE id=?',[req.params.id], function(err){
     if(err) return res.status(500).json({error: err.message});
     res.json({deleted: this.changes});
+  });
+});
+
+// Pixel data API
+app.get('/api/barony_pixels', (req, res) => {
+  const id = req.query.id;
+  if (id) {
+    db.get('SELECT data FROM barony_pixels WHERE barony_id=?', [id], (err, row) => {
+      if (err) return res.status(500).json({error: err.message});
+      if (!row) return res.json([]);
+      try {
+        const json = zlib.gunzipSync(row.data).toString();
+        res.json(JSON.parse(json));
+      } catch(e){
+        res.status(500).json({error: e.message});
+      }
+    });
+  } else {
+    db.all('SELECT barony_id, data FROM barony_pixels', [], (err, rows) => {
+      if (err) return res.status(500).json({error: err.message});
+      const out = {};
+      rows.forEach(r => {
+        try {
+          const json = zlib.gunzipSync(r.data).toString();
+          out[r.barony_id] = JSON.parse(json);
+        } catch {}
+      });
+      res.json(out);
+    });
+  }
+});
+
+app.put('/api/barony_pixels', (req, res) => {
+  const data = req.body || {};
+  db.serialize(() => {
+    const stmt = db.prepare('INSERT OR REPLACE INTO barony_pixels(barony_id,data) VALUES (?,?)');
+    for (const [id, coords] of Object.entries(data)) {
+      const buf = zlib.gzipSync(JSON.stringify(coords));
+      stmt.run(id, buf);
+    }
+    stmt.finalize(err => {
+      if (err) return res.status(500).json({error: err.message});
+      res.json({ok: true});
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- store per-barony pixel information in SQLite as compressed blobs
- expose `/api/barony_pixels` endpoints
- load pixel data from the server in editor and viewer
- allow saving edited pixels back to the DB
- remove import control from the viewer page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688be2be117c832dbc9cf02db0bf4bab