### PR TITLE
Fix building property editing and add selection dropdowns

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -60,6 +60,11 @@ const buildingPropLabels = {
   restrictions:'Restrictions',
   description:'Description'
 };
+const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
+const maxOptions = [
+  ...Array.from({length:10}, (_,i)=>({ id:String(i+1), name:String(i+1) })),
+  ...baronyPropFields.filter(f=>f!=='barony_id').map(f=>({ id:f, name:baronyPropLabels[f] || f }))
+];
 
 async function fetchJSON(url, options){
   const resp = await fetch(API_BASE + url, options);
@@ -253,7 +258,7 @@ function renderTable(container, rows, opts){
           if(el.getValue){
             payload[f] = el.getValue();
           } else if(opts.selects && opts.selects[f]){
-            payload[f] = el.value ? parseInt(el.value,10) : null;
+            payload[f] = el.value ? (isNaN(el.value) ? el.value : parseInt(el.value,10)) : null;
           } else {
             payload[f] = el.value.trim();
           }
@@ -288,7 +293,7 @@ function renderTable(container, rows, opts){
         if(el.getValue){
           payload[f] = el.getValue();
         } else if(opts.selects && opts.selects[f]){
-          payload[f] = el.value ? parseInt(el.value,10) : null;
+          payload[f] = el.value ? (isNaN(el.value) ? el.value : parseInt(el.value,10)) : null;
         } else {
           payload[f] = el.value.trim();
         }
@@ -449,7 +454,8 @@ async function loadAll(){
   renderTable(document.getElementById('tableBuildingProps'), buildingPropsById, {
     endpoint:'building_properties',
     fields:buildingPropFields,
-    labels:buildingPropLabels
+    labels:buildingPropLabels,
+    selects:{produces: resourceSelect, max: maxOptions}
   });
 }
 

--- a/server.js
+++ b/server.js
@@ -216,7 +216,7 @@ CREATE TABLE IF NOT EXISTS building_properties (
   produces TEXT,
   production INTEGER,
   costs TEXT,
-  max INTEGER,
+  max TEXT,
   workers_per_building INTEGER DEFAULT 1,
   restrictions TEXT,
   description TEXT
@@ -302,6 +302,11 @@ db.exec(initSql, () => {
       if (!rows.some(r => r.name === 'seigneur_id')) {
         db.run('ALTER TABLE kingdoms ADD COLUMN seigneur_id INTEGER REFERENCES seigneurs(id)');
       }
+    }
+  });
+  db.all("PRAGMA table_info(building_properties)", (err, rows) => {
+    if (!err && rows && !rows.some(r => r.name === 'label')) {
+      db.run('ALTER TABLE building_properties ADD COLUMN label TEXT');
     }
   });
   // Ensure every barony has a properties row with default values


### PR DESCRIPTION
## Summary
- Allow building properties updates by migrating legacy tables lacking `label`
- Support non-numeric maximums by treating `max` as text
- Add dropdowns for produced resource and maximum value in admin UI

## Testing
- `node --check server.js`
- `node --check admin.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e595971e0832d9bed030dcfc8f1a7