### PR TITLE
Allow dynamic activation of fields

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -68,6 +68,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const modifier = 1;
     const totalProd = fields.active * indivProd * modifier;
     const canBuild = inv.or_ >= costField && fields.built < maxFields;
+    const maxActive = Math.min(fields.built, s.population + employment.slaves);
     infra.innerHTML = `
       <h2>Production</h2>
       <table class="admin-table">
@@ -79,8 +80,14 @@ document.addEventListener('DOMContentLoaded', async () => {
           <td>${maxFields}</td>
           <td>${indivProd}</td>
           <td>${modifier}</td>
-          <td>${fields.active}</td>
-          <td>${totalProd}</td>
+          <td>
+            <div class="qty-control">
+              <button id="decreaseField" class="qty-btn">-</button>
+              <input type="number" id="fieldsActiveInput" min="0" max="${maxActive}" value="${fields.active}" />
+              <button id="increaseField" class="qty-btn">+</button>
+            </div>
+          </td>
+          <td id="fieldTotalProd">${totalProd}</td>
           <td>Aucune</td>
           <td>3 Or</td>
           <td><button id="buildField" ${canBuild ? '' : 'disabled'}>Construire</button></td>
@@ -97,6 +104,42 @@ document.addEventListener('DOMContentLoaded', async () => {
           alert('Construction impossible');
         }
       });
+    }
+
+    const activeInput = document.getElementById('fieldsActiveInput');
+    const incBtn = document.getElementById('increaseField');
+    const decBtn = document.getElementById('decreaseField');
+    function adjust(delta){
+      let v = parseInt(activeInput.value,10) + delta;
+      const max = parseInt(activeInput.max,10);
+      if(v < 0) v = 0;
+      if(v > max) v = max;
+      setActive(v);
+    }
+    if(incBtn) incBtn.addEventListener('click', ()=>adjust(1));
+    if(decBtn) decBtn.addEventListener('click', ()=>adjust(-1));
+    if(activeInput) activeInput.addEventListener('change', ()=>{
+      let v = parseInt(activeInput.value,10) || 0;
+      const max = parseInt(activeInput.max,10);
+      if(v < 0) v = 0;
+      if(v > max) v = max;
+      setActive(v);
+    });
+
+    async function setActive(value){
+      activeInput.value = value;
+      const resp = await fetch('/api/fields/activate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({quantity:value})});
+      if(resp.ok){
+        const data = await resp.json();
+        const prod = value * indivProd * modifier;
+        const prodCell = document.getElementById('fieldTotalProd');
+        if(prodCell) prodCell.textContent = prod;
+        const employedCell = document.querySelector('#populationSummary table tr:nth-child(3) td:nth-child(2)');
+        if(employedCell) employedCell.textContent = data.employment.employed;
+      } else {
+        alert('Mise à jour impossible');
+        location.reload();
+      }
     }
 
     function buildTable(list, showMax = false) {

--- a/styles.css
+++ b/styles.css
@@ -271,6 +271,21 @@ main {
   background-color: #3d6db2;
 }
 
+.qty-control {
+  display: flex;
+  align-items: center;
+}
+.qty-control .qty-btn {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin: 0 2px;
+}
+.qty-control input {
+  width: 50px;
+  text-align: center;
+}
+
 /* Onglets de la page d'administration */
 .tab-buttons {
   display: flex;


### PR DESCRIPTION
## Summary
- Add backend endpoint to update field activation with validation for built capacity and available workforce.
- Enable dynamic adjustment of active fields on management page via numeric input and +/- buttons.
- Style new quantity controls for compact button/input layout.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689648cd0ad8832da8a2619533fae734