### PR TITLE
Improve admin UI

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,35 +8,56 @@
 <body>
   <header class="app-header">
     <h1>Administration</h1>
+    <div class="controls-row">
+      <button class="control-btn" onclick="location.href='mapEditor.html'">Éditeur de carte</button>
+    </div>
   </header>
   <main>
-    <div style="padding:10px;overflow:auto;flex:1">
-      <section>
-        <h2>Seigneurs</h2>
-        <div id="tableSeigneurs"></div>
-      </section>
-      <section>
-        <h2>Religions</h2>
-        <div id="tableReligions"></div>
-      </section>
-      <section>
-        <h2>Cultures</h2>
-        <div id="tableCultures"></div>
-      </section>
-      <section>
-        <h2>Royaumes</h2>
-        <div id="tableKingdoms"></div>
-      </section>
-      <section>
-        <h2>Comtés</h2>
-        <div id="tableCounties"></div>
-      </section>
-      <section>
-        <h2>Duchés</h2>
-        <div id="tableDuchies"></div>
-      </section>
+    <div class="tab-container" style="overflow:auto;flex:1">
+      <div class="tab-buttons">
+        <button class="tab-btn active" data-tab="seigneurs">Seigneurs</button>
+        <button class="tab-btn" data-tab="religions">Religions</button>
+        <button class="tab-btn" data-tab="cultures">Cultures</button>
+        <button class="tab-btn" data-tab="kingdoms">Royaumes</button>
+        <button class="tab-btn" data-tab="counties">Comtés</button>
+        <button class="tab-btn" data-tab="duchies">Duchés</button>
+      </div>
+      <div class="tab-panels">
+        <div id="tab-seigneurs" class="tab-panel active">
+          <div id="tableSeigneurs"></div>
+        </div>
+        <div id="tab-religions" class="tab-panel">
+          <div id="tableReligions"></div>
+        </div>
+        <div id="tab-cultures" class="tab-panel">
+          <div id="tableCultures"></div>
+        </div>
+        <div id="tab-kingdoms" class="tab-panel">
+          <div id="tableKingdoms"></div>
+        </div>
+        <div id="tab-counties" class="tab-panel">
+          <div id="tableCounties"></div>
+        </div>
+        <div id="tab-duchies" class="tab-panel">
+          <div id="tableDuchies"></div>
+        </div>
+      </div>
     </div>
   </main>
   <script src="admin.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-btn');
+      const panels = document.querySelectorAll('.tab-panel');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          panels.forEach(p => p.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/admin.js
+++ b/admin.js
@@ -15,11 +15,16 @@ function renderTable(container, rows, opts){
   let sortCol = 'id';
   let sortDir = 'asc';
 
-  const headers = [{label:'ID', key:'id'}].concat(opts.fields.map(f=>({label:f, key:f})));
+  const headers = [{label:'ID', key:'id'}].concat(
+    opts.fields.map(f => ({
+      label: opts.labels && opts.labels[f] ? opts.labels[f] : f,
+      key: f
+    }))
+  );
   headers.forEach(h=>{
     const th = document.createElement('th');
-    th.textContent = h.label;
-    th.style.cursor = 'pointer';
+    th.dataset.key = h.key;
+    th.classList.add('sortable');
     th.addEventListener('click', ()=>{
       if(sortCol === h.key){
         sortDir = sortDir === 'asc' ? 'desc' : 'asc';
@@ -27,12 +32,23 @@ function renderTable(container, rows, opts){
         sortCol = h.key;
         sortDir = 'asc';
       }
+      updateHeaders();
       renderBody();
     });
     headRow.appendChild(th);
   });
   headRow.appendChild(document.createElement('th'));
   thead.appendChild(headRow);
+  const updateHeaders = () => {
+    Array.from(headRow.children).forEach(th => {
+      const key = th.dataset.key;
+      if(!key) return;
+      const base = headers.find(h => h.key === key).label;
+      let arrow = ' \u21C5';
+      if(sortCol === key) arrow = sortDir === 'asc' ? ' \u25B2' : ' \u25BC';
+      th.textContent = base + arrow;
+    });
+  };
   table.appendChild(thead);
   const tbody = document.createElement('tbody');
 
@@ -143,6 +159,7 @@ function renderTable(container, rows, opts){
 
   table.appendChild(tbody);
   container.appendChild(table);
+  updateHeaders();
   renderBody();
 }
 
@@ -172,35 +189,41 @@ async function loadAll(){
 
   renderTable(document.getElementById('tableReligions'), religionsById, {
     endpoint:'religions',
-    fields:['name']
+    fields:['name'],
+    labels:{name:'Nom'}
   });
 
   renderTable(document.getElementById('tableCultures'), culturesById, {
     endpoint:'cultures',
-    fields:['name']
+    fields:['name'],
+    labels:{name:'Nom'}
   });
 
   renderTable(document.getElementById('tableKingdoms'), kingdomsById, {
     endpoint:'kingdoms',
-    fields:['name']
+    fields:['name'],
+    labels:{name:'Nom'}
   });
 
   renderTable(document.getElementById('tableCounties'), countiesById, {
     endpoint:'counties',
     fields:['name','duchy_id'],
-    selects:{duchy_id:duchiesSelect}
+    selects:{duchy_id:duchiesSelect},
+    labels:{name:'Nom', duchy_id:'Duché'}
   });
 
   renderTable(document.getElementById('tableDuchies'), duchiesById, {
     endpoint:'duchies',
     fields:['name','kingdom_id'],
-    selects:{kingdom_id:kingdomsSelect}
+    selects:{kingdom_id:kingdomsSelect},
+    labels:{name:'Nom', kingdom_id:'Royaume'}
   });
 
   renderTable(document.getElementById('tableSeigneurs'), seigneursById, {
     endpoint:'seigneurs',
     fields:['name','religion_id','overlord_id'],
-    selects:{religion_id:religionsSelect, overlord_id:seigneursSelect}
+    selects:{religion_id:religionsSelect, overlord_id:seigneursSelect},
+    labels:{name:'Nom', religion_id:'Religion', overlord_id:'Seigneur'}
   });
 }
 

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -20,6 +20,7 @@
       <button id="mergeBarony" class="control-btn">Fusionner</button>
       <button id="toggleMap" class="control-btn">Changer fond</button>
       <button id="selectBarony" class="control-btn">Sélectionner</button>
+      <button class="control-btn" onclick="location.href='admin.html'">Administration</button>
     </div>
     <div id="tools" class="tools-row">
       <button id="brushTool" class="tool-btn" title="Pinceau">

--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,37 @@ main {
   background-color: #3d6db2;
 }
 
+/* Onglets de la page d'administration */
+.tab-buttons {
+  display: flex;
+  gap: 4px;
+  padding-left: 15px;
+  margin-bottom: 10px;
+}
+.tab-btn {
+  background-color: #e6ebf3;
+  border: 1px solid #c4d0e3;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.tab-btn.active {
+  background-color: white;
+  border-bottom: 1px solid white;
+}
+.tab-panel {
+  display: none;
+  padding: 10px 15px;
+}
+.tab-panel.active {
+  display: block;
+}
+.admin-table th.sortable {
+  cursor: pointer;
+  background-color: #f0f0f0;
+}
+
 /* Légende pour les filtres de couleur */
 .legend {
   position: absolute;


### PR DESCRIPTION
## Summary
- put each admin table on a separate tab
- show friendlier labels for table columns and improve sorting visibility
- add padding and styles for the new tab layout
- link admin and map editor pages with navigation buttons

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688cfab15714832db65c3836455d269d