### PR TITLE
feat: expand gestion resources and add page padding

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -12,7 +12,7 @@
       <span id="authArea" class="auth-area"></span>
     </div>
   </header>
-  <main>
+  <main class="gestion-main">
     <div id="summary"></div>
   </main>
   <script src="auth.js"></script>

--- a/gestion.js
+++ b/gestion.js
@@ -1,7 +1,9 @@
 const basicResources = [
   ['or_', 'Or'], ['pierre', 'Pierre'], ['fer', 'Fer'], ['lingot_or', "Lingots d'or"],
   ['antidote', 'Antidotes'], ['armureries', 'Armureries'], ['rhum', 'Rhum'], ['grague', 'Grague'],
-  ['vivres', 'Vivres']
+  ['vivres', 'Vivres'], ['architectes', 'Architectes'], ['charpentiers', 'Charpentiers'],
+  ['maitres_oeuvre', "Maîtres d'œuvre"], ['maitre_espions', 'Maîtres espions'],
+  ['points_magique', 'Points magiques'],
 ];
 
 const luxuryResources = [
@@ -27,7 +29,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       <p><strong>Travailleurs :</strong> ${s.workers}</p>
       <p><strong>Religion :</strong> ${barony.religion_name || 'Inconnue'}</p>
       <p><strong>Culture :</strong> ${barony.culture_name || 'Inconnue'}</p>
-      <p><strong>Esclaves :</strong> ${inv.esclaves || 0}</p>
       <p><strong>IDH :</strong> À calculer</p>
       <div id="resourceTables" class="resource-tables">
         <div class="resource-table-container">

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,11 @@ main {
   position: relative;
 }
 
+.gestion-main {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 /* En-tête avec contrôles et outils */
 .app-header {
   background-color: #0b3d91;


### PR DESCRIPTION
## Summary
- list all inventory resources on the management page
- add horizontal padding to the gestion page for better readability

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893f42fdc48832d9cdc4c12dca5a582