### PR TITLE
feat: centralize error handling with Winston logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 asgaria.db
 /tmp/
+
+server.log

--- a/logger.js
+++ b/logger.js
@@ -4,6 +4,7 @@ const logger = createLogger({
   level: 'info',
   format: format.combine(
     format.timestamp(),
+    format.errors({ stack: true }),
     format.json()
   ),
   transports: [

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,25 @@
+const { createLogger, format, transports } = require('winston');
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.json()
+  ),
+  transports: [
+    new transports.File({ filename: 'server.log' })
+  ]
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  logger.add(new transports.Console({
+    format: format.simple()
+  }));
+}
+
+function handleError(res, err) {
+  logger.error(err);
+  return res.status(500).json({ error: "Une erreur s'est produite" });
+}
+
+module.exports = { logger, handleError };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,28 @@
         "bcryptjs": "^2.4.3",
         "express": "^4.19.2",
         "express-session": "^1.17.3",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "winston": "^3.17.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -56,6 +77,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -178,6 +205,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -379,6 +412,41 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -387,6 +455,16 @@
       "optional": true,
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/concat-map": {
@@ -533,6 +611,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -726,6 +810,12 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -749,6 +839,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -1156,6 +1252,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1173,6 +1275,18 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1186,6 +1300,35 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1583,6 +1726,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -1818,6 +1970,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2027,6 +2188,15 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -2135,6 +2305,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/statuses": {
@@ -2252,6 +2431,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2259,6 +2444,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/tunnel-agent": {
@@ -2375,6 +2569,42 @@
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bcryptjs": "^2.4.3",
     "express": "^4.19.2",
     "express-session": "^1.17.3",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "winston": "^3.17.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const path = require('path');
 const session = require('express-session');
 const bcrypt = require('bcryptjs');
 const { inventaireFields, performTransaction } = require('./transactions');
-const { handleError } = require("./logger");
+const { logger, handleError } = require('./logger');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -857,4 +857,4 @@ app.put('/api/barony_pixels', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
+app.listen(PORT, () => logger.info(`Server running on http://localhost:${PORT}`));

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const session = require('express-session');
 const bcrypt = require('bcryptjs');
 const { inventaireFields, performTransaction } = require('./transactions');
+const { handleError } = require("./logger");
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -334,7 +335,7 @@ app.use(express.static(path.join(__dirname)));
 function list(table) {
   return (req, res) => {
     db.all(`SELECT * FROM ${table}`, [], (err, rows) => {
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       res.json(rows);
     });
   };
@@ -349,7 +350,7 @@ function create(table, fields) {
     const values = fields.map(f => sanitize(req.body[f]));
     const placeholders = fields.map(() => '?').join(',');
     db.run(`INSERT INTO ${table} (${fields.join(',')}) VALUES (${placeholders})`, values, function(err){
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       res.json({id: this.lastID});
     });
   };
@@ -362,7 +363,7 @@ function update(table, fields) {
     const values = fields.map(f => sanitize(req.body[f]));
     values.push(id);
     db.run(`UPDATE ${table} SET ${set} WHERE id=?`, values, function(err){
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       res.json({changes: this.changes});
     });
   };
@@ -379,7 +380,7 @@ app.post('/api/register', (req, res) => {
     'INSERT INTO users(email,password,first_name,last_name) VALUES (?,?,?,?)',
     [email, hash, first_name, last_name],
     function (err) {
-      if (err) return res.status(500).json({ error: err.message });
+      if (err) return handleError(res, err);
       req.session.user = {
         id: this.lastID,
         email,
@@ -422,7 +423,7 @@ app.get('/api/me', (req, res) => {
 
 app.get('/api/users', (req, res) => {
   db.all('SELECT id, email, first_name, last_name FROM users', [], (err, rows) => {
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) return handleError(res, err);
     res.json(rows);
   });
 });
@@ -447,7 +448,7 @@ app.post('/api/profile', (req, res) => {
     if (fields.length === 0) return res.json({ ok: true });
     values.push(req.session.user.id);
     db.run(`UPDATE users SET ${fields.join(',')} WHERE id=?`, values, function (err) {
-      if (err) return res.status(500).json({ error: err.message });
+      if (err) return handleError(res, err);
       res.json({ ok: true });
     });
   };
@@ -455,7 +456,7 @@ app.post('/api/profile', (req, res) => {
   if (password) {
     if (!current_password) return res.status(400).json({ error: 'Missing current password' });
     db.get('SELECT password FROM users WHERE id=?', [req.session.user.id], (err, row) => {
-      if (err) return res.status(500).json({ error: err.message });
+      if (err) return handleError(res, err);
       if (!row || !bcrypt.compareSync(current_password, row.password)) {
         return res.status(400).json({ error: 'Incorrect current password' });
       }
@@ -516,7 +517,7 @@ app.get('/api/seigneuries', (req, res) => {
   if (!req.session.user || !req.session.user.is_admin) return res.status(403).json({ error: 'Forbidden' });
   const invSelect = inventaireFields.map(f => `i.${f}`).join(',');
   db.all(`SELECT s.id, s.baronnie_id, s.seigneur_id, s.population, s.inventaire_id, ${invSelect} FROM seigneuries s JOIN inventaire i ON s.inventaire_id=i.id`, [], (err, rows) => {
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) return handleError(res, err);
     res.json(rows);
   });
 });
@@ -528,11 +529,11 @@ app.post('/api/seigneuries', (req, res) => {
   const invValues = inventaireFields.map(f => sanitize(req.body[f]) || 0);
   const invPlace = inventaireFields.map(() => '?').join(',');
   db.run(`INSERT INTO inventaire (${inventaireFields.join(',')}) VALUES (${invPlace})`, invValues, function(err){
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) return handleError(res, err);
     const invId = this.lastID;
     db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id) VALUES (?,?,?,?)',
       [...seigValues, invId], function(err2){
-        if (err2) return res.status(500).json({ error: err2.message });
+        if (err2) return handleError(res, err2);
         res.json({ id: this.lastID, inventaire_id: invId });
       });
   });
@@ -546,13 +547,13 @@ app.put('/api/seigneuries/:id', (req, res) => {
   const seigValues = seigFields.map(f => sanitize(req.body[f]));
   seigValues.push(id);
   db.run(`UPDATE seigneuries SET ${seigSet} WHERE id=?`, seigValues, function(err){
-    if (err) return res.status(500).json({ error: err.message });
+    if (err) return handleError(res, err);
     const invId = req.body.inventaire_id;
     const invSet = inventaireFields.map(f => `${f}=?`).join(',');
     const invValues = inventaireFields.map(f => sanitize(req.body[f]) || 0);
     invValues.push(invId);
     db.run(`UPDATE inventaire SET ${invSet} WHERE id=?`, invValues, function(err2){
-      if (err2) return res.status(500).json({ error: err2.message });
+      if (err2) return handleError(res, err2);
       res.json({ changes: this.changes });
     });
   });
@@ -563,38 +564,38 @@ app.get('/api/my_seigneurie', (req, res) => {
   const userId = req.session.user.id;
   db.serialize(() => {
     db.get('SELECT * FROM seigneurs WHERE user_id=?', [userId], (err, seigneur) => {
-      if (err) return res.status(500).json({ error: err.message });
+      if (err) return handleError(res, err);
       function ensureSeigneur(cb) {
         if (seigneur) return cb(seigneur);
         const name = `Seigneur ${req.session.user.first_name}`;
         db.run('INSERT INTO seigneurs(name,user_id) VALUES (?,?)', [name, userId], function(err){
-          if (err) return res.status(500).json({ error: err.message });
+          if (err) return handleError(res, err);
           cb({ id: this.lastID, name, user_id: userId });
         });
       }
       ensureSeigneur(seig => {
         db.get('SELECT * FROM seigneuries WHERE seigneur_id=?', [seig.id], (err, seigneurie) => {
-          if (err) return res.status(500).json({ error: err.message });
+          if (err) return handleError(res, err);
           function ensureSeigneurie(cb) {
             if (seigneurie) return cb(seigneurie);
             db.run('INSERT INTO inventaire DEFAULT VALUES', function(err){
-              if (err) return res.status(500).json({ error: err.message });
+              if (err) return handleError(res, err);
               const invId = this.lastID;
               db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id) VALUES (NULL,?,?,?)',
                 [seig.id, 0, invId], function(err){
-                  if (err) return res.status(500).json({ error: err.message });
+                  if (err) return handleError(res, err);
                   cb({ id: this.lastID, baronnie_id: null, seigneur_id: seig.id, population: 0, inventaire_id: invId });
                 });
             });
           }
           ensureSeigneurie(s => {
             db.get('SELECT * FROM inventaire WHERE id=?', [s.inventaire_id], (err, inventaire) => {
-              if (err) return res.status(500).json({ error: err.message });
+              if (err) return handleError(res, err);
               db.get('SELECT * FROM fields WHERE seigneurie_id=?', [s.id], (err, fieldRow) => {
-                if (err) return res.status(500).json({ error: err.message });
+                if (err) return handleError(res, err);
                 const fields = fieldRow || { built: 0, active: 0 };
                 db.get('SELECT workers_per_building FROM building_properties WHERE type=?', ['field'], (err2, bprop) => {
-                  if (err2) return res.status(500).json({ error: err2.message });
+                  if (err2) return handleError(res, err2);
                   const baseWorkers = bprop ? (bprop.workers_per_building || 0) : 1;
                   const slaves = inventaire.esclaves || 0;
                   const employed = fields.active * baseWorkers;
@@ -607,9 +608,9 @@ app.get('/api/my_seigneurie', (req, res) => {
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
-                      if (err3) return res.status(500).json({ error: err3.message });
+                      if (err3) return handleError(res, err3);
                       db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
-                        if (err4) return res.status(500).json({ error: err4.message });
+                        if (err4) return handleError(res, err4);
                         finalize(barony, props || {});
                       });
                     });
@@ -639,7 +640,7 @@ app.get('/api/baronies', (req, res) => {
   const id = req.query.id;
   if (id) {
     db.all('SELECT * FROM baronies WHERE id=?', [id], (err, rows) => {
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       res.json(rows);
     });
   } else {
@@ -656,7 +657,7 @@ app.put('/api/baronies/:id', update('baronies',[
 ]));
 app.delete('/api/baronies/:id', (req,res)=>{
   db.run('DELETE FROM baronies WHERE id=?',[req.params.id], function(err){
-    if(err) return res.status(500).json({error: err.message});
+    if(err) return handleError(res, err);
     res.json({deleted: this.changes});
   });
 });
@@ -733,7 +734,7 @@ app.post('/api/building', (req,res)=>{
   if(qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
   const userId = req.session.user.id;
   db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.inventaire_id FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
-    if(err) return res.status(500).json({ error: err.message });
+    if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     canConstruct(db, srow, type, qty, (err2, info)=>{
       if(err2) return res.status(400).json({ error: err2.message });
@@ -744,7 +745,7 @@ app.post('/api/building', (req,res)=>{
         const [resName, amount] = entries[idx++];
         if(amount === 0) return deduct();
         performTransaction(db, srow.id, resName, -amount, err3 => {
-          if(err3) return res.status(500).json({ error: err3.message });
+          if(err3) return handleError(res, err3);
           deduct();
         });
       }
@@ -754,9 +755,9 @@ app.post('/api/building', (req,res)=>{
         const sql = info.hasRow ? 'UPDATE fields SET built=?, active=? WHERE seigneurie_id=?' : 'INSERT INTO fields (built, active, seigneurie_id) VALUES (?,?,?)';
         const params = info.hasRow ? [newBuilt, newActive, srow.id] : [newBuilt, newActive, srow.id];
         db.run(sql, params, function(err4){
-          if(err4) return res.status(500).json({ error: err4.message });
+          if(err4) return handleError(res, err4);
           db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inventaire)=>{
-            if(err5) return res.status(500).json({ error: err5.message });
+            if(err5) return handleError(res, err5);
             res.json({ fields: { built: newBuilt, active: newActive }, inventaire });
           });
         });
@@ -772,27 +773,27 @@ app.post('/api/fields/activate', (req,res)=>{
   if(isNaN(qty) || qty < 0) return res.status(400).json({ error: 'Quantité invalide' });
   const userId = req.session.user.id;
   db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
-    if(err) return res.status(500).json({ error: err.message });
+    if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     db.get('SELECT built, active FROM fields WHERE seigneurie_id=?', [srow.id], (err2, frow)=>{
-      if(err2) return res.status(500).json({ error: err2.message });
+      if(err2) return handleError(res, err2);
       const built = frow ? frow.built : 0;
       if(qty > built) return res.status(400).json({ error: 'Quantité supérieure au construit' });
       db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
-        if(err3) return res.status(500).json({ error: err3.message });
+        if(err3) return handleError(res, err3);
         const slaves = inv ? (inv.esclaves || 0) : 0;
         const totalPop = srow.population + slaves;
         if(qty > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
         const done = ()=> res.json({ fields: { built, active: qty }, employment: { employed: qty, slaves } });
         if(frow){
           db.run('UPDATE fields SET active=? WHERE seigneurie_id=?', [qty, srow.id], function(err4){
-            if(err4) return res.status(500).json({ error: err4.message });
+            if(err4) return handleError(res, err4);
             done();
           });
         } else {
           if(qty > 0) return res.status(400).json({ error: 'Aucun champ construit' });
           db.run('INSERT INTO fields (seigneurie_id,built,active) VALUES (?,?,?)',[srow.id,0,0], function(err4){
-            if(err4) return res.status(500).json({ error: err4.message });
+            if(err4) return handleError(res, err4);
             done();
           });
         }
@@ -806,7 +807,7 @@ app.post('/api/canonical_lands', create('canonical_lands',['religion_id','barony
 app.delete('/api/canonical_lands', (req, res) => {
   const { religion_id, barony_id } = req.query;
   db.run('DELETE FROM canonical_lands WHERE religion_id=? AND barony_id=?', [religion_id, barony_id], function(err){
-    if(err) return res.status(500).json({error: err.message});
+    if(err) return handleError(res, err);
     res.json({deleted: this.changes});
   });
 });
@@ -816,18 +817,18 @@ app.get('/api/barony_pixels', (req, res) => {
   const id = req.query.id;
   if (id) {
     db.get('SELECT data FROM barony_pixels WHERE barony_id=?', [id], (err, row) => {
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       if (!row) return res.json([]);
       try {
         const json = zlib.gunzipSync(row.data).toString();
         res.json(JSON.parse(json));
       } catch(e){
-        res.status(500).json({error: e.message});
+        handleError(res, e);
       }
     });
   } else {
     db.all('SELECT barony_id, data FROM barony_pixels', [], (err, rows) => {
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       const out = {};
       rows.forEach(r => {
         try {
@@ -849,7 +850,7 @@ app.put('/api/barony_pixels', (req, res) => {
       stmt.run(id, buf);
     }
     stmt.finalize(err => {
-      if (err) return res.status(500).json({error: err.message});
+      if (err) return handleError(res, err);
       res.json({ok: true});
     });
   });


### PR DESCRIPTION
## Summary
- add reusable `handleError` helper backed by Winston logger
- replace direct 500 responses with centralized error handler
- install and configure `winston` for server logging

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68966129cf54832d924b33c35e38628d