### PR TITLE
Fix barony name display in map editor

### DIFF
--- a/script.js
+++ b/script.js
@@ -247,6 +247,8 @@
     fetch(`${API_BASE}/api/baronies?id=${id}`).then(r=>r.json()).then(list=>{
       const info = list.find(b=>String(b.id)===String(id));
       if(!info) return;
+      if (editNameInput) editNameInput.value = info.name || '';
+      baronyMeta[id].name = info.name || '';
       if (editSeigneur) editSeigneur.value = info.seigneur_id || '';
       if (editReligionPop) editReligionPop.value = info.religion_pop_id || '';
       if (editCulture) editCulture.value = info.culture_id || '';


### PR DESCRIPTION
## Summary
- fetch barony name when the barony is selected instead of preloading all names
- remove unused `/api/baronies` call from pixel data loader

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cc8671880832d9cc6c5223db08dd9