### PR TITLE
Guard building activation by available population

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -38,6 +38,8 @@ const baronyPropLabels = {
   high_sea_boat_limit:'Limite de Bateau en haute mer'
 };
 
+let gameState = {};
+
 document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
@@ -72,6 +74,8 @@ async function loadAndRender() {
     });
     const bpMap = Object.fromEntries(allBuildingProps.map(b => [String(b.id), b]));
 
+    gameState = { s, employment, buildings, bpMap };
+
     const summary = document.getElementById('summary');
     summary.innerHTML = `
       <p><strong>Baronnie :</strong> ${barony.name || 'Aucune'}</p>
@@ -99,6 +103,9 @@ async function loadAndRender() {
         .join('');
       employedHtml = `<span class="tooltip">${employment.employed}<table class="tooltip-table">${rows}</table></span>`;
     }
+    if (employment.employed > s.population) {
+      employedHtml = `<span style="color:red">${employedHtml}</span>`;
+    }
     popSummary.innerHTML = `
       <h2>Population</h2>
       <table class="admin-table">
@@ -116,6 +123,7 @@ async function loadAndRender() {
     luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails);
 
     const infra = document.getElementById('infrastructure');
+    const freePop = s.population + employment.slaves - employment.employed;
     if (infra) {
       let html = '<h2>Infrastructure</h2><table class="admin-table" id="buildingsTable">';
       html += '<tr><th>Nom</th><th>Production</th><th>Coût</th><th>Restrictions</th><th>Construits</th><th>Max</th><th>Actifs</th><th>Activer</th><th>Construire</th></tr>';
@@ -193,7 +201,13 @@ async function loadAndRender() {
         html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${costHtml}</td><td>${restrHtml}</td><td>${built}</td><td>${maxVal}</td>`;
         html += `<td>${active}</td>`;
         if (built > 0) {
-          html += `<td><input type="number" min="0" max="${built}" value="${active}" class="activate-input" style="width:4em" data-id="${bp.id}"><button class="activate-btn" data-id="${bp.id}">OK</button></td>`;
+          let maxActivate = built;
+          if (bp.workers_per_building) {
+            const workersPer = bp.workers_per_building;
+            const available = freePop + active * workersPer;
+            maxActivate = Math.min(built, Math.floor(available / workersPer));
+          }
+          html += `<td><input type="number" min="0" max="${maxActivate}" value="${active}" class="activate-input" style="width:4em" data-id="${bp.id}"><button class="activate-btn" data-id="${bp.id}">OK</button></td>`;
         } else {
           html += '<td></td>';
         }
@@ -233,6 +247,14 @@ async function handleBuildingTableClick(e) {
     const id = e.target.dataset.id;
     const input = table.querySelector(`input.activate-input[data-id="${id}"]`);
     const quantity = parseInt(input.value, 10);
+    const bp = gameState.bpMap[id];
+    const info = gameState.buildings[id] || { built: 0, active: 0 };
+    const workersPer = bp ? (bp.workers_per_building || 0) : 0;
+    const available = gameState.s.population + gameState.employment.slaves - gameState.employment.employed + (info.active || 0) * workersPer;
+    if (workersPer && quantity * workersPer > available) {
+      alert('Population non employée insuffisante');
+      return;
+    }
     const resp = await fetch('/api/building/activate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/server.js
+++ b/server.js
@@ -897,10 +897,10 @@ app.post('/api/building/activate', (req,res)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const buildings = safeParse(srow.buildings, {});
-    db.get('SELECT id, workers_per_building FROM building_properties WHERE id=?', [id], (err2, bprop)=>{
+    db.all('SELECT id, type, label, workers_per_building FROM building_properties', [], (err2, bprops) => {
       if(err2) return handleError(res, err2);
+      const bprop = bprops.find(bp => bp.id === id);
       if(!bprop) return res.status(400).json({ error: 'Bâtiment introuvable' });
-      const baseWorkers = bprop.workers_per_building || 0;
       const binfo = buildings[id] || { built: 0, active: 0 };
       const built = binfo.built;
       if(qty > built) return res.status(400).json({ error: 'Quantité supérieure au construit' });
@@ -908,32 +908,28 @@ app.post('/api/building/activate', (req,res)=>{
         if(err3) return handleError(res, err3);
         const slaves = inv ? (inv.esclaves || 0) : 0;
         const totalPop = srow.population + slaves;
-        if(qty > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
+        let employed = 0;
+        const employmentDetails = [];
+        for(const bp of bprops || []){
+          const info = buildings[bp.id] || { built: 0, active: 0 };
+          const active = (bp.id === id) ? qty : (info.active || 0);
+          const workers = active * (bp.workers_per_building || 0);
+          employed += workers;
+          if(workers) employmentDetails.push({ label: bp.label || bp.type, amount: workers, source: active });
+        }
+        if(employed > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
+        if(slaves) employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
+        const employment = { employed: Math.max(employed - slaves, 0), slaves };
         binfo.active = qty;
         buildings[id] = binfo;
         db.run('UPDATE seigneuries SET buildings=? WHERE id=?', [JSON.stringify(buildings), srow.id], function(err4){
           if(err4) return handleError(res, err4);
-          db.all('SELECT id, type, label, workers_per_building FROM building_properties', [], (err5, bprops) => {
-            if(err5) return handleError(res, err5);
-            let employed = 0;
-            const employmentDetails = [];
-            for(const bp of bprops || []){
-              const info = buildings[bp.id] || { built: 0, active: 0 };
-              const active = info.active || 0;
-              const workers = active * (bp.workers_per_building || 0);
-              employed += workers;
-              if(workers) employmentDetails.push({ label: bp.label || bp.type, amount: workers, source: active });
-            }
-            if(slaves) employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
-            const employment = { employed: Math.max(employed - slaves, 0), slaves };
-            res.json({ building: { id, built, active: qty }, employment, employmentDetails });
-          });
+          res.json({ building: { id, built, active: qty }, employment, employmentDetails });
         });
       });
     });
   });
 });
-
 app.get('/api/canonical_lands', list('canonical_lands'));
 app.post('/api/canonical_lands', create('canonical_lands',['religion_id','barony_id']));
 app.delete('/api/canonical_lands', (req, res) => {


### PR DESCRIPTION
## Summary
- Highlight employed population in red when it exceeds the total population.
- Prevent building activation from exceeding free population on both client and server.

## Testing
- `node --check gestion.js`
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ea801cab8832d96ae6dc95bf935c9