### PR TITLE
Show building restrictions in infrastructure table

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -18,7 +18,6 @@
         <button class="tab-btn active" data-tab="ressources">Ressources</button>
         <button class="tab-btn" data-tab="infra">Infrastructure Civile</button>
         <button class="tab-btn" data-tab="proprietes">Propriétés</button>
-        <button class="tab-btn" data-tab="restrictions">Restrictions</button>
       </div>
       <div class="tab-panels">
         <div id="tab-ressources" class="tab-panel active">
@@ -30,9 +29,6 @@
         <div id="tab-proprietes" class="tab-panel">
           <div id="baronyProps"></div>
         </div>
-        <div id="tab-restrictions" class="tab-panel">
-          <div id="restrictions"></div>
-        </div>
       </div>
     </div>
   </main>
@@ -43,7 +39,11 @@
       const buttons = document.querySelectorAll('.tab-btn');
       const panels = document.querySelectorAll('.tab-panel');
 
-      const savedTab = localStorage.getItem('gestionActiveTab') || 'ressources';
+      let savedTab = localStorage.getItem('gestionActiveTab');
+      const availableTabs = Array.from(buttons).map(btn => btn.dataset.tab);
+      if (!savedTab || !availableTabs.includes(savedTab)) {
+        savedTab = 'ressources';
+      }
 
       buttons.forEach(btn => {
         const isActive = btn.dataset.tab === savedTab;

--- a/gestion.js
+++ b/gestion.js
@@ -110,7 +110,7 @@ async function loadAndRender() {
     const infra = document.getElementById('infrastructure');
     if (infra) {
       let html = '<h2>Infrastructure</h2><table class="admin-table" id="buildingsTable">';
-      html += '<tr><th>Nom</th><th>Production</th><th>Coût</th><th>Construits</th><th>Max</th><th>Actifs</th><th>Activer</th><th>Construire</th></tr>';
+      html += '<tr><th>Nom</th><th>Production</th><th>Coût</th><th>Restrictions</th><th>Construits</th><th>Max</th><th>Actifs</th><th>Activer</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
         const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
         const prod = bp.production ? `${bp.production} ${prodLabel}` : '';
@@ -146,7 +146,26 @@ async function loadAndRender() {
           costHtml = `<span style="color:red">${costHtml}</span>`;
         }
 
-        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${costHtml}</td><td>${built}</td><td>${maxVal}</td>`;
+        let restrHtml = '';
+        try {
+          const infraR = bp.infra_restrictions ? JSON.parse(bp.infra_restrictions) : {};
+          const parts = [];
+          if (infraR.buildings) {
+            for (const [bid, qty] of Object.entries(infraR.buildings)) {
+              const ref = bpMap[String(bid)];
+              const name = ref ? (ref.label || ref.type) : bid;
+              parts.push(`${name}: ${qty}`);
+            }
+          }
+          if (infraR.population) {
+            parts.push(`Population: ${infraR.population}`);
+          }
+          restrHtml = parts.join('<br>');
+        } catch (e) {
+          restrHtml = '';
+        }
+
+        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${costHtml}</td><td>${restrHtml}</td><td>${built}</td><td>${maxVal}</td>`;
         html += `<td>${active}</td>`;
         html += `<td><input type="number" min="0" max="${built}" value="${active}" class="activate-input" style="width:4em" data-id="${bp.id}"><button class="activate-btn" data-id="${bp.id}">OK</button></td>`;
         html += `<td><button class="build-btn" data-id="${bp.id}">Construire</button></td></tr>`;
@@ -161,31 +180,6 @@ async function loadAndRender() {
     const propsDiv = document.getElementById('baronyProps');
     if (propsDiv) {
       propsDiv.innerHTML = buildPropsTable(baronyProps);
-    }
-    const restrDiv = document.getElementById('restrictions');
-    if (restrDiv) {
-      let html = '<h2>Restrictions</h2><table class="admin-table"><tr><th>Bâtiment</th><th>Restrictions</th></tr>';
-      for (const bp of buildingProps) {
-        try {
-          const infra = bp.infra_restrictions ? JSON.parse(bp.infra_restrictions) : {};
-          const parts = [];
-          if (infra.buildings) {
-            for (const [bid, qty] of Object.entries(infra.buildings)) {
-              const ref = bpMap[String(bid)];
-              const name = ref ? (ref.label || ref.type) : bid;
-              parts.push(`${name}: ${qty}`);
-            }
-          }
-          if (infra.population) {
-            parts.push(`Population: ${infra.population}`);
-          }
-          if (parts.length) {
-            html += `<tr><td>${bp.label || bp.type}</td><td>${parts.join('<br>')}</td></tr>`;
-          }
-        } catch(e){ /* ignore */ }
-      }
-      html += '</table>';
-      restrDiv.innerHTML = html;
     }
   } catch (e) {
     document.getElementById('summary').textContent = 'Erreur de chargement';


### PR DESCRIPTION
## Summary
- Display infrastructure restrictions directly in the building table
- Remove obsolete restrictions tab and ensure tab selection defaults to available options

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e9212c180832da76bcf16ec1cc0da