### PR TITLE
Enable list-based cost editing for buildings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -286,6 +286,22 @@ main {
   text-align: center;
 }
 
+.cost-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+.cost-row select {
+  flex: 1;
+}
+.cost-row input {
+  width: 60px;
+}
+.cost-row button {
+  padding: 0 6px;
+}
+
 /* Onglets de la page d'administration */
 .tab-buttons {
   display: flex;


### PR DESCRIPTION
## Summary
- Allow building costs to be edited as dynamic list rows with resource dropdowns and quantities
- Style cost rows for clarity in admin tables

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689656b124c0832d9bb4049dd872cc67