### PR TITLE
fix: display tooltips with custom styling

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -97,7 +97,7 @@ async function loadAndRender() {
       const tooltip = employmentDetails
         .map(src => `${src.label}: ${src.amount > 0 ? '+' : ''}${src.amount}`)
         .join('\n');
-      employedHtml = `<span class="tooltip" title="${tooltip}">${employment.employed}</span>`;
+      employedHtml = `<span class="tooltip" data-tooltip="${tooltip}">${employment.employed}</span>`;
     }
     popSummary.innerHTML = `
       <h2>Population</h2>
@@ -259,7 +259,7 @@ function buildTable(list, showMax = false, inv = {}, production = {}, production
         const tooltip = details
           .map(src => `${src.label}: ${src.amount > 0 ? '+' : ''}${src.amount}`)
           .join('\n');
-        prodHtml = `<span class="tooltip" title="${tooltip}">${spanAmount(total)}</span>`;
+        prodHtml = `<span class="tooltip" data-tooltip="${tooltip}">${spanAmount(total)}</span>`;
       } else if (production[key]) {
         prodHtml = spanAmount(production[key]);
       }

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,28 @@ main {
 .tooltip {
   font-weight: bold;
   cursor: help;
+  position: relative;
+}
+
+.tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: pre;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 10;
+}
+
+.tooltip:hover::after {
+  opacity: 1;
 }
 
 /* Tables des ressources */


### PR DESCRIPTION
## Summary
- implement CSS-based tooltip with pseudo-element
- use `data-tooltip` attribute for generated span elements in gestion.js

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e9ac2cc24832db4261504cef5195d