### PR TITLE
Prevent tooltip source line breaks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -405,6 +405,7 @@ main {
 
 .tooltip-table td {
   padding: 2px 6px;
+  white-space: nowrap;
 }
 
 .tooltip-table td:first-child {


### PR DESCRIPTION
## Summary
- avoid line breaks in tooltip source rows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e9f88fa8c832d97525acb5ff6df90