### PR TITLE
feat: render building list dynamically

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -38,14 +38,17 @@ const baronyPropLabels = {
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const res = await fetch('/api/my_seigneurie');
+    const [res, bRes] = await Promise.all([
+      fetch('/api/my_seigneurie'),
+      fetch('/api/building_properties')
+    ]);
     if (!res.ok) throw new Error('Erreur');
     const data = await res.json();
+    const buildingProps = bRes.ok ? await bRes.json() : [];
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
     const production = data.production || {};
-    const fields = data.fields || { built:0, active:0 };
     const baronyProps = data.baronyProps || {};
     const employment = data.employment || { employed:0, slaves:0 };
 
@@ -86,86 +89,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     luxuryTable.innerHTML = buildTable(luxuryResources);
 
     const infra = document.getElementById('infrastructure');
-    const maxFields = baronyProps.field_limit || 0;
-    const costField = 3;
-    const indivProd = 75;
-    const modifier = 1;
-    const totalProd = fields.active * indivProd * modifier;
-    const canBuild = inv.or_ >= costField && fields.built < maxFields;
-    const maxActive = Math.min(fields.built, s.population + employment.slaves);
-    infra.innerHTML = `
-      <h2>Production</h2>
-      <table class="admin-table">
-        <tr><th>Nom</th><th>Ressource Produite</th><th>Quantité construite</th><th>Maximum</th><th>Production Individuelle</th><th>Modificateur</th><th>Quantité activée</th><th>Production totale</th><th>Restriction</th><th>Prix de construction</th><th></th></tr>
-        <tr>
-          <td>Champs</td>
-          <td>Vivres</td>
-          <td>${fields.built}</td>
-          <td>${maxFields}</td>
-          <td>${indivProd}</td>
-          <td>${modifier}</td>
-          <td>
-            <div class="qty-control">
-              <button id="decreaseField" class="qty-btn">-</button>
-              <input type="number" id="fieldsActiveInput" min="0" max="${maxActive}" value="${fields.active}" />
-              <button id="increaseField" class="qty-btn">+</button>
-            </div>
-          </td>
-          <td id="fieldTotalProd">${totalProd}</td>
-          <td>Aucune</td>
-          <td>3 Or</td>
-          <td><button id="buildField" ${canBuild ? '' : 'disabled'}>Construire</button></td>
-        </tr>
-      </table>
-    `;
-    const buildBtn = document.getElementById('buildField');
-    if (buildBtn) {
-      buildBtn.addEventListener('click', async ()=>{
-        const resp = await fetch('/api/building',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({type:'field',quantity:1})});
-        if(resp.ok){
-          location.reload();
-        } else {
-          alert('Construction impossible');
+    if (infra) {
+      let html = '<h2>Production</h2><table class="admin-table" id="buildingsTable"><tr><th>Nom</th><th>Production</th><th></th></tr>';
+      for (const bp of buildingProps) {
+        const prod = bp.production ? `${bp.production} ${bp.produces || ''}` : '';
+        html += `<tr><td>${bp.label || bp.type}</td><td>${prod}</td><td><button data-type="${bp.type}">Construire</button></td></tr>`;
+      }
+      html += '</table>';
+      infra.innerHTML = html;
+      const table = document.getElementById('buildingsTable');
+      table.addEventListener('click', async e => {
+        if (e.target.tagName === 'BUTTON') {
+          const type = e.target.dataset.type;
+          const resp = await fetch('/api/building', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type, quantity: 1 })
+          });
+          if (resp.ok) {
+            location.reload();
+          } else {
+            alert('Construction impossible');
+          }
         }
       });
-    }
-    const activeInput = document.getElementById('fieldsActiveInput');
-    const incBtn = document.getElementById('increaseField');
-    const decBtn = document.getElementById('decreaseField');
-    function adjust(delta){
-      let v = parseInt(activeInput.value,10) + delta;
-      const max = parseInt(activeInput.max,10);
-      if(v < 0) v = 0;
-      if(v > max) v = max;
-      setActive(v);
-    }
-    if(incBtn) incBtn.addEventListener('click', ()=>adjust(1));
-    if(decBtn) decBtn.addEventListener('click', ()=>adjust(-1));
-    if(activeInput) activeInput.addEventListener('change', ()=>{
-      let v = parseInt(activeInput.value,10) || 0;
-      const max = parseInt(activeInput.max,10);
-      if(v < 0) v = 0;
-      if(v > max) v = max;
-      setActive(v);
-    });
-
-    async function setActive(value){
-      activeInput.value = value;
-      const resp = await fetch('/api/fields/activate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({quantity:value})});
-      if(resp.ok){
-        const data = await resp.json();
-        const prod = value * indivProd * modifier;
-        const prodCell = document.getElementById('fieldTotalProd');
-        if(prodCell) prodCell.textContent = prod;
-        const employedCell = document.querySelector('#populationSummary table tr:nth-child(3) td:nth-child(2)');
-        if(employedCell) employedCell.textContent = data.employment.employed;
-        // Met à jour la production dans le tableau récapitulatif des ressources
-        production.vivres = prod;
-        if(basicTable) basicTable.innerHTML = buildTable(basicResources, true);
-      } else {
-        alert('Mise à jour impossible');
-        location.reload();
-      }
     }
 
     const propsDiv = document.getElementById('baronyProps');


### PR DESCRIPTION
## Summary
- fetch building properties and use them to render building rows in infrastructure tab
- remove field-specific construction logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689663075f90832dad800c36d456b35e