### PR TITLE
Add religious buildings and canonical land support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
       <select id="colorFilter" class="control-btn">
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
+        <option value="sanctuary">Sanctuaire</option>
+        <option value="priory">Prieuré</option>
+        <option value="church">Église</option>
+        <option value="cathedral">Cathédrale</option>
+        <option value="canonical">Terres canoniques</option>
         <option value="culture">Culture</option>
         <option value="viscounty">Vicomté</option>
         <option value="county">Comté de jure</option>
@@ -51,6 +56,12 @@
       <div><strong>Archiduché :</strong> <span id="infoArchduchy"></span></div>
       <div><strong>Royaume :</strong> <span id="infoKingdom"></span></div>
       <div><strong>Empire :</strong> <span id="infoEmpire"></span></div>
+      <div><strong>Sanctuaire :</strong> <span id="infoSanctuary"></span></div>
+      <div><strong>Prieuré :</strong> <span id="infoPriory"></span></div>
+      <div><strong>Église :</strong> <span id="infoChurch"></span></div>
+      <div><strong>Cathédrale :</strong> <span id="infoCathedral"></span></div>
+      <div><strong>Joueur :</strong> <span id="infoPlayer"></span></div>
+      <div><strong>Terres canoniques :</strong> <span id="infoCanonical"></span></div>
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>
   </main>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -14,6 +14,11 @@
       <select id="colorFilter" class="control-btn">
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
+        <option value="sanctuary">Sanctuaire</option>
+        <option value="priory">Prieuré</option>
+        <option value="church">Église</option>
+        <option value="cathedral">Cathédrale</option>
+        <option value="canonical">Terres canoniques</option>
         <option value="culture">Culture</option>
         <option value="viscounty">Vicomté</option>
         <option value="county">Comté de jure</option>
@@ -73,6 +78,15 @@
       <select id="editSeigneur"></select>
       <label for="editReligionPop">Religion population&nbsp;:</label>
       <select id="editReligionPop"></select>
+      <label for="editSanctuary">Sanctuaire&nbsp;:</label>
+      <select id="editSanctuary"></select>
+      <label for="editPriory">Prieuré&nbsp;:</label>
+      <select id="editPriory"></select>
+      <label for="editChurch">Église&nbsp;:</label>
+      <select id="editChurch"></select>
+      <label for="editCathedral">Cathédrale&nbsp;:</label>
+      <select id="editCathedral"></select>
+      <label><input type="checkbox" id="editPlayer"> Joueur</label>
       <label for="editCulture">Culture&nbsp;:</label>
       <select id="editCulture"></select>
       <label for="editViscounty">Vicomté de jure&nbsp;:</label>


### PR DESCRIPTION
## Summary
- track sanctuary, priory, church, cathedral and player flag on baronies
- add canonical lands table and API
- support new map filters including canonical land patterns

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js script.js viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68926e66b190832d8b067827d601963e