### PR TITLE
Unify seigneuries and inventory

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,7 +61,6 @@
         </div>
         <div id="tab-seigneuries" class="tab-panel">
           <div id="tableSeigneuries"></div>
-          <div id="tableInventaire"></div>
         </div>
       </div>
     </div>

--- a/gestion.js
+++ b/gestion.js
@@ -26,7 +26,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     summary.innerHTML = `
       <p><strong>Baronnie :</strong> ${barony.name || 'Aucune'}</p>
       <p><strong>Population :</strong> ${s.population}</p>
-      <p><strong>Travailleurs :</strong> ${s.workers}</p>
       <p><strong>Religion :</strong> ${barony.religion_name || 'Inconnue'}</p>
       <p><strong>Culture :</strong> ${barony.culture_name || 'Inconnue'}</p>
       <p><strong>IDH :</strong> À calculer</p>


### PR DESCRIPTION
## Summary
- merge seigneurie and inventory management into one admin table
- auto-create inventories and drop workers column
- clean up player view to hide non-existent worker count

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894d1731b78832da18e629a24bd7cce