### PR TITLE
Fix barony deselection color

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,7 +220,8 @@
   function selectBarony(id) {
     // remettre l'opacité par défaut sur l'ancienne sélection
     if (currentSelectedId && colorMap[currentSelectedId]) {
-      colorMap[currentSelectedId][3] = 180;
+      // Rétablir l'opacité normale
+      colorMap[currentSelectedId][3] = 100;
     }
     currentSelectedId = id;
     if (!id) {


### PR DESCRIPTION
## Summary
- ensure previous barony resets opacity when changing selection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bf4072630832d8f2df7467028bd42