### PR TITLE
Split building restrictions and show infrastructure limits

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -49,7 +49,7 @@ const baronyPropLabels = {
   high_sea_boat_limit:'Limite de Bateau en haute mer'
 };
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','restrictions','description'];
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','description'];
 const buildingPropLabels = {
   label:'Nom',
   produces:'Ressource produite',
@@ -57,7 +57,8 @@ const buildingPropLabels = {
   costs:'Coûts',
   max:'Maximum',
   workers_per_building:'Travailleurs/bâtiment',
-  restrictions:'Restrictions',
+  absolute_restrictions:'Restrictions absolues',
+  infra_restrictions:'Restrictions infrastructure',
   description:'Description'
 };
 const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
@@ -204,7 +205,57 @@ function renderTable(container, rows, opts){
       };
       return container;
     }
-    if(field === 'restrictions'){
+    if(field === 'absolute_restrictions'){
+      const container = document.createElement('div');
+      const list = document.createElement('div');
+      container.appendChild(list);
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.textContent = '+';
+      container.appendChild(addBtn);
+      function addRow(prop = ''){
+        const row = document.createElement('div');
+        row.className = 'restriction-row';
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        baronyPropBoolFields.forEach(f=>{
+          const op = document.createElement('option');
+          op.value = f;
+          op.textContent = baronyPropLabels[f] || f;
+          if(f === prop) op.selected = true;
+          sel.appendChild(op);
+        });
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.textContent = '-';
+        removeBtn.addEventListener('click', ()=> row.remove());
+        row.appendChild(sel);
+        row.appendChild(removeBtn);
+        list.appendChild(row);
+      }
+      addBtn.addEventListener('click', ()=> addRow());
+      try{
+        const arr = JSON.parse(val || '[]');
+        if(Array.isArray(arr) && arr.length){
+          arr.forEach(p=> addRow(p));
+        } else {
+          addRow();
+        }
+      } catch(e){
+        addRow();
+      }
+      container.getValue = ()=>{
+        const res = [];
+        list.querySelectorAll('select').forEach(sel=>{
+          if(sel.value) res.push(sel.value);
+        });
+        return JSON.stringify(res);
+      };
+      return container;
+    }
+    if(field === 'infra_restrictions'){
       const container = document.createElement('div');
       const list = document.createElement('div');
       container.appendChild(list);
@@ -216,11 +267,10 @@ function renderTable(container, rows, opts){
         const row = document.createElement('div');
         row.className = 'restriction-row';
         const typeSel = document.createElement('select');
-        const typeBlank = document.createElement('option');
-        typeBlank.value = '';
-        typeSel.appendChild(typeBlank);
+        const blank = document.createElement('option');
+        blank.value = '';
+        typeSel.appendChild(blank);
         const typeOptions = [
-          {id:'prop', name:'Propriété'},
           {id:'building', name:'Bâtiment'},
           {id:'population', name:'Population'}
         ];
@@ -244,29 +294,7 @@ function renderTable(container, rows, opts){
         function updateFields(){
           keySpan.innerHTML = '';
           valSpan.innerHTML = '';
-          if(typeSel.value === 'prop'){
-            const sel = document.createElement('select');
-            const blank = document.createElement('option');
-            blank.value = '';
-            sel.appendChild(blank);
-            baronyPropBoolFields.forEach(f=>{
-              const op = document.createElement('option');
-              op.value = f;
-              op.textContent = baronyPropLabels[f] || f;
-              if(f === data.prop) op.selected = true;
-              sel.appendChild(op);
-            });
-            keySpan.appendChild(sel);
-            const yn = document.createElement('select');
-            yesNoSelect.forEach(o=>{
-              const op = document.createElement('option');
-              op.value = o.id;
-              op.textContent = o.name;
-              if(String(o.id) === String(data.value ? 1 : 0)) op.selected = true;
-              yn.appendChild(op);
-            });
-            valSpan.appendChild(yn);
-          } else if(typeSel.value === 'building'){
+          if(typeSel.value === 'building'){
             const sel = document.createElement('select');
             const blank = document.createElement('option');
             blank.value = '';
@@ -297,19 +325,15 @@ function renderTable(container, rows, opts){
         list.appendChild(row);
       }
       addBtn.addEventListener('click', ()=> addRow());
-      try {
+      try{
         const obj = JSON.parse(val || '{}');
-        const req = obj.requires || {};
-        if(req.props){
-          Object.entries(req.props).forEach(([p,v])=> addRow('prop',{prop:p,value:v}));
+        if(obj.buildings){
+          Object.entries(obj.buildings).forEach(([b,v])=> addRow('building',{building:b,value:v}));
         }
-        if(req.buildings){
-          Object.entries(req.buildings).forEach(([b,v])=> addRow('building',{building:b,value:v}));
+        if(obj.population){
+          addRow('population',{value:obj.population});
         }
-        if(req.population){
-          addRow('population',{value:req.population});
-        }
-        if(!req.props && !req.buildings && !req.population){
+        if(!obj.buildings && !obj.population){
           addRow();
         }
       } catch(e){
@@ -317,17 +341,11 @@ function renderTable(container, rows, opts){
       }
       container.getValue = ()=>{
         const res = {};
-        const props = {};
         const buildings = {};
         let population;
         list.querySelectorAll('.restriction-row').forEach(rw=>{
           const type = rw.querySelector('select').value;
-          if(type === 'prop'){
-            const [propSel, valSel] = rw.querySelectorAll('span select');
-            const prop = propSel.value;
-            const val = valSel.value;
-            if(prop) props[prop] = val === '1';
-          } else if(type === 'building'){
+          if(type === 'building'){
             const sel = rw.querySelector('span select');
             const inp = rw.querySelector('span input');
             const b = sel.value;
@@ -339,11 +357,8 @@ function renderTable(container, rows, opts){
             if(q) population = q;
           }
         });
-        const requires = {};
-        if(Object.keys(props).length) requires.props = props;
-        if(Object.keys(buildings).length) requires.buildings = buildings;
-        if(population != null) requires.population = population;
-        if(Object.keys(requires).length) res.requires = requires;
+        if(Object.keys(buildings).length) res.buildings = buildings;
+        if(population != null) res.population = population;
         return JSON.stringify(res);
       };
       return container;

--- a/gestion.html
+++ b/gestion.html
@@ -18,6 +18,7 @@
         <button class="tab-btn active" data-tab="ressources">Ressources</button>
         <button class="tab-btn" data-tab="infra">Infrastructure Civile</button>
         <button class="tab-btn" data-tab="proprietes">Propriétés</button>
+        <button class="tab-btn" data-tab="restrictions">Restrictions</button>
       </div>
       <div class="tab-panels">
         <div id="tab-ressources" class="tab-panel active">
@@ -28,6 +29,9 @@
         </div>
         <div id="tab-proprietes" class="tab-panel">
           <div id="baronyProps"></div>
+        </div>
+        <div id="tab-restrictions" class="tab-panel">
+          <div id="restrictions"></div>
         </div>
       </div>
     </div>

--- a/gestion.js
+++ b/gestion.js
@@ -52,7 +52,7 @@ async function loadAndRender() {
     ]);
     if (!res.ok) throw new Error('Erreur');
     const data = await res.json();
-    const buildingProps = bRes.ok ? await bRes.json() : [];
+    const allBuildingProps = bRes.ok ? await bRes.json() : [];
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
@@ -61,6 +61,15 @@ async function loadAndRender() {
     const baronyProps = data.baronyProps || {};
     const employment = data.employment || { employed:0, slaves:0 };
     const buildings = data.buildings || {};
+    const buildingProps = allBuildingProps.filter(bp => {
+      try {
+        const arr = bp.absolute_restrictions ? JSON.parse(bp.absolute_restrictions) : [];
+        return arr.every(p => baronyProps[p]);
+      } catch {
+        return true;
+      }
+    });
+    const bpMap = Object.fromEntries(allBuildingProps.map(b => [String(b.id), b]));
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -103,15 +112,17 @@ async function loadAndRender() {
       let html = '<h2>Infrastructure</h2><table class="admin-table" id="buildingsTable">';
       html += '<tr><th>Nom</th><th>Production</th><th>Coût</th><th>Construits</th><th>Max</th><th>Actifs</th><th>Activer</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
-        const prod = bp.production ? `${bp.production} ${bp.produces || ''}` : '';
+        const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
+        const prod = bp.production ? `${bp.production} ${prodLabel}` : '';
         const info = buildings[bp.id] || { built: 0, active: 0 };
         const built = info.built || 0;
         const active = info.active || 0;
 
         let maxVal = '';
         if (bp.max !== undefined && bp.max !== null) {
-          if (typeof bp.max === 'number') {
-            maxVal = bp.max;
+          const parsed = parseInt(bp.max, 10);
+          if (!isNaN(parsed)) {
+            maxVal = parsed;
           } else if (baronyProps[bp.max] !== undefined) {
             maxVal = baronyProps[bp.max];
           }
@@ -150,6 +161,31 @@ async function loadAndRender() {
     const propsDiv = document.getElementById('baronyProps');
     if (propsDiv) {
       propsDiv.innerHTML = buildPropsTable(baronyProps);
+    }
+    const restrDiv = document.getElementById('restrictions');
+    if (restrDiv) {
+      let html = '<h2>Restrictions</h2><table class="admin-table"><tr><th>Bâtiment</th><th>Restrictions</th></tr>';
+      for (const bp of buildingProps) {
+        try {
+          const infra = bp.infra_restrictions ? JSON.parse(bp.infra_restrictions) : {};
+          const parts = [];
+          if (infra.buildings) {
+            for (const [bid, qty] of Object.entries(infra.buildings)) {
+              const ref = bpMap[String(bid)];
+              const name = ref ? (ref.label || ref.type) : bid;
+              parts.push(`${name}: ${qty}`);
+            }
+          }
+          if (infra.population) {
+            parts.push(`Population: ${infra.population}`);
+          }
+          if (parts.length) {
+            html += `<tr><td>${bp.label || bp.type}</td><td>${parts.join('<br>')}</td></tr>`;
+          }
+        } catch(e){ /* ignore */ }
+      }
+      html += '</table>';
+      restrDiv.innerHTML = html;
     }
   } catch (e) {
     document.getElementById('summary').textContent = 'Erreur de chargement';

--- a/server.js
+++ b/server.js
@@ -218,7 +218,8 @@ CREATE TABLE IF NOT EXISTS building_properties (
   costs TEXT,
   max TEXT,
   workers_per_building INTEGER DEFAULT 1,
-  restrictions TEXT,
+  absolute_restrictions TEXT,
+  infra_restrictions TEXT,
   description TEXT
 );
 `;
@@ -311,6 +312,12 @@ db.exec(initSql, () => {
     }
     if (!rows.some(r => r.name === 'produces')) {
       db.run('ALTER TABLE building_properties ADD COLUMN produces TEXT');
+    }
+    if (!rows.some(r => r.name === 'absolute_restrictions')) {
+      db.run('ALTER TABLE building_properties ADD COLUMN absolute_restrictions TEXT');
+    }
+    if (!rows.some(r => r.name === 'infra_restrictions')) {
+      db.run('ALTER TABLE building_properties ADD COLUMN infra_restrictions TEXT');
     }
   });
   // Ensure every barony has a properties row with default values
@@ -765,7 +772,7 @@ app.put('/api/barony_properties/:id', requireAdmin, (req,res)=>{
   update('barony_properties', baronyPropFields)(req,res);
 });
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','restrictions','description'];
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','description'];
 app.get('/api/building_properties', (req,res)=>{
   list('building_properties')(req,res);
 });
@@ -789,9 +796,9 @@ function canConstruct(db, srow, id, qty, cb){
     if (err) return cb(err);
     if (!bprops) return cb(new Error('Type inconnu'));
     if (!srow.baronnie_id) return cb(new Error('Aucune baronnie associée'));
-    const absMax = bprops.max != null ? bprops.max : Infinity;
     const costObj = safeParse(bprops.costs, {});
-    const restrictions = safeParse(bprops.restrictions, {});
+    const absReq = safeParse(bprops.absolute_restrictions, []);
+    const infraReq = safeParse(bprops.infra_restrictions, {});
     const costs = {};
     Object.entries(costObj).forEach(([res, val]) => {
       costs[res] = (parseInt(val, 10) || 0) * qty;
@@ -799,29 +806,28 @@ function canConstruct(db, srow, id, qty, cb){
     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err2, props) => {
       if (err2) return cb(err2);
       const barProps = props || {};
-      let max = absMax;
-      if (restrictions.limit_prop && barProps[restrictions.limit_prop] != null) {
-        max = Math.min(max, barProps[restrictions.limit_prop]);
+      let max = Infinity;
+      if (bprops.max != null) {
+        const parsed = parseInt(bprops.max, 10);
+        if (!isNaN(parsed)) {
+          max = parsed;
+        } else if (barProps[bprops.max] != null) {
+          max = barProps[bprops.max];
+        }
       }
-      const requires = restrictions.requires || {};
-      if (requires.props) {
-        for (const [prop, val] of Object.entries(requires.props)) {
-          const propVal = barProps[prop] || 0;
-          if (typeof val === 'boolean') {
-            if (!!propVal !== val) return cb(new Error('Restriction non satisfaite'));
-          } else {
-            if (propVal < val) return cb(new Error('Restriction non satisfaite'));
-          }
+      if (Array.isArray(absReq)) {
+        for (const prop of absReq) {
+          if (!barProps[prop]) return cb(new Error('Restriction non satisfaite'));
         }
       }
       const buildings = safeParse(srow.buildings, {});
-      if (requires.buildings) {
-        for (const [bid, count] of Object.entries(requires.buildings)) {
+      if (infraReq.buildings) {
+        for (const [bid, count] of Object.entries(infraReq.buildings)) {
           const builtCount = buildings[bid] ? (buildings[bid].built || 0) : 0;
           if (builtCount < count) return cb(new Error('Restriction non satisfaite'));
         }
       }
-      if (requires.population && (srow.population || 0) < requires.population) {
+      if (infraReq.population && (srow.population || 0) < infraReq.population) {
         return cb(new Error('Restriction non satisfaite'));
       }
       const binfo = buildings[id] || { built: 0, active: 0 };


### PR DESCRIPTION
## Summary
- Split building restrictions into `absolute_restrictions` and `infra_restrictions` and enforce them server-side
- Update admin UI for new restriction fields and remove optional yes/no for property restrictions
- Filter buildings by absolute restrictions, display numeric maxima and proper resource labels, and add infrastructure restriction tab in management

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e66710320832dbfee0ee4d41a4714