### PR TITLE
Refine editor and admin interfaces

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -9,10 +9,10 @@
   <header class="app-header">
     <h1>Administration</h1>
     <div id="controls" class="controls-row">
-      <button class="control-btn" onclick="location.href='mapEditor.html'">Éditeur de carte</button>
       <span id="authArea" class="auth-area"></span>
     </div>
   </header>
+  <div id="saveIndicator" class="save-indicator">✔️</div>
   <main>
     <div class="tab-container" style="overflow:auto;flex:1">
       <div class="tab-buttons">

--- a/auth.js
+++ b/auth.js
@@ -45,18 +45,21 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   if (user && controls) {
-    if (user.is_admin) {
+    const current = location.pathname.split('/').pop();
+    if (user.is_admin && current !== 'admin.html') {
       const adminBtn = document.createElement('button');
       adminBtn.className = 'control-btn';
       adminBtn.textContent = 'Admin';
       adminBtn.onclick = () => location.href = 'admin.html';
       controls.appendChild(adminBtn);
     }
-    const editorBtn = document.createElement('button');
-    editorBtn.className = 'control-btn';
-    editorBtn.textContent = 'Éditeur';
-    editorBtn.onclick = () => location.href = 'mapEditor.html';
-    controls.appendChild(editorBtn);
+    if (current !== 'mapEditor.html') {
+      const editorBtn = document.createElement('button');
+      editorBtn.className = 'control-btn';
+      editorBtn.textContent = 'Éditeur';
+      editorBtn.onclick = () => location.href = 'mapEditor.html';
+      controls.appendChild(editorBtn);
+    }
   }
 
   const loginForm = document.getElementById('loginForm');

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -23,17 +23,10 @@
         <option value="kingdom">Royaume</option>
         <option value="empire">Empire</option>
       </select>
-      <button id="exportJson" class="control-btn">Exporter JSON</button>
       <button id="saveToFile" class="control-btn">Enregistrer</button>
-      <label class="file-label control-btn">
-        Importer JSON
-        <input type="file" id="jsonFileInput" accept=".json">
-      </label>
       <button id="deleteBarony" class="control-btn">Supprimer</button>
-      <button id="mergeBarony" class="control-btn">Fusionner</button>
       <button id="toggleMap" class="control-btn">Changer fond</button>
       <button id="selectBarony" class="control-btn">Sélectionner</button>
-      <button class="control-btn" onclick="location.href='admin.html'">Administration</button>
       <span id="authArea" class="auth-area"></span>
     </div>
     <div id="tools" class="tools-row">
@@ -54,6 +47,7 @@
       </button>
       <label for="brushSize" class="brush-size-label">Taille&nbsp;
         <input type="range" id="brushSize" min="1" max="10" value="1">
+        <span id="brushSizeValue">1</span>
       </label>
     </div>
     <div id="authArea" class="auth-area"></div>

--- a/script.js
+++ b/script.js
@@ -106,11 +106,8 @@
   const mapContainer = document.getElementById('mapContainer');
   const toggleEditBtn = document.getElementById('toggleEdit');
   const randomBtn = document.getElementById('randomColors');
-  const exportBtn = document.getElementById('exportJson');
   const saveBtn = document.getElementById('saveToFile');
-  const importInput = document.getElementById('jsonFileInput');
   const deleteBtn = document.getElementById('deleteBarony');
-  const mergeBtn = document.getElementById('mergeBarony');
   const toggleMapBtn = document.getElementById('toggleMap');
   const selectBtn = document.getElementById('selectBarony');
   const infoPanel = document.getElementById('infoPanel');
@@ -199,6 +196,7 @@
   const bucketToolBtn = document.getElementById('bucketTool');
   const newBaronyBtn = document.getElementById('newBarony');
   const brushSizeInput = document.getElementById('brushSize');
+  const brushSizeValue = document.getElementById('brushSizeValue');
 
   // Save pixels to the server
   if (saveBtn) saveBtn.addEventListener('click', () => {
@@ -220,6 +218,7 @@
   let editMode = defaultEditMode;
   let currentTool = null;
   let brushSize = 1;
+  if (brushSizeValue) brushSizeValue.textContent = brushSize;
   let painting = false;
   let currentSelectedId = null;
   let mergeMode = false;
@@ -963,18 +962,7 @@
   });
   if (randomBtn) randomBtn.addEventListener('click', randomizeColors);
   if (filterSelect) filterSelect.addEventListener('change', () => applyFilter(filterSelect.value));
-  if (exportBtn) exportBtn.addEventListener('click', exportJson);
-  if (importInput) importInput.addEventListener('change', (e) => {
-    const file = e.target.files[0];
-    if (file) importJson(file);
-  });
   if (deleteBtn) deleteBtn.addEventListener('click', deleteBarony);
-  if (mergeBtn) mergeBtn.addEventListener('click', () => {
-    if (!currentSelectedId) return;
-    mergeMode = true;
-    mergeBaseId = currentSelectedId;
-    alert('Mode fusion activé : cliquez sur la baronnie à fusionner.');
-  });
   if (toggleMapBtn) toggleMapBtn.addEventListener('click', toggleMap);
   if (selectBtn) selectBtn.addEventListener('click', () => {
     const id = prompt('ID de la baronnie à sélectionner ?');
@@ -1022,6 +1010,7 @@
     brushSizeInput.addEventListener('input', () => {
       const val = parseInt(brushSizeInput.value, 10);
       brushSize = isNaN(val) ? 1 : val;
+      if (brushSizeValue) brushSizeValue.textContent = brushSize;
     });
 
   // Événements souris pour peinture et sélection

--- a/server.js
+++ b/server.js
@@ -258,6 +258,13 @@ app.get('/api/me', (req, res) => {
   res.json(req.session.user || null);
 });
 
+app.get('/api/users', (req, res) => {
+  db.all('SELECT id, email, first_name, last_name FROM users', [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
 app.post('/api/profile', (req, res) => {
   if (!req.session.user) return res.status(401).json({ error: 'Unauthorized' });
   const { first_name, last_name, password, current_password } = req.body;

--- a/styles.css
+++ b/styles.css
@@ -320,3 +320,17 @@ main {
   height: 14px;
   border: 1px solid #000;
 }
+
+/* Indicateur de sauvegarde */
+.save-indicator {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background-color: #4caf50;
+  color: white;
+  padding: 6px 8px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  display: none;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- Clean map editor controls and show active brush size
- Simplify admin navigation, add user assignment and save confirmation icon
- Skip adding navigation link for current page and expose users API

## Testing
- `node --check script.js`
- `node --check admin.js`
- `node --check auth.js`
- `node --check server.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890cf051790832d87a5bc4e15371855