### PR TITLE
feat: add color field for religions and cultures

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -87,6 +87,12 @@ function renderTable(container, rows, opts){
       });
       return select;
     }
+    if(opts.colorFields && opts.colorFields.includes(field)){
+      const input = document.createElement('input');
+      input.type = 'color';
+      input.value = val || '#000000';
+      return input;
+    }
     const input = document.createElement('input');
     input.value = val ?? '';
     return input;
@@ -189,14 +195,16 @@ async function loadAll(){
 
   renderTable(document.getElementById('tableReligions'), religionsById, {
     endpoint:'religions',
-    fields:['name'],
-    labels:{name:'Nom'}
+    fields:['name','color'],
+    labels:{name:'Nom', color:'Couleur'},
+    colorFields:['color']
   });
 
   renderTable(document.getElementById('tableCultures'), culturesById, {
     endpoint:'cultures',
-    fields:['name'],
-    labels:{name:'Nom'}
+    fields:['name','color'],
+    labels:{name:'Nom', color:'Couleur'},
+    colorFields:['color']
   });
 
   renderTable(document.getElementById('tableKingdoms'), kingdomsById, {

--- a/script.js
+++ b/script.js
@@ -47,6 +47,13 @@
     };
     return [f(0), f(8), f(4)];
   }
+  function hexToRgb(hex) {
+    if (!hex) return null;
+    const m = hex.trim().match(/^#?([a-fA-F0-9]{6})$/);
+    if (!m) return null;
+    const num = parseInt(m[1], 16);
+    return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+  }
   function generateColor(id) {
     const num = parseInt(id, 10);
     const hue = (num * 137) % 360;
@@ -322,7 +329,14 @@
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {
-          col = generateColor(String(groupId || 0)).slice(0, 3);
+          if (type === 'religion') {
+            col = hexToRgb(religionMap[groupId]?.color);
+          } else if (type === 'culture') {
+            col = hexToRgb(cultureMapInfo[groupId]?.color);
+          }
+          if (!col) {
+            col = generateColor(String(groupId || 0)).slice(0, 3);
+          }
         }
         groupColors[groupId] = { color: col, name: groupName || 'N/A' };
       }

--- a/server.js
+++ b/server.js
@@ -25,11 +25,13 @@ CREATE TABLE IF NOT EXISTS counties (
 );
 CREATE TABLE IF NOT EXISTS religions (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT UNIQUE
+  name TEXT UNIQUE,
+  color TEXT
 );
 CREATE TABLE IF NOT EXISTS cultures (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT UNIQUE
+  name TEXT UNIQUE,
+  color TEXT
 );
 CREATE TABLE IF NOT EXISTS seigneurs (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -61,6 +63,16 @@ db.exec(initSql, () => {
   db.all("PRAGMA table_info(seigneurs)", (err, rows) => {
     if (!err && rows && !rows.some(r => r.name === 'overlord_id')) {
       db.run('ALTER TABLE seigneurs ADD COLUMN overlord_id INTEGER');
+    }
+  });
+  db.all("PRAGMA table_info(religions)", (err, rows) => {
+    if (!err && rows && !rows.some(r => r.name === 'color')) {
+      db.run('ALTER TABLE religions ADD COLUMN color TEXT');
+    }
+  });
+  db.all("PRAGMA table_info(cultures)", (err, rows) => {
+    if (!err && rows && !rows.some(r => r.name === 'color')) {
+      db.run('ALTER TABLE cultures ADD COLUMN color TEXT');
     }
   });
 });
@@ -116,10 +128,12 @@ app.get('/api/duchies', list('duchies'));
 app.post('/api/duchies', create('duchies',['name','kingdom_id']));
 
 app.get('/api/religions', list('religions'));
-app.post('/api/religions', create('religions',['name']));
+app.post('/api/religions', create('religions',['name','color']));
+app.put('/api/religions/:id', update('religions',['name','color']));
 
 app.get('/api/cultures', list('cultures'));
-app.post('/api/cultures', create('cultures',['name']));
+app.post('/api/cultures', create('cultures',['name','color']));
+app.put('/api/cultures/:id', update('cultures',['name','color']));
 
 app.get('/api/seigneurs', list('seigneurs'));
 app.post('/api/seigneurs', create('seigneurs',['name','religion_id','overlord_id']));

--- a/viewer.js
+++ b/viewer.js
@@ -70,6 +70,13 @@
     };
     return [f(0), f(8), f(4)];
   }
+  function hexToRgb(hex) {
+    if (!hex) return null;
+    const m = hex.trim().match(/^#?([a-fA-F0-9]{6})$/);
+    if (!m) return null;
+    const num = parseInt(m[1], 16);
+    return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+  }
   function generateColor(id) {
     const num = parseInt(id, 10);
     const hue = (num * 137) % 360;
@@ -328,7 +335,14 @@
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {
-          col = generateColor(String(groupId || 0)).slice(0, 3);
+          if (type === 'religion') {
+            col = hexToRgb(religionMap[groupId]?.color);
+          } else if (type === 'culture') {
+            col = hexToRgb(cultureMapInfo[groupId]?.color);
+          }
+          if (!col) {
+            col = generateColor(String(groupId || 0)).slice(0, 3);
+          }
         }
         groupColors[groupId] = { color: col, name: groupName || 'N/A' };
       }


### PR DESCRIPTION
## Summary
- store a default color for religions and cultures
- allow editing default colors in admin table
- use configured colors when filtering maps by religion or culture

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./server.js'); setTimeout(()=>process.exit(0),1000)"`

------
https://chatgpt.com/codex/tasks/task_e_688d8948bd24832d9353d63b6e3dea8a