### PR TITLE
Add fallback session secret to avoid express-session deprecation warning

### DIFF
--- a/server.js
+++ b/server.js
@@ -324,8 +324,12 @@ db.exec(initSql, () => {
 
 // accept large pixel blobs
 app.use(express.json({ limit: '50mb' }));
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  logger.warn('SESSION_SECRET environment variable not set; using fallback secret');
+}
 app.use(session({
-  secret: process.env.SESSION_SECRET,
+  secret: sessionSecret || 'dev-secret',
   resave: false,
   saveUninitialized: false,
   cookie: {


### PR DESCRIPTION
## Summary
- avoid express-session `req.secret` deprecation by supplying fallback secret
- warn when SESSION_SECRET environment variable is missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e35cbafc0832d883c667fa46c74bb