### PR TITLE
Allow atheist religion

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -22,7 +22,11 @@ function renderTable(container, rows, opts){
       const optList = opts.selects[field];
       const blank = document.createElement('option');
       blank.value = '';
-      blank.textContent = '';
+      if (opts.nullLabels && opts.nullLabels[field]) {
+        blank.textContent = opts.nullLabels[field];
+      } else {
+        blank.textContent = '';
+      }
       select.appendChild(blank);
       optList.forEach(o=>{
         const op = document.createElement('option');
@@ -143,7 +147,8 @@ async function loadAll(){
   renderTable(document.getElementById('tableSeigneurs'), seigneurs, {
     endpoint:'seigneurs',
     fields:['name','religion_id','overlord_id'],
-    selects:{religion_id:religions, overlord_id:seigneurs}
+    selects:{religion_id:religions, overlord_id:seigneurs},
+    nullLabels:{religion_id:'Athée'}
   });
 }
 

--- a/script.js
+++ b/script.js
@@ -116,7 +116,10 @@
     cultureOptions = cultures;
     countyOptions = counties;
     if (editSeigneur) editSeigneur.innerHTML = seigneurs.map(s=>`<option value="${s.id}">${s.name}</option>`).join('');
-    if (editReligionPop) editReligionPop.innerHTML = religions.map(r=>`<option value="${r.id}">${r.name}</option>`).join('');
+    if (editReligionPop) {
+      const atheistOpt = '<option value="">Athée</option>';
+      editReligionPop.innerHTML = atheistOpt + religions.map(r=>`<option value="${r.id}">${r.name}</option>`).join('');
+    }
     if (editCulture) editCulture.innerHTML = cultures.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
     if (editCounty) editCounty.innerHTML = counties.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
   }


### PR DESCRIPTION
## Summary
- allow specifying labels for null select options in admin table rendering
- show 'Athée' when seigneur religion is empty
- include 'Athée' option in barony population religion picker

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c2a4450a8832db396721514544254