### PR TITLE
Store map pixel data in DB

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,6 @@
     <h1>Carte des baronnies</h1>
     <div id="controls" class="controls-row">
       <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
-      <label class="file-label control-btn">
-        Importer JSON
-        <input type="file" id="jsonFileInput" accept=".json">
-      </label>
     </div>
   </header>
   <main>


### PR DESCRIPTION
## Summary
- store per-barony pixel information in SQLite as compressed blobs
- expose `/api/barony_pixels` endpoints
- load pixel data from the server in editor and viewer
- allow saving edited pixels back to the DB
- remove import control from the viewer page
- increase JSON body size limit for large payloads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688be2be117c832dbc9cf02db0bf4bab