### PR TITLE
Fix filter functionality in map editor

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,8 +10,11 @@
   async function loadPixelData() {
     const resp = await fetch(API_BASE + '/api/barony_pixels');
     pixelData = await resp.json();
-    baronyMeta = {};
-    Object.keys(pixelData).forEach(id => { baronyMeta[id] = { id, name: '' }; });
+    Object.keys(pixelData).forEach(id => {
+      if (!baronyMeta[id]) {
+        baronyMeta[id] = { id, name: '' };
+      }
+    });
     for (let y = 0; y < originalHeight; y++) pixelMap[y].fill(0);
     Object.entries(pixelData).forEach(([id, coords]) => {
       coords.forEach(([x, y]) => {


### PR DESCRIPTION
## Summary
- preserve barony metadata when loading pixel data so filters work in map editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6890ffa4e270832d8a24e23725065ea5