### PR TITLE
Improve tooltip display with aligned table layout

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -94,10 +94,10 @@ async function loadAndRender() {
     const popSummary = document.getElementById('populationSummary');
     let employedHtml = employment.employed;
     if (employmentDetails.length) {
-      const tooltip = employmentDetails
-        .map(src => `${src.label}: ${src.amount > 0 ? '+' : ''}${src.amount}`)
-        .join('\n');
-      employedHtml = `<span class="tooltip" data-tooltip="${tooltip}">${employment.employed}</span>`;
+      const rows = employmentDetails
+        .map(src => `<tr><td>${src.label}</td><td>${spanAmount(src.amount)}</td></tr>`)
+        .join('');
+      employedHtml = `<span class="tooltip">${employment.employed}<table class="tooltip-table">${rows}</table></span>`;
     }
     popSummary.innerHTML = `
       <h2>Population</h2>
@@ -256,10 +256,10 @@ function buildTable(list, showMax = false, inv = {}, production = {}, production
       let prodHtml = '';
       if (details.length) {
         const total = details.reduce((sum, s) => sum + s.amount, 0);
-        const tooltip = details
-          .map(src => `${src.label}: ${src.amount > 0 ? '+' : ''}${src.amount}`)
-          .join('\n');
-        prodHtml = `<span class="tooltip" data-tooltip="${tooltip}">${spanAmount(total)}</span>`;
+        const rows = details
+          .map(src => `<tr><td>${src.label}</td><td>${spanAmount(src.amount)}</td></tr>`)
+          .join('');
+        prodHtml = `<span class="tooltip">${spanAmount(total)}<table class="tooltip-table">${rows}</table></span>`;
       } else if (production[key]) {
         prodHtml = spanAmount(production[key]);
       }

--- a/styles.css
+++ b/styles.css
@@ -388,25 +388,36 @@ main {
   position: relative;
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
+.tooltip-table {
+  display: none;
   position: absolute;
-  background-color: rgba(0, 0, 0, 0.8);
-  color: #fff;
-  padding: 4px 8px;
-  border-radius: 4px;
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  white-space: pre;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s;
+  background-color: white;
+  border-collapse: collapse;
+  border: 1px solid #ccc;
+  color: inherit;
+  font-weight: normal;
+  margin-top: 4px;
   z-index: 10;
 }
 
-.tooltip:hover::after {
-  opacity: 1;
+.tooltip-table td {
+  padding: 2px 6px;
+}
+
+.tooltip-table td:first-child {
+  text-align: left;
+  padding-right: 8px;
+}
+
+.tooltip-table td:last-child {
+  text-align: right;
+}
+
+.tooltip:hover .tooltip-table {
+  display: table;
 }
 
 /* Tables des ressources */


### PR DESCRIPTION
## Summary
- Replace text-based tooltips with small table elements for clearer layout
- Align tooltip numbers and reuse positive/negative color classes for clarity
- Add CSS styling for table-based tooltips

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e9ce6df40832dbcc4749c84c474f9