### PR TITLE
feat: expand building properties

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,7 +27,7 @@
         <button class="tab-btn" data-tab="counties">Comtés</button>
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
-        <button class="tab-btn" data-tab="buildingprops">Propriétés bâtiments</button>
+        <button class="tab-btn" data-tab="buildingprops">Infrastructures civiles</button>
         <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
       <div class="tab-panels">

--- a/admin.js
+++ b/admin.js
@@ -49,9 +49,12 @@ const baronyPropLabels = {
   high_sea_boat_limit:'Limite de Bateau en haute mer'
 };
 
-const buildingPropFields = ['type','costs','max','workers_per_building','restrictions','description'];
+const buildingPropFields = ['type','label','produces','production','costs','max','workers_per_building','restrictions','description'];
 const buildingPropLabels = {
   type:'Type',
+  label:'Nom',
+  produces:'Ressource produite',
+  production:'Production',
   costs:'Coûts',
   max:'Maximum',
   workers_per_building:'Travailleurs/bâtiment',

--- a/server.js
+++ b/server.js
@@ -201,6 +201,9 @@ CREATE TABLE IF NOT EXISTS barony_properties (
 CREATE TABLE IF NOT EXISTS building_properties (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   type TEXT UNIQUE,
+  label TEXT,
+  produces TEXT,
+  production INTEGER,
   costs TEXT,
   max INTEGER,
   workers_per_building INTEGER DEFAULT 1,
@@ -672,7 +675,7 @@ app.put('/api/barony_properties/:id', (req,res)=>{
   update('barony_properties', baronyPropFields)(req,res);
 });
 
-const buildingPropFields = ['type','costs','max','workers_per_building','restrictions','description'];
+const buildingPropFields = ['type','label','produces','production','costs','max','workers_per_building','restrictions','description'];
 app.get('/api/building_properties', (req,res)=>{
   if(!req.session.user || !req.session.user.is_admin) return res.status(403).json({ error: 'Forbidden' });
   list('building_properties')(req,res);


### PR DESCRIPTION
## Summary
- allow building properties to store display name, output resource, and production amount
- expose new building property fields through admin interface
- rename admin tab to Infrastructures civiles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68965a84eea0832da8fdc23c0e9d24e5