### PR TITLE
feat: add infrastructure management and barony properties

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,6 +27,7 @@
         <button class="tab-btn" data-tab="counties">Comtés</button>
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
+        <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
       <div class="tab-panels">
         <div id="tab-seigneurs" class="tab-panel active">
@@ -61,6 +62,9 @@
         </div>
         <div id="tab-seigneuries" class="tab-panel">
           <div id="tableSeigneuries"></div>
+        </div>
+        <div id="tab-baronyprops" class="tab-panel">
+          <div id="tableBaronyProps"></div>
         </div>
       </div>
     </div>

--- a/admin.js
+++ b/admin.js
@@ -21,6 +21,34 @@ const extraResources = [
 const inventaireFields = [...basicResources, ...luxuryResources, ...extraResources].map(([k]) => k);
 const inventaireLabels = Object.fromEntries([...basicResources, ...luxuryResources, ...extraResources]);
 
+const yesNoSelect = [{id:1,name:'Oui'},{id:0,name:'Non'}];
+const baronyPropBoolFields = ['water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin'];
+const baronyPropIntFields = ['field_limit','fishing_limit','high_sea_boat_limit'];
+const baronyPropFields = ['barony_id', ...baronyPropBoolFields, ...baronyPropIntFields];
+const baronyPropLabels = {
+  barony_id:'Baronnie',
+  water_access:"Accès à l'eau",
+  sea_access:'Accès à la mer',
+  has_or:'Or',
+  has_argent:'Argent',
+  has_fer:'Fer',
+  has_pierre:'Pierre',
+  has_epices:'Épices',
+  has_perle:'Perle',
+  has_encens:'Encens',
+  has_huiles:'Huiles',
+  has_pierre_precieuses:'Pierres Précieuses',
+  has_soie:'Soie',
+  has_sel:'Sel',
+  has_fourrure:'Fourrure',
+  has_teinture:'Teinture',
+  has_ivoire:'Ivoire',
+  has_vin:'Vin',
+  field_limit:'Limite de champs',
+  fishing_limit:'Limite de Pêche',
+  high_sea_boat_limit:'Limite de Bateau en haute mer'
+};
+
 async function fetchJSON(url, options){
   const resp = await fetch(API_BASE + url, options);
   return resp.json();
@@ -208,7 +236,7 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
@@ -222,6 +250,7 @@ async function loadAll(){
     fetchJSON('/api/users'),
     fetchJSON('/api/seigneuries'),
     fetchJSON('/api/baronies'),
+    fetchJSON('/api/barony_properties'),
   ]);
 
   const seigneursSelect = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -329,6 +358,16 @@ async function loadAll(){
     fields:['name','user_id','religion_id','overlord_id'],
     selects:{user_id:userSelectFn, religion_id:religionsSelect, overlord_id:seigneursSelect},
     labels:{name:'Nom', user_id:'Utilisateur', religion_id:'Religion', overlord_id:'Suzerain'}
+  });
+
+  const baronyPropsById = baronyProps.slice().sort((a,b)=>a.id - b.id);
+  const boolSelects = {};
+  baronyPropBoolFields.forEach(f => { boolSelects[f] = yesNoSelect; });
+  renderTable(document.getElementById('tableBaronyProps'), baronyPropsById, {
+    endpoint:'barony_properties',
+    fields:baronyPropFields,
+    selects:{barony_id:baroniesSelect, ...boolSelects},
+    labels:baronyPropLabels
   });
 }
 

--- a/gestion.html
+++ b/gestion.html
@@ -13,9 +13,36 @@
     </div>
   </header>
   <main class="gestion-main">
-    <div id="summary"></div>
+    <div class="tab-container" style="overflow:auto;flex:1">
+      <div class="tab-buttons">
+        <button class="tab-btn active" data-tab="ressources">Ressources</button>
+        <button class="tab-btn" data-tab="infra">Infrastructure Civile</button>
+      </div>
+      <div class="tab-panels">
+        <div id="tab-ressources" class="tab-panel active">
+          <div id="summary"></div>
+        </div>
+        <div id="tab-infra" class="tab-panel">
+          <div id="infrastructure"></div>
+        </div>
+      </div>
+    </div>
   </main>
   <script src="auth.js"></script>
   <script src="gestion.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const buttons = document.querySelectorAll('.tab-btn');
