### PR TITLE
Add seigneurie management page

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -53,6 +53,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       adminBtn.onclick = () => location.href = 'admin.html';
       controls.appendChild(adminBtn);
     }
+    if (current !== 'gestion.html') {
+      const gestionBtn = document.createElement('button');
+      gestionBtn.className = 'control-btn';
+      gestionBtn.textContent = 'Gestion';
+      gestionBtn.onclick = () => location.href = 'gestion.html';
+      controls.appendChild(gestionBtn);
+    }
     if (current !== 'mapEditor.html') {
       const editorBtn = document.createElement('button');
       editorBtn.className = 'control-btn';

--- a/gestion.html
+++ b/gestion.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Gestion de la seigneurie</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <h1>Gestion de la seigneurie</h1>
+    <div id="controls" class="controls-row">
+      <span id="authArea" class="auth-area"></span>
+    </div>
+  </header>
+  <main>
+    <div class="tab-container" style="overflow:auto;flex:1">
+      <div class="tab-buttons">
+        <button class="tab-btn active" data-tab="sommaire">Sommaire</button>
+        <button class="tab-btn" data-tab="biens">Vos Biens</button>
+      </div>
+      <div class="tab-panels">
+        <div id="tab-sommaire" class="tab-panel active">
+          <div id="summary"></div>
+        </div>
+        <div id="tab-biens" class="tab-panel">
+          <table id="inventoryTable" class="admin-table"></table>
+        </div>
+      </div>
+    </div>
+  </main>
+  <script src="auth.js"></script>
+  <script src="gestion.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-btn');
+      const panels = document.querySelectorAll('.tab-panel');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          panels.forEach(p => p.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/gestion.js
+++ b/gestion.js
@@ -1,0 +1,55 @@
+const resources = [
+  ['or_', 'Or'], ['pierre', 'Pierre'], ['fer', 'Fer'], ['lingot_or', "Lingots d'or"],
+  ['antidote', 'Antidotes'], ['armureries', 'Armureries'], ['rhum', 'Rhum'], ['grague', 'Grague'],
+  ['vivres', 'Vivres'], ['architectes', 'Architectes'], ['charpentiers', 'Charpentiers'], ['maitres_oeuvre', "Maîtres d'œuvre"],
+  ['maitre_espions', 'Maîtres espions'], ['points_magique', 'Points magiques'], ['fourrure', 'Fourrures'], ['ivoire', 'Ivoire'],
+  ['soie', 'Soie'], ['huile', 'Huile'], ['teinture', 'Teintures'], ['epices', 'Épices'],
+  ['sel', 'Sel'], ['perle', 'Perles'], ['encens', 'Encens'], ['vin', 'Vin'],
+  ['pierre_precieuse', 'Pierres précieuses'], ['esclaves', 'Esclaves'], ['prestige', 'Prestige'], ['renommee', 'Renommée']
+];
+
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const res = await fetch('/api/my_seigneurie');
+    if (!res.ok) throw new Error('Erreur');
+    const data = await res.json();
+    const s = data.seigneurie;
+    const inv = data.inventaire || {};
+    const barony = data.barony || {};
+    const production = data.production || {};
+
+    const summary = document.getElementById('summary');
+    summary.innerHTML = `
+      <p><strong>Baronnie :</strong> ${barony.name || 'Aucune'}</p>
+      <p><strong>Population :</strong> ${s.population}</p>
+      <p><strong>Travailleurs :</strong> ${s.workers}</p>
+      <p><strong>Religion :</strong> ${barony.religion_name || 'Inconnue'}</p>
+      <p><strong>Culture :</strong> ${barony.culture_name || 'Inconnue'}</p>
+      <p><strong>Esclaves :</strong> ${inv.esclaves || 0}</p>
+      <p><strong>IDH :</strong> À calculer</p>
+    `;
+
+    const table = document.getElementById('inventoryTable');
+    let html = '<tr><th>Ressource</th><th>Quantité</th><th>Production</th><th>Ressource</th><th>Quantité</th><th>Production</th></tr>';
+    for (let i = 0; i < resources.length; i += 2) {
+      html += '<tr>' + render(resources[i]) + render(resources[i + 1]) + '</tr>';
+    }
+    table.innerHTML = html;
+
+    function render(r) {
+      if (!r) return '<td></td><td></td><td></td>';
+      const [key, label] = r;
+      const qty = inv[key] ?? 0;
+      const prod = production[key];
+      let prodHtml = '';
+      if (prod) {
+        const sign = prod > 0 ? '+' : '';
+        const cls = prod > 0 ? 'prod-positive' : 'prod-negative';
+        prodHtml = `<span class="${cls}">${sign}${prod}</span>`;
+      }
+      return `<td>${label}</td><td>${qty}</td><td>${prodHtml}</td>`;
+    }
+  } catch (e) {
+    document.getElementById('summary').textContent = 'Erreur de chargement';
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -332,3 +332,11 @@ main {
   display: none;
   z-index: 1000;
 }
+
+/* Indicateurs de production */
+.prod-positive {
+  color: #2e8b57;
+}
+.prod-negative {
+  color: #c0392b;
+}


### PR DESCRIPTION
## Summary
- add Gestion page for players to view seigneurie summary and inventory
- expose `/api/my_seigneurie` endpoint and workers column for seigneuries table
- include navigation link and production indicators

## Testing
- `npm test` (fails: Missing script)
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6893d34a2120832da936489493219df3