### PR TITLE
Add user accounts with admin access control and profile management

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -11,6 +11,7 @@
     <div class="controls-row">
       <button class="control-btn" onclick="location.href='mapEditor.html'">Éditeur de carte</button>
     </div>
+    <div id="authArea" class="auth-area"></div>
   </header>
   <main>
     <div class="tab-container" style="overflow:auto;flex:1">
@@ -60,6 +61,7 @@
       </div>
     </div>
   </main>
+  <script src="auth.js"></script>
   <script src="admin.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,105 @@
+async function getCurrentUser() {
+  try {
+    const res = await fetch('/api/me');
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const user = await getCurrentUser();
+  const params = new URLSearchParams(window.location.search);
+  const authArea = document.getElementById('authArea');
+  const controls = document.getElementById('controls');
+  const authDialog = document.getElementById('authDialog');
+
+  const showLogin = (!user || params.has('auth')) && authDialog;
+  if (authArea && showLogin) {
+    const loginBtn = document.createElement('button');
+    loginBtn.id = 'loginBtn';
+    loginBtn.className = 'control-btn';
+    loginBtn.textContent = 'Connexion';
+    loginBtn.addEventListener('click', () => authDialog.showModal());
+    authArea.appendChild(loginBtn);
+  }
+
+  if (user && authArea) {
+    const userLink = document.createElement('a');
+    userLink.href = 'profile.html';
+    userLink.className = 'user-link';
+    userLink.innerHTML = `
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M6 20c0-4 4-6 6-6s6 2 6 6"></path></svg>
+      <span>${user.first_name}</span>`;
+    authArea.appendChild(userLink);
+
+    const logoutBtn = document.createElement('button');
+    logoutBtn.className = 'icon-btn';
+    logoutBtn.innerHTML = `
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>`;
+    logoutBtn.addEventListener('click', async () => {
+      await fetch('/api/logout', { method: 'POST' });
+      location.reload();
+    });
+    authArea.appendChild(logoutBtn);
+  }
+
+  if (user && user.is_admin && controls) {
+    const adminBtn = document.createElement('button');
+    adminBtn.className = 'control-btn';
+    adminBtn.textContent = 'Admin';
+    adminBtn.onclick = () => location.href = 'admin.html';
+    controls.appendChild(adminBtn);
+
+    const editorBtn = document.createElement('button');
+    editorBtn.className = 'control-btn';
+    editorBtn.textContent = 'Éditeur';
+    editorBtn.onclick = () => location.href = 'mapEditor.html';
+    controls.appendChild(editorBtn);
+  }
+
+  const loginForm = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+  if (loginForm && registerForm) {
+    document.getElementById('showRegister').addEventListener('click', e => {
+      e.preventDefault();
+      loginForm.style.display = 'none';
+      registerForm.style.display = 'flex';
+    });
+    document.getElementById('showLogin').addEventListener('click', e => {
+      e.preventDefault();
+      registerForm.style.display = 'none';
+      loginForm.style.display = 'flex';
+    });
+
+    loginForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(loginForm));
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        location.reload();
+      } else {
+        alert('Échec de la connexion');
+      }
+    });
+
+    registerForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(registerForm));
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        location.reload();
+      } else {
+        alert('Échec de la création du compte');
+      }
+    });
+  }
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <option value="empire">Empire</option>
       </select>
     </div>
+    <div id="authArea" class="auth-area"></div>
   </header>
   <main>
     <div id="mapContainer" class="map-container">
@@ -51,5 +52,25 @@
   </main>
   <script src="pixelData.js"></script>
   <script src="viewer.js"></script>
+  <dialog id="authDialog">
+    <form id="loginForm" method="dialog">
+      <h3>Connexion</h3>
+      <input type="email" name="email" placeholder="Email" required>
+      <input type="password" name="password" placeholder="Mot de passe" required>
+      <button type="submit" class="control-btn">Connexion</button>
+      <p><a href="#" id="showRegister">Créer un compte</a></p>
+    </form>
+    <form id="registerForm" method="dialog" style="display:none;flex-direction:column;">
+      <h3>Créer un compte</h3>
+      <input type="email" name="email" placeholder="Email" required>
+      <input type="password" name="password" placeholder="Mot de passe" required>
+      <input type="text" name="first_name" placeholder="Prénom réel" required>
+      <input type="text" name="last_name" placeholder="Nom de famille réel" required>
+      <small>Utilisez vos vrais prénom et nom (pas de personnage).</small>
+      <button type="submit" class="control-btn">Créer</button>
+      <p><a href="#" id="showLogin">Déjà un compte ?</a></p>
+    </form>
+  </dialog>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -55,6 +55,7 @@
         <input type="range" id="brushSize" min="1" max="10" value="1">
       </label>
     </div>
+    <div id="authArea" class="auth-area"></div>
   </header>
   <main>
     <div id="mapContainer" class="map-container">
@@ -86,5 +87,6 @@
   <script>window.defaultEditMode = true;</script>
   <script src="pixelData.js"></script>
   <script src="script.js"></script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "asgaria",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "express": "^4.19.2",
+        "express-session": "^1.17.3",
         "sqlite3": "^5.1.6"
       }
     },
@@ -203,6 +205,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/bindings": {
@@ -683,6 +691,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1523,6 +1565,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1656,6 +1707,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -2224,6 +2284,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "express": "^4.19.2",
+    "express-session": "^1.17.3",
     "sqlite3": "^5.1.6"
   }
 }

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Profil</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <h1>Profil</h1>
+    <div id="authArea" class="auth-area"></div>
+  </header>
+  <main>
+    <form id="profileForm" class="controls-row" style="flex-direction:column;max-width:300px;margin:20px auto;gap:8px;">
+      <label>Prénom
+        <input type="text" name="first_name" required>
+      </label>
+      <label>Nom
+        <input type="text" name="last_name" required>
+      </label>
+      <label>Nouveau mot de passe
+        <input type="password" name="password" placeholder="Laisser vide pour ne pas changer">
+      </label>
+      <button type="submit" class="control-btn">Mettre à jour</button>
+    </form>
+  </main>
+  <script src="auth.js"></script>
+  <script src="profile.js"></script>
+</body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const res = await fetch('/api/me');
+  const user = await res.json();
+  if (!user) {
+    location.href = '/';
+    return;
+  }
+  const form = document.getElementById('profileForm');
+  form.first_name.value = user.first_name || '';
+  form.last_name.value = user.last_name || '';
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form));
+    const res = await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (res.ok) {
+      alert('Profil mis à jour');
+      form.password.value = '';
+    } else {
+      alert('Erreur lors de la mise à jour');
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,38 @@ main {
   align-items: center;
 }
 
+.auth-area {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.user-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: white;
+  text-decoration: none;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: white;
+}
+
+#authDialog form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#authDialog input {
+  padding: 6px;
+}
+
 /* Boutons généraux */
 .control-btn {
   background-color: #1d56a4;


### PR DESCRIPTION
## Summary
- add SQLite-backed user accounts with hashed passwords and session auth
- restrict admin and map editor pages to administrator accounts
- provide login/register modal, profile page, and icon-based user navigation

## Testing
- `node server.js` (start server)
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e59934358832d968de95a2c6ffd5e