### PR TITLE
Use environment session secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Ce dépôt contient un éditeur de carte et une interface d'administration pour 
    npm install
    ```
 
+## Configuration
+Définir la variable d'environnement `SESSION_SECRET` avec une valeur aléatoire pour signer les cookies de session.
+Par exemple :
+```bash
+export SESSION_SECRET="votre-valeur-secrète"
+```
+
 ## Lancement du serveur
 Le fichier `server.js` lance un petit serveur Express et crée automatiquement une base SQLite `asgaria.db`.
 

--- a/server.js
+++ b/server.js
@@ -315,9 +315,14 @@ db.exec(initSql, () => {
 // accept large pixel blobs
 app.use(express.json({ limit: '50mb' }));
 app.use(session({
-  secret: 'asgaria-secret',
+  secret: process.env.SESSION_SECRET,
   resave: false,
-  saveUninitialized: false
+  saveUninitialized: false,
+  cookie: {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict'
+  }
 }));
 app.use((req,res,next)=>{
   const adminPages = ['/admin.html','/mapEditor.html'];


### PR DESCRIPTION
## Summary
- Replace static Express session secret with `process.env.SESSION_SECRET`
- Harden session cookies via `httpOnly`, `secure` in production, and `sameSite: 'strict'`
- Document `SESSION_SECRET` environment variable in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896611dfe9c832d8c7022ec86b6728a