### PR TITLE
Stay on current tab after building

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -34,13 +34,24 @@
     document.addEventListener('DOMContentLoaded', () => {
       const buttons = document.querySelectorAll('.tab-btn');
       const panels = document.querySelectorAll('.tab-panel');
+
+      const savedTab = localStorage.getItem('gestionActiveTab') || 'ressources';
+
       buttons.forEach(btn => {
+        const isActive = btn.dataset.tab === savedTab;
+        btn.classList.toggle('active', isActive);
         btn.addEventListener('click', () => {
+          const tab = btn.dataset.tab;
           buttons.forEach(b => b.classList.remove('active'));
           panels.forEach(p => p.classList.remove('active'));
           btn.classList.add('active');
-          document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+          document.getElementById('tab-' + tab).classList.add('active');
+          localStorage.setItem('gestionActiveTab', tab);
         });
+      });
+
+      panels.forEach(p => {
+        p.classList.toggle('active', p.id === 'tab-' + savedTab);
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- Preserve selected tab between reloads so building a structure no longer returns the user to the summary tab.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896463adc6c832dbe0ad19626d86ea3