### PR TITLE
feat: expand feudal hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Le serveur écoute par défaut sur [http://localhost:3000](http://localhost:3000
 
 ## Utilisation
 - `index.html` : visualisation simple de la carte.
-- `mapEditor.html` : éditeur de baronnies. La barre latérale permet de modifier l'ID, le nom et les métadonnées (seigneur, religions, culture, duché).
-- `admin.html` : page d'administration pour consulter et modifier royaumes, comtés, duchés, seigneurs, religions et cultures. Les tableaux présentent les données existantes et une ligne vide permet d'en ajouter de nouvelles.
+- `mapEditor.html` : éditeur de baronnies. La barre latérale permet de modifier l'ID, le nom et les métadonnées (seigneur, religions, culture, vicomté, comté).
+- `admin.html` : page d'administration pour consulter et modifier empires, royaumes, archiduchés, duchés, marquisats, comtés, vicomtés, seigneurs, religions et cultures. Les tableaux présentent les données existantes et une ligne vide permet d'en ajouter de nouvelles.
 
 Il suffit d'ouvrir ces fichiers dans le navigateur (par exemple <http://localhost:3000/mapEditor.html>) une fois le serveur lancé.
 Ne les ouvrez pas directement avec `file://`, car les requêtes vers l'API seraient bloquées par le navigateur.

--- a/admin.html
+++ b/admin.html
@@ -18,9 +18,13 @@
         <button class="tab-btn active" data-tab="seigneurs">Seigneurs</button>
         <button class="tab-btn" data-tab="religions">Religions</button>
         <button class="tab-btn" data-tab="cultures">Cultures</button>
+        <button class="tab-btn" data-tab="empires">Empires</button>
         <button class="tab-btn" data-tab="kingdoms">Royaumes</button>
-        <button class="tab-btn" data-tab="counties">Comtés</button>
+        <button class="tab-btn" data-tab="archduchies">Archiduchés</button>
         <button class="tab-btn" data-tab="duchies">Duchés</button>
+        <button class="tab-btn" data-tab="marquisates">Marquisats</button>
+        <button class="tab-btn" data-tab="counties">Comtés</button>
+        <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
       </div>
       <div class="tab-panels">
         <div id="tab-seigneurs" class="tab-panel active">
@@ -32,14 +36,26 @@
         <div id="tab-cultures" class="tab-panel">
           <div id="tableCultures"></div>
         </div>
+        <div id="tab-empires" class="tab-panel">
+          <div id="tableEmpires"></div>
+        </div>
         <div id="tab-kingdoms" class="tab-panel">
           <div id="tableKingdoms"></div>
+        </div>
+        <div id="tab-archduchies" class="tab-panel">
+          <div id="tableArchduchies"></div>
+        </div>
+        <div id="tab-duchies" class="tab-panel">
+          <div id="tableDuchies"></div>
+        </div>
+        <div id="tab-marquisates" class="tab-panel">
+          <div id="tableMarquisates"></div>
         </div>
         <div id="tab-counties" class="tab-panel">
           <div id="tableCounties"></div>
         </div>
-        <div id="tab-duchies" class="tab-panel">
-          <div id="tableDuchies"></div>
+        <div id="tab-viscounties" class="tab-panel">
+          <div id="tableViscounties"></div>
         </div>
       </div>
     </div>

--- a/admin.js
+++ b/admin.js
@@ -170,13 +170,17 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
     fetchJSON('/api/kingdoms'),
     fetchJSON('/api/counties'),
     fetchJSON('/api/duchies'),
+    fetchJSON('/api/viscounties'),
+    fetchJSON('/api/marquisates'),
+    fetchJSON('/api/archduchies'),
+    fetchJSON('/api/empires'),
   ]);
 
   const seigneursSelect = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -185,6 +189,10 @@ async function loadAll(){
   const kingdomsSelect = kingdoms.slice().sort((a, b) => a.name.localeCompare(b.name));
   const countiesSelect = counties.slice().sort((a, b) => a.name.localeCompare(b.name));
   const duchiesSelect = duchies.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const viscountiesSelect = viscounties.slice().sort((a,b)=>a.name.localeCompare(b.name));
+  const marquisatesSelect = marquisates.slice().sort((a,b)=>a.name.localeCompare(b.name));
+  const archduchiesSelect = archduchies.slice().sort((a,b)=>a.name.localeCompare(b.name));
+  const empiresSelect = empires.slice().sort((a,b)=>a.name.localeCompare(b.name));
 
   const seigneursById = seigneurs.slice().sort((a,b)=>a.id - b.id);
   const religionsById = religions.slice().sort((a,b)=>a.id - b.id);
@@ -192,6 +200,10 @@ async function loadAll(){
   const kingdomsById = kingdoms.slice().sort((a,b)=>a.id - b.id);
   const countiesById = counties.slice().sort((a,b)=>a.id - b.id);
   const duchiesById = duchies.slice().sort((a,b)=>a.id - b.id);
+  const viscountiesById = viscounties.slice().sort((a,b)=>a.id - b.id);
+  const marquisatesById = marquisates.slice().sort((a,b)=>a.id - b.id);
+  const archduchiesById = archduchies.slice().sort((a,b)=>a.id - b.id);
+  const empiresById = empires.slice().sort((a,b)=>a.id - b.id);
 
   renderTable(document.getElementById('tableReligions'), religionsById, {
     endpoint:'religions',
@@ -207,24 +219,53 @@ async function loadAll(){
     colorFields:['color']
   });
 
-  renderTable(document.getElementById('tableKingdoms'), kingdomsById, {
-    endpoint:'kingdoms',
-    fields:['name'],
-    labels:{name:'Nom'}
+  renderTable(document.getElementById('tableEmpires'), empiresById, {
+    endpoint:'empires',
+    fields:['name','seigneur_id'],
+    selects:{seigneur_id:seigneursSelect},
+    labels:{name:'Nom', seigneur_id:'Seigneur'}
   });
 
-  renderTable(document.getElementById('tableCounties'), countiesById, {
-    endpoint:'counties',
-    fields:['name','duchy_id'],
-    selects:{duchy_id:duchiesSelect},
-    labels:{name:'Nom', duchy_id:'Duché'}
+  renderTable(document.getElementById('tableKingdoms'), kingdomsById, {
+    endpoint:'kingdoms',
+    fields:['name','empire_id'],
+    selects:{empire_id:empiresSelect},
+    labels:{name:'Nom', empire_id:'Empire'}
+  });
+
+  renderTable(document.getElementById('tableArchduchies'), archduchiesById, {
+    endpoint:'archduchies',
+    fields:['name','seigneur_id'],
+    selects:{seigneur_id:seigneursSelect},
+    labels:{name:'Nom', seigneur_id:'Seigneur'}
   });
 
   renderTable(document.getElementById('tableDuchies'), duchiesById, {
     endpoint:'duchies',
-    fields:['name','kingdom_id'],
-    selects:{kingdom_id:kingdomsSelect},
-    labels:{name:'Nom', kingdom_id:'Royaume'}
+    fields:['name','kingdom_id','archduchy_id'],
+    selects:{kingdom_id:kingdomsSelect, archduchy_id:archduchiesSelect},
+    labels:{name:'Nom', kingdom_id:'Royaume', archduchy_id:'Archiduché'}
+  });
+
+  renderTable(document.getElementById('tableMarquisates'), marquisatesById, {
+    endpoint:'marquisates',
+    fields:['name','seigneur_id'],
+    selects:{seigneur_id:seigneursSelect},
+    labels:{name:'Nom', seigneur_id:'Seigneur'}
+  });
+
+  renderTable(document.getElementById('tableCounties'), countiesById, {
+    endpoint:'counties',
+    fields:['name','duchy_id','marquisate_id'],
+    selects:{duchy_id:duchiesSelect, marquisate_id:marquisatesSelect},
+    labels:{name:'Nom', duchy_id:'Duché', marquisate_id:'Marquisat'}
+  });
+
+  renderTable(document.getElementById('tableViscounties'), viscountiesById, {
+    endpoint:'viscounties',
+    fields:['name','seigneur_id'],
+    selects:{seigneur_id:seigneursSelect},
+    labels:{name:'Nom', seigneur_id:'Seigneur'}
   });
 
   renderTable(document.getElementById('tableSeigneurs'), seigneursById, {

--- a/index.html
+++ b/index.html
@@ -15,9 +15,13 @@
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
         <option value="culture">Culture</option>
+        <option value="viscounty">Vicomté</option>
         <option value="county">Comté</option>
+        <option value="marquisate">Marquisat</option>
         <option value="duchy">Duché</option>
+        <option value="archduchy">Archiduché</option>
         <option value="kingdom">Royaume</option>
+        <option value="empire">Empire</option>
       </select>
     </div>
   </header>
@@ -35,9 +39,13 @@
       <div><strong>Seigneur :</strong> <span id="infoSeigneur"></span></div>
       <div><strong>Religion :</strong> <span id="infoReligion"></span></div>
       <div><strong>Culture :</strong> <span id="infoCulture"></span></div>
+      <div><strong>Vicomté :</strong> <span id="infoViscounty"></span></div>
       <div><strong>Comté :</strong> <span id="infoCounty"></span></div>
+      <div><strong>Marquisat :</strong> <span id="infoMarquisate"></span></div>
       <div><strong>Duché :</strong> <span id="infoDuchy"></span></div>
+      <div><strong>Archiduché :</strong> <span id="infoArchduchy"></span></div>
       <div><strong>Royaume :</strong> <span id="infoKingdom"></span></div>
+      <div><strong>Empire :</strong> <span id="infoEmpire"></span></div>
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>
   </main>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -15,9 +15,13 @@
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
         <option value="culture">Culture</option>
+        <option value="viscounty">Vicomté</option>
         <option value="county">Comté</option>
+        <option value="marquisate">Marquisat</option>
         <option value="duchy">Duché</option>
+        <option value="archduchy">Archiduché</option>
         <option value="kingdom">Royaume</option>
+        <option value="empire">Empire</option>
       </select>
       <button id="exportJson" class="control-btn">Exporter JSON</button>
       <button id="saveToFile" class="control-btn">Enregistrer</button>
@@ -71,6 +75,8 @@
       <select id="editReligionPop"></select>
       <label for="editCulture">Culture&nbsp;:</label>
       <select id="editCulture"></select>
+      <label for="editViscounty">Vicomté de jure&nbsp;:</label>
+      <select id="editViscounty"></select>
       <label for="editCounty">Comté de jure&nbsp;:</label>
       <select id="editCounty"></select>
       <button id="updateBarony" class="control-btn">Mettre à jour</button>

--- a/viewer.js
+++ b/viewer.js
@@ -11,6 +11,10 @@
   let countyMap = {};
   let duchyMap = {};
   let kingdomMap = {};
+  let viscountyMap = {};
+  let marquisateMap = {};
+  let archduchyMap = {};
+  let empireMap = {};
 
   async function loadPixelData() {
     const resp = await fetch(API_BASE + '/api/barony_pixels');
@@ -21,14 +25,18 @@
   }
 
   async function loadMetaData() {
-    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms] = await Promise.all([
+    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires] = await Promise.all([
       fetch(API_BASE + '/api/baronies').then(r => r.json()),
       fetch(API_BASE + '/api/seigneurs').then(r => r.json()),
       fetch(API_BASE + '/api/religions').then(r => r.json()),
       fetch(API_BASE + '/api/cultures').then(r => r.json()),
       fetch(API_BASE + '/api/counties').then(r => r.json()),
       fetch(API_BASE + '/api/duchies').then(r => r.json()),
-      fetch(API_BASE + '/api/kingdoms').then(r => r.json())
+      fetch(API_BASE + '/api/kingdoms').then(r => r.json()),
+      fetch(API_BASE + '/api/viscounties').then(r => r.json()),
+      fetch(API_BASE + '/api/marquisates').then(r => r.json()),
+      fetch(API_BASE + '/api/archduchies').then(r => r.json()),
+      fetch(API_BASE + '/api/empires').then(r => r.json())
     ]);
     baronyMeta = {};
     baronies.forEach(b => { baronyMeta[b.id] = b; });
@@ -44,6 +52,14 @@
     duchies.forEach(d => { duchyMap[d.id] = d; });
     kingdomMap = {};
     kingdoms.forEach(k => { kingdomMap[k.id] = k; });
+    viscountyMap = {};
+    viscounties.forEach(v => { viscountyMap[v.id] = v; });
+    marquisateMap = {};
+    marquisates.forEach(m => { marquisateMap[m.id] = m; });
+    archduchyMap = {};
+    archduchies.forEach(a => { archduchyMap[a.id] = a; });
+    empireMap = {};
+    empires.forEach(e => { empireMap[e.id] = e; });
   }
 
   const pixelMap = Array.from({ length: originalHeight }, () => new Array(originalWidth).fill(0));
@@ -126,6 +142,10 @@
   const infoCounty = document.getElementById('infoCounty');
   const infoDuchy = document.getElementById('infoDuchy');
   const infoKingdom = document.getElementById('infoKingdom');
+  const infoViscounty = document.getElementById('infoViscounty');
+  const infoMarquisate = document.getElementById('infoMarquisate');
+  const infoArchduchy = document.getElementById('infoArchduchy');
+  const infoEmpire = document.getElementById('infoEmpire');
 
   const ctx = pixelCanvas.getContext('2d');
   pixelCanvas.width = originalWidth;
@@ -251,12 +271,20 @@
       infoSeigneur.textContent = seigneurMap[info.seigneur_id]?.name || '';
       infoReligion.textContent = religionMap[info.religion_pop_id]?.name || '';
       infoCulture.textContent = cultureMapInfo[info.culture_id]?.name || '';
+      const viscounty = viscountyMap[info.viscounty_id];
+      infoViscounty.textContent = viscounty ? viscounty.name : '';
       const county = countyMap[info.county_id];
       infoCounty.textContent = county ? county.name : '';
+      const marquisate = county ? marquisateMap[county.marquisate_id] : null;
+      infoMarquisate.textContent = marquisate ? marquisate.name : '';
       const duchy = county ? duchyMap[county.duchy_id] : null;
       infoDuchy.textContent = duchy ? duchy.name : '';
+      const archduchy = duchy ? archduchyMap[duchy.archduchy_id] : null;
+      infoArchduchy.textContent = archduchy ? archduchy.name : '';
       const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
       infoKingdom.textContent = kingdom ? kingdom.name : '';
+      const empire = kingdom ? empireMap[kingdom.empire_id] : null;
+      infoEmpire.textContent = empire ? empire.name : '';
       infoPanel.style.display = 'block';
     }
     drawAll();
@@ -316,18 +344,36 @@
       } else if (type === 'culture') {
         groupId = info.culture_id;
         groupName = cultureMapInfo[groupId]?.name || '';
+      } else if (type === 'viscounty') {
+        groupId = info.viscounty_id;
+        groupName = viscountyMap[groupId]?.name || '';
       } else if (type === 'county') {
         groupId = info.county_id;
         groupName = countyMap[groupId]?.name || '';
+      } else if (type === 'marquisate') {
+        const county = countyMap[info.county_id];
+        groupId = county ? county.marquisate_id : null;
+        groupName = marquisateMap[groupId]?.name || '';
       } else if (type === 'duchy') {
         const county = countyMap[info.county_id];
         groupId = county ? county.duchy_id : null;
         groupName = duchyMap[groupId]?.name || '';
+      } else if (type === 'archduchy') {
+        const county = countyMap[info.county_id];
+        const duchy = county ? duchyMap[county.duchy_id] : null;
+        groupId = duchy ? duchy.archduchy_id : null;
+        groupName = archduchyMap[groupId]?.name || '';
       } else if (type === 'kingdom') {
         const county = countyMap[info.county_id];
         const duchy = county ? duchyMap[county.duchy_id] : null;
         groupId = duchy ? duchy.kingdom_id : null;
         groupName = kingdomMap[groupId]?.name || '';
+      } else if (type === 'empire') {
+        const county = countyMap[info.county_id];
+        const duchy = county ? duchyMap[county.duchy_id] : null;
+        const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
+        groupId = kingdom ? kingdom.empire_id : null;
+        groupName = empireMap[groupId]?.name || '';
       }
       if (!groupColors[groupId]) {
         let col;


### PR DESCRIPTION
## Summary
- introduce viscounties, marquisates, archduchies and empires with database support and REST endpoints
- extend admin panel, editor and viewer to manage and visualize new feudal levels
- document new hierarchy in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`
- `node --check admin.js`
- `node --check script.js`
- `node --check viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_688e514587cc832d80a180bae2e51713