### PR TITLE
Tri alphabétique des entrées de dropdowns

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -117,37 +117,44 @@ async function loadAll(){
     fetchJSON('/api/duchies'),
   ]);
 
-  renderTable(document.getElementById('tableReligions'), religions, {
+  const seigneursSorted = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const religionsSorted = religions.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const culturesSorted = cultures.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const kingdomsSorted = kingdoms.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const countiesSorted = counties.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const duchiesSorted = duchies.slice().sort((a, b) => a.name.localeCompare(b.name));
+
+  renderTable(document.getElementById('tableReligions'), religionsSorted, {
     endpoint:'religions',
     fields:['name']
   });
 
-  renderTable(document.getElementById('tableCultures'), cultures, {
+  renderTable(document.getElementById('tableCultures'), culturesSorted, {
     endpoint:'cultures',
     fields:['name']
   });
 
-  renderTable(document.getElementById('tableKingdoms'), kingdoms, {
+  renderTable(document.getElementById('tableKingdoms'), kingdomsSorted, {
     endpoint:'kingdoms',
     fields:['name']
   });
 
-  renderTable(document.getElementById('tableCounties'), counties, {
+  renderTable(document.getElementById('tableCounties'), countiesSorted, {
     endpoint:'counties',
     fields:['name','duchy_id'],
-    selects:{duchy_id:duchies}
+    selects:{duchy_id:duchiesSorted}
   });
 
-  renderTable(document.getElementById('tableDuchies'), duchies, {
+  renderTable(document.getElementById('tableDuchies'), duchiesSorted, {
     endpoint:'duchies',
     fields:['name','kingdom_id'],
-    selects:{kingdom_id:kingdoms}
+    selects:{kingdom_id:kingdomsSorted}
   });
 
-  renderTable(document.getElementById('tableSeigneurs'), seigneurs, {
+  renderTable(document.getElementById('tableSeigneurs'), seigneursSorted, {
     endpoint:'seigneurs',
     fields:['name','religion_id','overlord_id'],
-    selects:{religion_id:religions, overlord_id:seigneurs}
+    selects:{religion_id:religionsSorted, overlord_id:seigneursSorted}
   });
 }
 

--- a/script.js
+++ b/script.js
@@ -106,24 +106,24 @@
 
   async function loadOptions() {
     const [seigneurs, religions, cultures, counties] = await Promise.all([
-      fetch(API_BASE + '/api/seigneurs').then(r=>r.json()),
-      fetch(API_BASE + '/api/religions').then(r=>r.json()),
-      fetch(API_BASE + '/api/cultures').then(r=>r.json()),
-      fetch(API_BASE + '/api/counties').then(r=>r.json()),
+      fetch(API_BASE + '/api/seigneurs').then(r => r.json()),
+      fetch(API_BASE + '/api/religions').then(r => r.json()),
+      fetch(API_BASE + '/api/cultures').then(r => r.json()),
+      fetch(API_BASE + '/api/counties').then(r => r.json()),
     ]);
-    seigneurOptions = seigneurs;
-    religionOptions = religions;
-    cultureOptions = cultures;
-    countyOptions = counties;
+    seigneurOptions = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
+    religionOptions = religions.slice().sort((a, b) => a.name.localeCompare(b.name));
+    cultureOptions = cultures.slice().sort((a, b) => a.name.localeCompare(b.name));
+    countyOptions = counties.slice().sort((a, b) => a.name.localeCompare(b.name));
     if (editSeigneur) {
       const blankOpt = '<option value=""></option>';
-      editSeigneur.innerHTML = blankOpt + seigneurs.map(s=>`<option value="${s.id}">${s.name}</option>`).join('');
+      editSeigneur.innerHTML = blankOpt + seigneurOptions.map(s => `<option value="${s.id}">${s.name}</option>`).join('');
     }
     if (editReligionPop) {
-      editReligionPop.innerHTML = religions.map(r=>`<option value="${r.id}">${r.name}</option>`).join('');
+      editReligionPop.innerHTML = religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
     }
-    if (editCulture) editCulture.innerHTML = cultures.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
-    if (editCounty) editCounty.innerHTML = counties.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
+    if (editCulture) editCulture.innerHTML = cultureOptions.map(c => `<option value="${c.id}">${c.name}</option>`).join('');
+    if (editCounty) editCounty.innerHTML = countyOptions.map(c => `<option value="${c.id}">${c.name}</option>`).join('');
   }
   // Outils
   const brushToolBtn = document.getElementById('brushTool');


### PR DESCRIPTION
## Summary
- sort dropdown options alphabetically when loading meta data
- ensure admin tables use sorted option lists

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688cd110c520832d87fb942b5536e2ea