### PR TITLE
Refactor admin UI and seigneur schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Le serveur écoute par défaut sur [http://localhost:3000](http://localhost:3000
 ## Utilisation
 - `index.html` : visualisation simple de la carte.
 - `mapEditor.html` : éditeur de baronnies. La barre latérale permet de modifier l'ID, le nom et les métadonnées (seigneur, religions, culture, duché).
-- `admin.html` : page d'administration pour ajouter royaumes, comtés, duchés, seigneurs, religions et cultures.
+- `admin.html` : page d'administration pour consulter et modifier royaumes, comtés, duchés, seigneurs, religions et cultures. Les tableaux présentent les données existantes et une ligne vide permet d'en ajouter de nouvelles.
 
 Il suffit d'ouvrir ces fichiers dans le navigateur (par exemple <http://localhost:3000/mapEditor.html>) une fois le serveur lancé.
 Ne les ouvrez pas directement avec `file://`, car les requêtes vers l'API seraient bloquées par le navigateur.

--- a/admin.html
+++ b/admin.html
@@ -13,42 +13,27 @@
     <div style="padding:10px;overflow:auto;flex:1">
       <section>
         <h2>Seigneurs</h2>
-        <input type="text" id="newSeigneur" placeholder="Nom">
-        <select id="seigneurReligion"></select>
-        <button onclick="addSeigneur()">Ajouter</button>
-        <ul id="listSeigneurs"></ul>
+        <div id="tableSeigneurs"></div>
       </section>
       <section>
         <h2>Religions</h2>
-        <input type="text" id="newReligion" placeholder="Nom">
-        <button onclick="addReligion()">Ajouter</button>
-        <ul id="listReligions"></ul>
+        <div id="tableReligions"></div>
       </section>
       <section>
         <h2>Cultures</h2>
-        <input type="text" id="newCulture" placeholder="Nom">
-        <button onclick="addCulture()">Ajouter</button>
-        <ul id="listCultures"></ul>
+        <div id="tableCultures"></div>
       </section>
       <section>
         <h2>Royaumes</h2>
-        <input type="text" id="newKingdom" placeholder="Nom">
-        <button onclick="addKingdom()">Ajouter</button>
-        <ul id="listKingdoms"></ul>
+        <div id="tableKingdoms"></div>
       </section>
       <section>
         <h2>Comtés</h2>
-        <input type="text" id="newCounty" placeholder="Nom">
-        <select id="countyKingdom"></select>
-        <button onclick="addCounty()">Ajouter</button>
-        <ul id="listCounties"></ul>
+        <div id="tableCounties"></div>
       </section>
       <section>
         <h2>Duchés</h2>
-        <input type="text" id="newDuchy" placeholder="Nom">
-        <select id="duchyCounty"></select>
-        <button onclick="addDuchy()">Ajouter</button>
-        <ul id="listDuchies"></ul>
+        <div id="tableDuchies"></div>
       </section>
     </div>
   </main>

--- a/server.js
+++ b/server.js
@@ -34,12 +34,8 @@ CREATE TABLE IF NOT EXISTS seigneurs (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT UNIQUE,
   religion_id INTEGER,
-  FOREIGN KEY(religion_id) REFERENCES religions(id)
-);
-CREATE TABLE IF NOT EXISTS allegiances (
-  seigneur_id INTEGER PRIMARY KEY,
   overlord_id INTEGER,
-  FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id),
+  FOREIGN KEY(religion_id) REFERENCES religions(id),
   FOREIGN KEY(overlord_id) REFERENCES seigneurs(id)
 );
 CREATE TABLE IF NOT EXISTS baronies (
@@ -56,7 +52,13 @@ CREATE TABLE IF NOT EXISTS baronies (
 );
 `;
 
-db.exec(initSql);
+db.exec(initSql, () => {
+  db.all("PRAGMA table_info(seigneurs)", (err, rows) => {
+    if (!err && rows && !rows.some(r => r.name === 'overlord_id')) {
+      db.run('ALTER TABLE seigneurs ADD COLUMN overlord_id INTEGER');
+    }
+  });
+});
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname)));
@@ -110,11 +112,8 @@ app.get('/api/cultures', list('cultures'));
 app.post('/api/cultures', create('cultures',['name']));
 
 app.get('/api/seigneurs', list('seigneurs'));
-app.post('/api/seigneurs', create('seigneurs',['name','religion_id']));
-app.put('/api/seigneurs/:id', update('seigneurs',['name','religion_id']));
-
-app.get('/api/allegiances', list('allegiances'));
-app.post('/api/allegiances', create('allegiances',['seigneur_id','overlord_id']));
+app.post('/api/seigneurs', create('seigneurs',['name','religion_id','overlord_id']));
+app.put('/api/seigneurs/:id', update('seigneurs',['name','religion_id','overlord_id']));
 
 app.get('/api/baronies', (req, res) => {
   const id = req.query.id;

--- a/styles.css
+++ b/styles.css
@@ -182,3 +182,30 @@ main {
 .info-panel button:hover {
   background-color: #3d6db2;
 }
+
+/* Table d'administration */
+.admin-table {
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+.admin-table th,
+.admin-table td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+}
+.admin-table input,
+.admin-table select {
+  width: 100%;
+  box-sizing: border-box;
+}
+.admin-table button {
+  padding: 4px 8px;
+  background-color: #1d56a4;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.admin-table button:hover {
+  background-color: #3d6db2;
+}


### PR DESCRIPTION
## Summary
- remove obsolete `allegiances` table and add `overlord_id` to `seigneurs`
- update Express routes to use new column
- automatically add `overlord_id` when starting with an old database
- redesign `admin.html` with editable tables
- new `admin.js` implementation to render and edit tables
- add basic table styles
- document new admin page behaviour

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bee781ae4832d8cc0b991800e0d77