### PR TITLE
feat: add building properties admin tab

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,6 +27,7 @@
         <button class="tab-btn" data-tab="counties">Comtés</button>
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
+        <button class="tab-btn" data-tab="buildingprops">Propriétés bâtiments</button>
         <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
       <div class="tab-panels">
@@ -62,6 +63,9 @@
         </div>
         <div id="tab-seigneuries" class="tab-panel">
           <div id="tableSeigneuries"></div>
+        </div>
+        <div id="tab-buildingprops" class="tab-panel">
+          <div id="tableBuildingProps"></div>
         </div>
         <div id="tab-baronyprops" class="tab-panel">
           <div id="tableBaronyProps"></div>

--- a/admin.js
+++ b/admin.js
@@ -49,6 +49,16 @@ const baronyPropLabels = {
   high_sea_boat_limit:'Limite de Bateau en haute mer'
 };
 
+const buildingPropFields = ['type','costs','max','workers_per_building','restrictions','description'];
+const buildingPropLabels = {
+  type:'Type',
+  costs:'Coûts',
+  max:'Maximum',
+  workers_per_building:'Travailleurs/bâtiment',
+  restrictions:'Restrictions',
+  description:'Description'
+};
+
 async function fetchJSON(url, options){
   const resp = await fetch(API_BASE + url, options);
   return resp.json();
@@ -236,7 +246,7 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
@@ -251,6 +261,7 @@ async function loadAll(){
     fetchJSON('/api/seigneuries'),
     fetchJSON('/api/baronies'),
     fetchJSON('/api/barony_properties'),
+    fetchJSON('/api/building_properties'),
   ]);
 
   const seigneursSelect = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -368,6 +379,13 @@ async function loadAll(){
     fields:baronyPropFields,
     selects:{barony_id:baroniesSelect, ...boolSelects},
     labels:baronyPropLabels
+  });
+
+  const buildingPropsById = buildingProps.slice().sort((a,b)=>a.id - b.id);
+  renderTable(document.getElementById('tableBuildingProps'), buildingPropsById, {
+    endpoint:'building_properties',
+    fields:buildingPropFields,
+    labels:buildingPropLabels
   });
 }
 


### PR DESCRIPTION
## Summary
- add `building_properties` table and API endpoints
- allow admin to edit building definitions via new tab
- compute employment based on building worker requirements

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check server.js`
- `node --check admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68965023a38c832db3af7ccc3b9fc1f5