### PR TITLE
Disable build button when requirements unmet

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -135,18 +135,18 @@ async function loadAndRender() {
           const parts = [];
           for (const [k, q] of Object.entries(costs)) {
             const label = resourceLabels[k] || k;
-            parts.push(`${label}: ${q}`);
-            if ((inv[k] || 0) < q) hasResources = false;
+            const ok = (inv[k] || 0) >= q;
+            if (!ok) hasResources = false;
+            const color = ok ? '' : ' style="color:red"';
+            parts.push(`<span${color}>${label}: ${q}</span>`);
           }
           costHtml = parts.join('<br>');
         } catch (e) {
           costHtml = '';
         }
-        if (costHtml && !hasResources) {
-          costHtml = `<span style="color:red">${costHtml}</span>`;
-        }
 
         let restrHtml = '';
+        let restrictionsMet = true;
         try {
           const infraR = bp.infra_restrictions ? JSON.parse(bp.infra_restrictions) : {};
           const parts = [];
@@ -154,21 +154,38 @@ async function loadAndRender() {
             for (const [bid, qty] of Object.entries(infraR.buildings)) {
               const ref = bpMap[String(bid)];
               const name = ref ? (ref.label || ref.type) : bid;
-              parts.push(`${name}: ${qty}`);
+              const builtInfo = buildings[bid] || buildings[String(bid)] || {};
+              const ok = (builtInfo.built || 0) >= qty;
+              if (!ok) restrictionsMet = false;
+              const color = ok ? '' : ' style="color:red"';
+              parts.push(`<span${color}>${name}: ${qty}</span>`);
             }
           }
           if (infraR.population) {
-            parts.push(`Population: ${infraR.population}`);
+            const ok = (s.population || 0) >= infraR.population;
+            if (!ok) restrictionsMet = false;
+            const color = ok ? '' : ' style="color:red"';
+            parts.push(`<span${color}>Population: ${infraR.population}</span>`);
           }
           restrHtml = parts.join('<br>');
         } catch (e) {
           restrHtml = '';
         }
 
+        let maxReached = false;
+        if (maxVal !== '') {
+          const maxNum = parseInt(maxVal, 10);
+          if (!isNaN(maxNum) && built >= maxNum) {
+            maxReached = true;
+          }
+        }
+
+        const canBuild = hasResources && restrictionsMet && !maxReached;
+
         html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${costHtml}</td><td>${restrHtml}</td><td>${built}</td><td>${maxVal}</td>`;
         html += `<td>${active}</td>`;
         html += `<td><input type="number" min="0" max="${built}" value="${active}" class="activate-input" style="width:4em" data-id="${bp.id}"><button class="activate-btn" data-id="${bp.id}">OK</button></td>`;
-        html += `<td><button class="build-btn" data-id="${bp.id}">Construire</button></td></tr>`;
+        html += `<td><button class="build-btn" data-id="${bp.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
       }
       html += '</table>';
       infra.innerHTML = html;

--- a/styles.css
+++ b/styles.css
@@ -392,3 +392,9 @@ main {
   flex: 1;
   min-width: 250px;
 }
+
+/* Bouton de construction désactivé */
+.build-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- Highlight missing resources and restrictions in red
- Disable construction button when costs, restrictions, or max limits block building
- Style disabled build button for visual feedback

## Testing
- `npm test` (fails: Missing script "test")
- `node --check gestion.js`

------
https://chatgpt.com/codex/tasks/task_e_689e94822c08832d8fc36f653bf851e6