### PR TITLE
Show save confirmation next to updated column

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -5,9 +5,12 @@ async function fetchJSON(url, options){
   return resp.json();
 }
 
-function showSaveIndicator() {
+function showSaveIndicator(target) {
   const el = document.getElementById('saveIndicator');
-  if (!el) return;
+  if (!el || !target) return;
+  const rect = target.getBoundingClientRect();
+  el.style.top = `${rect.top}px`;
+  el.style.left = `${rect.right + 5}px`;
   el.style.display = 'block';
   setTimeout(() => {
     el.style.display = 'none';
@@ -135,7 +138,7 @@ function renderTable(container, rows, opts){
           }
         });
         await fetchJSON(`/api/${opts.endpoint}/${item.id}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
-        showSaveIndicator();
+        showSaveIndicator(btn.parentElement);
         loadAll();
       });
       td.appendChild(btn);
@@ -167,7 +170,7 @@ function renderTable(container, rows, opts){
         }
       });
       await fetchJSON(`/api/${opts.endpoint}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
-      showSaveIndicator();
+      showSaveIndicator(addBtn.parentElement);
       loadAll();
     });
     addTd.appendChild(addBtn);

--- a/styles.css
+++ b/styles.css
@@ -324,8 +324,6 @@ main {
 /* Indicateur de sauvegarde */
 .save-indicator {
   position: fixed;
-  top: 10px;
-  right: 10px;
   background-color: #4caf50;
   color: white;
   padding: 6px 8px;


### PR DESCRIPTION
## Summary
- Reposition save indicator to appear beside the table column that was saved
- Adjust admin table logic to pass the target cell to the save indicator
- Simplify indicator styling for dynamic placement

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890ff0fed00832d89bede5b313c40a2