### PR TITLE
Add manual barony selection option

### DIFF
--- a/mapEditor.html
+++ b/mapEditor.html
@@ -19,6 +19,7 @@
       <button id="deleteBarony" class="control-btn">Supprimer</button>
       <button id="mergeBarony" class="control-btn">Fusionner</button>
       <button id="toggleMap" class="control-btn">Changer fond</button>
+      <button id="selectBarony" class="control-btn">Sélectionner</button>
     </div>
     <div id="tools" class="tools-row">
       <button id="brushTool" class="tool-btn" title="Pinceau">

--- a/script.js
+++ b/script.js
@@ -90,6 +90,7 @@
   const deleteBtn = document.getElementById('deleteBarony');
   const mergeBtn = document.getElementById('mergeBarony');
   const toggleMapBtn = document.getElementById('toggleMap');
+  const selectBtn = document.getElementById('selectBarony');
   const infoPanel = document.getElementById('infoPanel');
   const editIdInput = document.getElementById('editId');
   const editNameInput = document.getElementById('editName');
@@ -233,6 +234,9 @@
       if (infoPanel) infoPanel.style.display = 'none';
       drawAll();
       return;
+    }
+    if (!baronyMeta[id]) {
+      baronyMeta[id] = { id: id, name: '' };
     }
     // s'assurer que la baronnie a une couleur puis la mettre en valeur
     if (!colorMap[id]) {
@@ -797,6 +801,10 @@
     alert('Mode fusion activé : cliquez sur la baronnie à fusionner.');
   });
   if (toggleMapBtn) toggleMapBtn.addEventListener('click', toggleMap);
+  if (selectBtn) selectBtn.addEventListener('click', () => {
+    const id = prompt('ID de la baronnie à sélectionner ?');
+    if (id) selectBarony(id.trim());
+  });
   if (updateBtn) updateBtn.addEventListener('click', updateBarony);
 
   // Outils


### PR DESCRIPTION
## Summary
- add a *Sélectionner* button in the map editor controls
- allow choosing any barony ID via prompt and highlight it even without pixels

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ccfadb3c8832da5bdc2e83584a1dc