+      const panels = document.querySelectorAll('.tab-panel');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.classList.remove('active'));
+          panels.forEach(p => p.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/gestion.js
+++ b/gestion.js
@@ -21,6 +21,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const inv = data.inventaire || {};
     const barony = data.barony || {};
     const production = data.production || {};
+    const fields = data.fields || { built:0, active:0 };
+    const baronyProps = data.baronyProps || {};
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -46,6 +48,44 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     basicTable.innerHTML = buildTable(basicResources, true);
     luxuryTable.innerHTML = buildTable(luxuryResources);
+
+    const infra = document.getElementById('infrastructure');
+    const maxFields = baronyProps.field_limit || 0;
+    const costField = 3;
+    const indivProd = 75;
+    const modifier = 1;
+    const totalProd = fields.active * indivProd * modifier;
+    const canBuild = inv.or_ >= costField && fields.built < maxFields;
+    infra.innerHTML = `
+      <h2>Production</h2>
+      <table class="admin-table">
+        <tr><th>Nom</th><th>Ressource Produite</th><th>Quantité construite</th><th>Maximum</th><th>Production Individuelle</th><th>Modificateur</th><th>Quantité activée</th><th>Production totale</th><th>Restriction</th><th>Prix de construction</th><th></th></tr>
+        <tr>
+          <td>Champs</td>
+          <td>Vivres</td>
+          <td>${fields.built}</td>
+          <td>${maxFields}</td>
+          <td>${indivProd}</td>
+          <td>${modifier}</td>
+          <td>${fields.active}</td>
+          <td>${totalProd}</td>
+          <td>Aucune</td>
+          <td>3 Or</td>
+          <td><button id="buildField" ${canBuild ? '' : 'disabled'}>Construire</button></td>
+        </tr>
+      </table>
+    `;
+    const buildBtn = document.getElementById('buildField');
+    if (buildBtn) {
+      buildBtn.addEventListener('click', async ()=>{
+        const resp = await fetch('/api/building',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({type:'field',quantity:1})});
+        if(resp.ok){
+          location.reload();
+        } else {
+          alert('Construction impossible');
+        }
+      });
+    }
 
     function buildTable(list, showMax = false) {
       let html = '<tr><th>Ressource</th><th>Quantité</th><th>Production</th>';

--- a/transactions.js
+++ b/transactions.js
@@ -1,0 +1,18 @@
+const inventaireFields = [
+  'or_','pierre','fer','lingot_or','antidote','armureries','rhum','grague','vivres','architectes','charpentiers','maitres_oeuvre','maitre_espions','points_magique',
+  'fourrure','ivoire','soie','huile','teinture','epices','sel','perle','encens','vin','pierre_precieuse','esclaves','prestige','renommee'
+];
+
+function performTransaction(db, seigneurieId, resource, amount, cb){
+  if(!inventaireFields.includes(resource)) return cb(new Error('Invalid resource'));
+  db.serialize(()=>{
+    db.run(`UPDATE inventaire SET ${resource} = ${resource} + ? WHERE id = (SELECT inventaire_id FROM seigneuries WHERE id=?)`,
+      [amount, seigneurieId], function(err){
+        if(err) return cb(err);
+        db.run('INSERT INTO transactions (seigneurie_id, resource, amount) VALUES (?,?,?)',
+          [seigneurieId, resource, amount], cb);
+      });
+  });
+}
+
+module.exports = {inventaireFields, performTransaction};


### PR DESCRIPTION
## Summary
- add barony properties and fields tracking tables
- expose admin UI for barony properties
- introduce infrastructure tab with field construction and server-side transactions

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check server.js`
- `node --check gestion.js`
- `node --check admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689635db8988832d85f433c794cebb4a