### PR TITLE
fix: handle UNIQUE user_id column on seigneurs

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,7 +110,11 @@ db.exec(initSql, () => {
         db.run('ALTER TABLE seigneurs ADD COLUMN overlord_id INTEGER');
       }
       if (!rows.some(r => r.name === 'user_id')) {
-        db.run('ALTER TABLE seigneurs ADD COLUMN user_id INTEGER UNIQUE');
+        db.run('ALTER TABLE seigneurs ADD COLUMN user_id INTEGER', () => {
+          db.run('CREATE UNIQUE INDEX IF NOT EXISTS idx_seigneurs_user_id ON seigneurs(user_id)');
+        });
+      } else {
+        db.run('CREATE UNIQUE INDEX IF NOT EXISTS idx_seigneurs_user_id ON seigneurs(user_id)');
       }
     }
   });


### PR DESCRIPTION
## Summary
- avoid SQLite error when migrating seigneurs.user_id by creating unique index separately

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890c45302f8832d82b038b3cb3e23d1