### PR TITLE
feat: add barony occupation filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <option value="archduchy">Archiduché</option>
         <option value="kingdom">Royaume</option>
         <option value="empire">Empire</option>
+        <option value="occupation">Occupation</option>
       </select>
       <span id="authArea" class="auth-area"></span>
     </div>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -22,6 +22,7 @@
         <option value="archduchy">Archiduché</option>
         <option value="kingdom">Royaume</option>
         <option value="empire">Empire</option>
+        <option value="occupation">Occupation</option>
       </select>
       <button id="saveToFile" class="control-btn">Enregistrer</button>
       <button id="deleteBarony" class="control-btn">Supprimer</button>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@
   const originalWidth = 1724;
   const originalHeight = 1291;
   const terrainColor = [239, 228, 176];
+  const playerColor = [82, 190, 128];
+  const npcColor = [231, 76, 60];
 
   // Pixel data loaded from the server
   let pixelData = {};
@@ -364,6 +366,20 @@
         const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
         groupId = kingdom ? kingdom.empire_id : null;
         groupName = empireMap[groupId]?.name || '';
+      } else if (type === 'occupation') {
+        if (!info.seigneur_id) {
+          groupId = 'unoccupied';
+          groupName = 'Non occupée';
+        } else {
+          const s = seigneurMap[info.seigneur_id];
+          if (s && s.user_id) {
+            groupId = 'player';
+            groupName = 'Joueur';
+          } else {
+            groupId = 'npc';
+            groupName = 'PNJ';
+          }
+        }
       }
       if (groupId == null) {
         colorMap[id] = [...terrainColor, 100];
@@ -371,7 +387,11 @@
       }
       if (!groupColors[groupId]) {
         let col;
-        if (randomize) {
+        if (type === 'occupation') {
+          if (groupId === 'player') col = playerColor;
+          else if (groupId === 'npc') col = npcColor;
+          else col = terrainColor;
+        } else if (randomize) {
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {

--- a/viewer.js
+++ b/viewer.js
@@ -3,6 +3,8 @@
   const originalWidth = 1724;
   const originalHeight = 1291;
   const terrainColor = [239, 228, 176];
+  const playerColor = [82, 190, 128];
+  const npcColor = [231, 76, 60];
 
   let pixelData = {};
   let baronyMeta = {};
@@ -375,6 +377,20 @@
         const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
         groupId = kingdom ? kingdom.empire_id : null;
         groupName = empireMap[groupId]?.name || '';
+      } else if (type === 'occupation') {
+        if (!info.seigneur_id) {
+          groupId = 'unoccupied';
+          groupName = 'Non occupée';
+        } else {
+          const s = seigneurMap[info.seigneur_id];
+          if (s && s.user_id) {
+            groupId = 'player';
+            groupName = 'Joueur';
+          } else {
+            groupId = 'npc';
+            groupName = 'PNJ';
+          }
+        }
       }
       if (groupId == null) {
         colorMap[id] = [...terrainColor, 100];
@@ -382,7 +398,11 @@
       }
       if (!groupColors[groupId]) {
         let col;
-        if (randomize) {
+        if (type === 'occupation') {
+          if (groupId === 'player') col = playerColor;
+          else if (groupId === 'npc') col = npcColor;
+          else col = terrainColor;
+        } else if (randomize) {
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {


### PR DESCRIPTION
## Summary
- add filter to color baronies by occupation: player, NPC, or free
- wire new option into viewer and editor

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689108e72678832d93a56b6306d9b3f5