### PR TITLE
Allow baronies without lord

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -147,8 +147,7 @@ async function loadAll(){
   renderTable(document.getElementById('tableSeigneurs'), seigneurs, {
     endpoint:'seigneurs',
     fields:['name','religion_id','overlord_id'],
-    selects:{religion_id:religions, overlord_id:seigneurs},
-    nullLabels:{religion_id:'Athée'}
+    selects:{religion_id:religions, overlord_id:seigneurs}
   });
 }
 

--- a/script.js
+++ b/script.js
@@ -115,10 +115,12 @@
     religionOptions = religions;
     cultureOptions = cultures;
     countyOptions = counties;
-    if (editSeigneur) editSeigneur.innerHTML = seigneurs.map(s=>`<option value="${s.id}">${s.name}</option>`).join('');
+    if (editSeigneur) {
+      const blankOpt = '<option value=""></option>';
+      editSeigneur.innerHTML = blankOpt + seigneurs.map(s=>`<option value="${s.id}">${s.name}</option>`).join('');
+    }
     if (editReligionPop) {
-      const atheistOpt = '<option value="">Athée</option>';
-      editReligionPop.innerHTML = atheistOpt + religions.map(r=>`<option value="${r.id}">${r.name}</option>`).join('');
+      editReligionPop.innerHTML = religions.map(r=>`<option value="${r.id}">${r.name}</option>`).join('');
     }
     if (editCulture) editCulture.innerHTML = cultures.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
     if (editCounty) editCounty.innerHTML = counties.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS baronies (
   religion_pop_id INTEGER,
   county_id INTEGER,
   culture_id INTEGER,
-  FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id),
+  FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id) ON DELETE SET NULL,
   FOREIGN KEY(religion_pop_id) REFERENCES religions(id),
   FOREIGN KEY(county_id) REFERENCES counties(id),
   FOREIGN KEY(culture_id) REFERENCES cultures(id)
@@ -78,9 +78,13 @@ function list(table) {
   };
 }
 
+function sanitize(val){
+  return val === '' ? null : val;
+}
+
 function create(table, fields) {
   return (req, res) => {
-    const values = fields.map(f => req.body[f]);
+    const values = fields.map(f => sanitize(req.body[f]));
     const placeholders = fields.map(() => '?').join(',');
     db.run(`INSERT INTO ${table} (${fields.join(',')}) VALUES (${placeholders})`, values, function(err){
       if (err) return res.status(500).json({error: err.message});
@@ -93,7 +97,7 @@ function update(table, fields) {
   return (req, res) => {
     const id = req.params.id;
     const set = fields.map(f => `${f}=?`).join(',');
-    const values = fields.map(f => req.body[f]);
+    const values = fields.map(f => sanitize(req.body[f]));
     values.push(id);
     db.run(`UPDATE ${table} SET ${set} WHERE id=?`, values, function(err){
       if (err) return res.status(500).json({error: err.message});


### PR DESCRIPTION
## Summary
- remove placeholder 'Athée' label from admin interface
- allow selecting no lord for a barony
- sanitize empty values server side and set `ON DELETE SET NULL` for the barony->seigneur foreign key

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_688cc307e228832da20bdc26ae422414