### PR TITLE
feat: add barony properties tab

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -17,6 +17,7 @@
       <div class="tab-buttons">
         <button class="tab-btn active" data-tab="ressources">Ressources</button>
         <button class="tab-btn" data-tab="infra">Infrastructure Civile</button>
+        <button class="tab-btn" data-tab="proprietes">Propriétés</button>
       </div>
       <div class="tab-panels">
         <div id="tab-ressources" class="tab-panel active">
@@ -24,6 +25,9 @@
         </div>
         <div id="tab-infra" class="tab-panel">
           <div id="infrastructure"></div>
+        </div>
+        <div id="tab-proprietes" class="tab-panel">
+          <div id="baronyProps"></div>
         </div>
       </div>
     </div>

--- a/gestion.js
+++ b/gestion.js
@@ -12,6 +12,30 @@ const luxuryResources = [
   ['encens', 'Encens'], ['vin', 'Vin'], ['pierre_precieuse', 'Pierres précieuses']
 ];
 
+const baronyPropBoolFields = ['water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin'];
+const baronyPropLabels = {
+  water_access:"Accès à l'eau",
+  sea_access:'Accès à la mer',
+  has_or:'Or',
+  has_argent:'Argent',
+  has_fer:'Fer',
+  has_pierre:'Pierre',
+  has_epices:'Épices',
+  has_perle:'Perle',
+  has_encens:'Encens',
+  has_huiles:'Huiles',
+  has_pierre_precieuses:'Pierres Précieuses',
+  has_soie:'Soie',
+  has_sel:'Sel',
+  has_fourrure:'Fourrure',
+  has_teinture:'Teinture',
+  has_ivoire:'Ivoire',
+  has_vin:'Vin',
+  field_limit:'Limite de champs',
+  fishing_limit:'Limite de Pêche',
+  high_sea_boat_limit:'Limite de Bateau en haute mer'
+};
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     const res = await fetch('/api/my_seigneurie');
@@ -99,6 +123,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       });
     }
 
+    const propsDiv = document.getElementById('baronyProps');
+    if (propsDiv) {
+      propsDiv.innerHTML = buildPropsTable(baronyProps);
+    }
+
     function buildTable(list, showMax = false) {
       let html = '<tr><th>Ressource</th><th>Quantité</th><th>Production</th>';
       if (showMax) html += '<th>Maximum</th>';
@@ -116,6 +145,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (showMax) html += '<td></td>';
         html += '</tr>';
       }
+      return html;
+    }
+
+    function buildPropsTable(props) {
+      let html = '<table class="admin-table"><tr><th>Propriété</th><th>Valeur</th></tr>';
+      for (const [key, label] of Object.entries(baronyPropLabels)) {
+        let val = props[key];
+        if (baronyPropBoolFields.includes(key)) {
+          val = val ? 'Oui' : 'Non';
+        } else if (val === undefined || val === null) {
+          val = '';
+        }
+        html += `<tr><td>${label}</td><td>${val}</td></tr>`;
+      }
+      html += '</table>';
       return html;
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- add "Propriétés" tab to the management page showing barony attributes

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68964722834c832d922402dbe12b1f5e