### PR TITLE
Add user authentication with admin roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 asgaria.db
 /tmp/
+sessions.db

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,91 @@
+(async function() {
+  async function getUser() {
+    try {
+      const res = await fetch('/api/users/me');
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  const authBtn = document.getElementById('authBtn');
+  const logoutBtn = document.getElementById('logoutBtn');
+  const profileLink = document.getElementById('profileLink');
+  const adminNav = document.getElementById('adminNav');
+  const authModal = document.getElementById('authModal');
+  const loginForm = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+  const closeAuth = document.getElementById('closeAuth');
+
+  const params = new URLSearchParams(window.location.search);
+  const forceAuth = params.has('showAuth');
+
+  const user = await getUser();
+  if (user) {
+    profileLink.style.display = 'inline-block';
+    logoutBtn.style.display = 'inline-block';
+    if (user.is_admin) {
+      adminNav.style.display = 'flex';
+    }
+    if (forceAuth) authBtn.style.display = 'inline-block';
+  } else {
+    authBtn.style.display = 'inline-block';
+  }
+
+  authBtn?.addEventListener('click', () => {
+    authModal.style.display = 'flex';
+    loginForm.style.display = 'block';
+    registerForm.style.display = 'none';
+  });
+  closeAuth?.addEventListener('click', () => {
+    authModal.style.display = 'none';
+  });
+  document.getElementById('showRegister')?.addEventListener('click', e => {
+    e.preventDefault();
+    loginForm.style.display = 'none';
+    registerForm.style.display = 'block';
+  });
+  document.getElementById('showLogin')?.addEventListener('click', e => {
+    e.preventDefault();
+    registerForm.style.display = 'none';
+    loginForm.style.display = 'block';
+  });
+
+  document.getElementById('loginSubmit')?.addEventListener('click', async () => {
+    const email = document.getElementById('loginEmail').value;
+    const password = document.getElementById('loginPassword').value;
+    const res = await fetch('/api/users/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      location.reload();
+    } else {
+      alert('Échec de la connexion');
+    }
+  });
+
+  document.getElementById('registerSubmit')?.addEventListener('click', async () => {
+    const first = document.getElementById('regFirst').value;
+    const last = document.getElementById('regLast').value;
+    const email = document.getElementById('regEmail').value;
+    const password = document.getElementById('regPassword').value;
+    const res = await fetch('/api/users/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ first_name: first, last_name: last, email, password })
+    });
+    if (res.ok) {
+      location.reload();
+    } else {
+      alert('Création échouée');
+    }
+  });
+
+  logoutBtn?.addEventListener('click', async () => {
+    await fetch('/api/users/logout', { method: 'POST' });
+    location.reload();
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -17,8 +17,17 @@
         <option value="culture">Culture</option>
         <option value="county">Comté</option>
         <option value="duchy">Duché</option>
-        <option value="kingdom">Royaume</option>
+      <option value="kingdom">Royaume</option>
       </select>
+    </div>
+    <div id="userControls" class="controls-row">
+      <nav id="adminNav" style="display:none; gap:6px;">
+        <a href="admin.html" class="control-btn">Admin</a>
+        <a href="mapEditor.html" class="control-btn">Éditeur</a>
+      </nav>
+      <a id="profileLink" href="profile.html" class="control-btn" style="display:none;">Mon profil</a>
+      <button id="authBtn" class="control-btn" style="display:none;">Connexion / Inscription</button>
+      <button id="logoutBtn" class="control-btn" style="display:none;">Déconnexion</button>
     </div>
   </header>
   <main>
@@ -41,7 +50,30 @@
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>
   </main>
+  <div id="authModal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span id="closeAuth" style="float:right; cursor:pointer;">&times;</span>
+      <div id="loginForm">
+        <h2>Connexion</h2>
+        <input type="email" id="loginEmail" placeholder="Email">
+        <input type="password" id="loginPassword" placeholder="Mot de passe">
+        <button id="loginSubmit" class="control-btn">Connexion</button>
+        <p>Pas de compte? <a href="#" id="showRegister">Créer un compte</a></p>
+      </div>
+      <div id="registerForm" style="display:none;">
+        <h2>Créer un compte</h2>
+        <p>Utilisez votre vrai prénom et nom, pas un personnage.</p>
+        <input type="text" id="regFirst" placeholder="Prénom">
+        <input type="text" id="regLast" placeholder="Nom">
+        <input type="email" id="regEmail" placeholder="Email">
+        <input type="password" id="regPassword" placeholder="Mot de passe">
+        <button id="registerSubmit" class="control-btn">Créer</button>
+        <p>Déjà un compte? <a href="#" id="showLogin">Connexion</a></p>
+      </div>
+    </div>
+  </div>
   <script src="pixelData.js"></script>
   <script src="viewer.js"></script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "asgaria",
       "version": "1.0.0",
       "dependencies": {
+        "bcrypt": "^6.0.0",
+        "connect-sqlite3": "^0.9.16",
         "express": "^4.19.2",
+        "express-session": "^1.18.2",
         "sqlite3": "^5.1.6"
       }
     },
@@ -205,6 +208,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/bcrypt/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -387,6 +413,17 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/connect-sqlite3": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/connect-sqlite3/-/connect-sqlite3-0.9.16.tgz",
+      "integrity": "sha512-2gqo0QmcBBL8p8+eqpBETn7RgM/PaoKvpQGl8PfjEgwlr0VuMYNMxRJRrRCo3KR3fxMYeSsCw2tGNG0JKN9Nvg==",
+      "dependencies": {
+        "sqlite3": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -683,6 +720,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1466,6 +1537,17 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -1519,6 +1601,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1656,6 +1747,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -2224,6 +2324,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
+    "connect-sqlite3": "^0.9.16",
     "express": "^4.19.2",
+    "express-session": "^1.18.2",
     "sqlite3": "^5.1.6"
   }
 }

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Mon profil</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Mon profil</h1>
+  <form id="infoForm">
+    <label>Prénom : <input type="text" id="firstName"></label><br>
+    <label>Nom : <input type="text" id="lastName"></label><br>
+    <button type="submit" class="control-btn">Mettre à jour</button>
+  </form>
+  <hr>
+  <form id="passwordForm">
+    <h2>Changer le mot de passe</h2>
+    <label>Mot de passe actuel : <input type="password" id="currentPassword"></label><br>
+    <label>Nouveau mot de passe : <input type="password" id="newPassword"></label><br>
+    <button type="submit" class="control-btn">Changer</button>
+  </form>
+  <script src="profile.js"></script>
+</body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,46 @@
+async function loadProfile() {
+  const res = await fetch('/api/users/me');
+  if (!res.ok) {
+    window.location = '/';
+    return;
+  }
+  const user = await res.json();
+  document.getElementById('firstName').value = user.first_name || '';
+  document.getElementById('lastName').value = user.last_name || '';
+}
+
+loadProfile();
+
+document.getElementById('infoForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const first_name = document.getElementById('firstName').value;
+  const last_name = document.getElementById('lastName').value;
+  const res = await fetch('/api/users/me', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ first_name, last_name })
+  });
+  if (res.ok) {
+    alert('Informations mises à jour');
+  } else {
+    alert("Échec de la mise à jour");
+  }
+});
+
+document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const current_password = document.getElementById('currentPassword').value;
+  const new_password = document.getElementById('newPassword').value;
+  const res = await fetch('/api/users/password', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ current_password, new_password })
+  });
+  if (res.ok) {
+    alert('Mot de passe changé');
+    document.getElementById('currentPassword').value = '';
+    document.getElementById('newPassword').value = '';
+  } else {
+    alert('Échec du changement');
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -264,3 +264,31 @@ main {
   height: 14px;
   border: 1px solid #000;
 }
+
+/* Auth modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 4px;
+  width: 300px;
+}
+
+.modal-content input {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 6px;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add session-based authentication with bcrypt-hashed passwords and admin flag
- show admin/editor navigation only to admins and provide login/register modal requiring real name
- create profile page for updating personal info and changing password

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_688e53e91cc4832db7b2bcc560ec19a5