### PR TITLE
Display population employment and slave counts

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -23,11 +23,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const production = data.production || {};
     const fields = data.fields || { built:0, active:0 };
     const baronyProps = data.baronyProps || {};
+    const employment = data.employment || { employed:0, slaves:0 };
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
       <p><strong>Baronnie :</strong> ${barony.name || 'Aucune'}</p>
-      <p><strong>Population :</strong> ${s.population}</p>
+      <div id="populationSummary"></div>
       <p><strong>Religion :</strong> ${barony.religion_name || 'Inconnue'}</p>
       <p><strong>Culture :</strong> ${barony.culture_name || 'Inconnue'}</p>
       <p><strong>IDH :</strong> À calculer</p>
@@ -41,6 +42,17 @@ document.addEventListener('DOMContentLoaded', async () => {
           <table id="luxuryResourcesTable" class="admin-table"></table>
         </div>
       </div>
+    `;
+
+    const popSummary = document.getElementById('populationSummary');
+    popSummary.innerHTML = `
+      <h2>Population</h2>
+      <table class="admin-table">
+        <tr><th>Type</th><th>Nombre</th></tr>
+        <tr><td>Population totale</td><td>${s.population}</td></tr>
+        <tr><td>Population employée</td><td>${employment.employed}</td></tr>
+        <tr><td>Esclaves</td><td>${employment.slaves}</td></tr>
+      </table>
     `;
 
     const basicTable = document.getElementById('basicResourcesTable');

--- a/server.js
+++ b/server.js
@@ -562,28 +562,29 @@ app.get('/api/my_seigneurie', (req, res) => {
           ensureSeigneurie(s => {
             db.get('SELECT * FROM inventaire WHERE id=?', [s.inventaire_id], (err, inventaire) => {
               if (err) return res.status(500).json({ error: err.message });
-              db.all('SELECT resource, SUM(amount) as total FROM transactions WHERE seigneurie_id=? GROUP BY resource', [s.id], (err, rows) => {
+              db.get('SELECT * FROM fields WHERE seigneurie_id=?', [s.id], (err, fieldRow) => {
                 if (err) return res.status(500).json({ error: err.message });
-                const production = {};
-                rows.forEach(r => production[r.resource] = r.total);
-                db.get('SELECT * FROM fields WHERE seigneurie_id=?', [s.id], (err, fieldRow) => {
-                  if (err) return res.status(500).json({ error: err.message });
-                  const fields = fieldRow || { built: 0, active: 0 };
-                  function finalize(barony, baronyProps) {
-                    res.json({ seigneurie: s, barony, inventaire, production, fields, baronyProps });
-                  }
-                  if (s.baronnie_id) {
-                    db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err, props) => {
+                const fields = fieldRow || { built: 0, active: 0 };
+                const slaves = inventaire.esclaves || 0;
+                const employed = fields.active; // one worker per active field for now
+                const production = {
+                  vivres: fields.active * 75 - (s.population * 15 + slaves * 5)
+                };
+                const employment = { employed, slaves };
+                function finalize(barony, baronyProps) {
+                  res.json({ seigneurie: s, barony, inventaire, production, fields, baronyProps, employment });
+                }
+                if (s.baronnie_id) {
+                  db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err, props) => {
+                    if (err) return res.status(500).json({ error: err.message });
+                    db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err, barony) => {
                       if (err) return res.status(500).json({ error: err.message });
-                      db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err, barony) => {
-                        if (err) return res.status(500).json({ error: err.message });
-                        finalize(barony, props || {});
-                      });
+                      finalize(barony, props || {});
                     });
-                  } else {
-                    finalize(null, {});
-                  }
-                });
+                  });
+                } else {
+                  finalize(null, {});
+                }
               });
             });
           });


### PR DESCRIPTION
## Summary
- Calculate food production minus population and slave consumption server-side
- Return employment and slave counts from API
- Show consolidated population/employment table in management screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689645382694832d95a353e167a68cc1