### PR TITLE
Require admin session for PUT requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,10 @@ Ne les ouvrez pas directement avec `file://`, car les requêtes vers l'API serai
 
 La base de données `asgaria.db` est créée dans le répertoire racine et stocke toutes les informations (baronnies, seigneurs, etc.).
 
+## API
+Toutes les requêtes `PUT` vers l'API nécessitent qu'un utilisateur administrateur soit authentifié via la session.
+- Si aucun utilisateur n'est connecté, le serveur répond avec `401 Unauthorized`.
+- Si l'utilisateur connecté n'est pas administrateur, le serveur répond avec `403 Forbidden`.
+
 ## Tests
 Aucun test automatisé n'est défini. La commande `npm test` renverra donc une erreur.

--- a/server.js
+++ b/server.js
@@ -331,6 +331,19 @@ app.use((req,res,next)=>{
 });
 app.use(express.static(path.join(__dirname)));
 
+// require authentication for all PUT requests
+app.use((req, res, next) => {
+  if (req.method === 'PUT') {
+    if (!req.session.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    if (!req.session.user.is_admin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+  }
+  next();
+});
+
 function list(table) {
   return (req, res) => {
     db.all(`SELECT * FROM ${table}`, [], (err, rows) => {


### PR DESCRIPTION
## Summary
- enforce session and admin check for all PUT routes
- document authentication requirement for PUT API calls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689660aecc68832d9bbc944dcce05646