### PR TITLE
feat: add infrastructure buildings system

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -27,7 +27,7 @@
         <button class="tab-btn" data-tab="counties">Comtés</button>
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
-        <button class="tab-btn" data-tab="buildingprops">Infrastructures civiles</button>
+        <button class="tab-btn" data-tab="batiments">Bâtiments</button>
         <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
       <div class="tab-panels">
@@ -64,8 +64,11 @@
         <div id="tab-seigneuries" class="tab-panel">
           <div id="tableSeigneuries"></div>
         </div>
-        <div id="tab-buildingprops" class="tab-panel">
+        <div id="tab-batiments" class="tab-panel">
+          <h2>Production</h2>
           <div id="tableBuildingProps"></div>
+          <h2>Infrastructures Civiles</h2>
+          <div id="tableInfraProps"></div>
         </div>
         <div id="tab-baronyprops" class="tab-panel">
           <div id="tableBaronyProps"></div>

--- a/admin.js
+++ b/admin.js
@@ -61,6 +61,18 @@ const buildingPropLabels = {
   infra_restrictions:'Restrictions infrastructure',
   description:'Description'
 };
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','restrictions','description'];
+const infraPropLabels = {
+  label:'Nom',
+  type:'Type',
+  max:'Maximum',
+  workers_per_building:'Travailleurs/bâtiment',
+  effects:'Effets',
+  costs:'Coûts',
+  restrictions:'Restrictions',
+  description:'Description',
+};
+const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];
 const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
 let buildingPropsSelect = [];
 const maxOptions = [
@@ -475,7 +487,7 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps, infraProps] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
@@ -491,6 +503,7 @@ async function loadAll(){
     fetchJSON('/api/baronies'),
     fetchJSON('/api/barony_properties'),
     fetchJSON('/api/building_properties'),
+    fetchJSON('/api/infrastructure_properties'),
   ]);
 
   const seigneursSelect = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -617,6 +630,13 @@ async function loadAll(){
     fields:buildingPropFields,
     labels:buildingPropLabels,
     selects:{produces: resourceSelect, max: maxOptions}
+  });
+  const infraPropsById = infraProps.slice().sort((a,b)=>a.id - b.id);
+  renderTable(document.getElementById('tableInfraProps'), infraPropsById, {
+    endpoint:'infrastructure_properties',
+    fields:infraPropFields,
+    labels:infraPropLabels,
+    selects:{type:typeSelect}
   });
 }
 

--- a/effects.js
+++ b/effects.js
@@ -1,0 +1,34 @@
+class Effect {
+  apply(ctx, count, label) {}
+}
+
+class StorageEffect extends Effect {
+  constructor(resource, amount) {
+    super();
+    this.resource = resource;
+    this.amount = amount;
+  }
+  apply(ctx, count) {
+    if (!ctx.capacity) ctx.capacity = {};
+    const base = ctx.capacity[this.resource] || 0;
+    ctx.capacity[this.resource] = base + this.amount * count;
+  }
+}
+
+class ResourceProductionEffect extends Effect {
+  constructor(resource, amount) {
+    super();
+    this.resource = resource;
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    if (!ctx.production) ctx.production = {};
+    if (!ctx.productionDetails) ctx.productionDetails = {};
+    ctx.production[this.resource] = (ctx.production[this.resource] || 0) + total;
+    if (!ctx.productionDetails[this.resource]) ctx.productionDetails[this.resource] = [];
+    ctx.productionDetails[this.resource].push({ label, amount: total, source: count });
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect };

--- a/gestion.html
+++ b/gestion.html
@@ -16,7 +16,8 @@
     <div class="tab-container" style="overflow:auto;flex:1">
       <div class="tab-buttons">
         <button class="tab-btn active" data-tab="ressources">Ressources</button>
-        <button class="tab-btn" data-tab="infra">Infrastructure Civile</button>
+        <button class="tab-btn" data-tab="infra">Infrastructures Civiles</button>
+        <button class="tab-btn" data-tab="infraMili">Infrastructures Militaires</button>
         <button class="tab-btn" data-tab="proprietes">Propriétés</button>
       </div>
       <div class="tab-panels">
@@ -24,7 +25,13 @@
           <div id="summary"></div>
         </div>
         <div id="tab-infra" class="tab-panel">
-          <div id="infrastructure"></div>
+          <h2>Production</h2>
+          <div id="productionInfra"></div>
+          <h2>Infrastructures Civiles</h2>
+          <div id="civilInfra"></div>
+        </div>
+        <div id="tab-infraMili" class="tab-panel">
+          <div id="militaryInfra"></div>
         </div>
         <div id="tab-proprietes" class="tab-panel">
           <div id="baronyProps"></div>

--- a/gestion.js
+++ b/gestion.js
@@ -48,13 +48,15 @@ async function init() {
 
 async function loadAndRender() {
   try {
-    const [res, bRes] = await Promise.all([
+    const [res, bRes, iRes] = await Promise.all([
       fetch('/api/my_seigneurie'),
-      fetch('/api/building_properties')
+      fetch('/api/building_properties'),
+      fetch('/api/infrastructure_properties')
     ]);
     if (!res.ok) throw new Error('Erreur');
     const data = await res.json();
     const allBuildingProps = bRes.ok ? await bRes.json() : [];
+    const allInfraProps = iRes.ok ? await iRes.json() : [];
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
@@ -64,6 +66,8 @@ async function loadAndRender() {
     const employment = data.employment || { employed:0, slaves:0 };
     const employmentDetails = data.employmentDetails || [];
     const buildings = data.buildings || {};
+    const infrastructures = data.infrastructures || {};
+    const capacities = data.capacities || {};
     const buildingProps = allBuildingProps.filter(bp => {
       try {
         const arr = bp.absolute_restrictions ? JSON.parse(bp.absolute_restrictions) : [];
@@ -73,8 +77,17 @@ async function loadAndRender() {
       }
     });
     const bpMap = Object.fromEntries(allBuildingProps.map(b => [String(b.id), b]));
+    const infraProps = allInfraProps.filter(ip => {
+      try {
+        const arr = ip.restrictions ? JSON.parse(ip.restrictions) : [];
+        return arr.every(p => baronyProps[p]);
+      } catch {
+        return true;
+      }
+    });
+    const ipMap = Object.fromEntries(allInfraProps.map(b => [String(b.id), b]));
 
-    gameState = { s, employment, buildings, bpMap };
+    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap };
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -119,13 +132,15 @@ async function loadAndRender() {
     const basicTable = document.getElementById('basicResourcesTable');
     const luxuryTable = document.getElementById('luxuryResourcesTable');
 
-    basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails);
-    luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails);
+    basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails, capacities);
+    luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails, capacities);
 
-    const infra = document.getElementById('infrastructure');
+    const prodDiv = document.getElementById('productionInfra');
+    const civilDiv = document.getElementById('civilInfra');
+    const miliDiv = document.getElementById('militaryInfra');
     const freePop = s.population + employment.slaves - employment.employed;
-    if (infra) {
-      let html = '<h2>Infrastructure</h2><table class="admin-table" id="buildingsTable">';
+    if (prodDiv) {
+      let html = '<table class="admin-table" id="buildingsTable">';
       html += '<tr><th>Nom</th><th>Production</th><th>Restrictions</th><th>Construits</th><th>Max</th><th>Activer</th><th>Coût</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
         const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
@@ -214,11 +229,22 @@ async function loadAndRender() {
         html += `<td>${costHtml}</td><td><button class="build-btn" data-id="${bp.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
       }
       html += '</table>';
-      infra.innerHTML = html;
+      prodDiv.innerHTML = html;
 
       const table = document.getElementById('buildingsTable');
       table.addEventListener('click', handleBuildingTableClick);
       table.addEventListener('change', handleBuildingActivationChange);
+    }
+
+    if (civilDiv) {
+      civilDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='civil'), infrastructures, inv, 'civilInfraTable');
+      const table = document.getElementById('civilInfraTable');
+      table.addEventListener('click', handleInfraTableClick);
+    }
+    if (miliDiv) {
+      miliDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='militaire'), infrastructures, inv, 'militaryInfraTable');
+      const table = document.getElementById('militaryInfraTable');
+      table.addEventListener('click', handleInfraTableClick);
     }
 
     const propsDiv = document.getElementById('baronyProps');
@@ -275,7 +301,47 @@ async function handleBuildingActivationChange(e) {
   }
 }
 
-function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}) {
+async function handleInfraTableClick(e) {
+  if (e.target.classList.contains('infra-build-btn')) {
+    const id = e.target.dataset.id;
+    const resp = await fetch('/api/infrastructure', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, quantity: 1 })
+    });
+    if (resp.ok) {
+      await loadAndRender();
+    } else {
+      alert('Construction impossible');
+    }
+  }
+}
+
+function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
+  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Coût</th><th>Construire</th></tr>`;
+  for (const ip of list) {
+    const built = infraBuilt[ip.id] || 0;
+    let costHtml = '';
+    let hasRes = true;
+    try {
+      const costs = ip.costs ? JSON.parse(ip.costs) : {};
+      const parts = [];
+      for (const [k, q] of Object.entries(costs)) {
+        const label = resourceLabels[k] || k;
+        const ok = (inv[k] || 0) >= q;
+        if (!ok) hasRes = false;
+        const color = ok ? '' : ' style="color:red"';
+        parts.push(`<span${color}>${label}: ${q}</span>`);
+      }
+      costHtml = parts.join('<br>');
+    } catch {}
+    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${built}</td><td>${costHtml}</td><td><button class="infra-build-btn" data-id="${ip.id}"${hasRes ? '' : ' disabled'}>Construire</button></td></tr>`;
+  }
+  html += '</table>';
+  return html;
+}
+
+function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}) {
   let html = '<tr><th>Ressource</th><th>Quantité</th><th>Production</th>';
   if (showMax) html += '<th>Maximum</th>';
   html += '</tr>';
@@ -293,7 +359,7 @@ function buildTable(list, showMax = false, inv = {}, production = {}, production
         prodHtml = spanAmount(production[key]);
       }
     html += `<tr><td>${label}</td><td>${qty}</td><td>${prodHtml}</td>`;
-    if (showMax) html += '<td></td>';
+    if (showMax) html += `<td>${capacity[key] !== undefined ? capacity[key] : ''}</td>`;
     html += '</tr>';
   }
   return html;

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
+const { StorageEffect, ResourceProductionEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -15,7 +16,7 @@ const VALID_TABLES = new Set([
   'users','religions','cultures','seigneurs','empires','kingdoms','archduchies',
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
   'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
-  'building_properties'
+  'building_properties','infrastructure_properties'
 ]);
 
 // create tables if they do not exist
@@ -172,6 +173,7 @@ CREATE TABLE IF NOT EXISTS seigneuries (
   population INTEGER,
   inventaire_id INTEGER,
   buildings TEXT DEFAULT '{}',
+  infrastructures TEXT DEFAULT '{}',
   FOREIGN KEY(baronnie_id) REFERENCES baronies(id),
   FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id),
   FOREIGN KEY(inventaire_id) REFERENCES inventaire(id)
@@ -222,6 +224,17 @@ CREATE TABLE IF NOT EXISTS building_properties (
   infra_restrictions TEXT,
   description TEXT
 );
+CREATE TABLE IF NOT EXISTS infrastructure_properties (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  label TEXT,
+  type TEXT,
+  max TEXT,
+  workers_per_building INTEGER DEFAULT 0,
+  effects TEXT,
+  costs TEXT,
+  restrictions TEXT,
+  description TEXT
+);
 `;
 
 db.exec(initSql, () => {
@@ -245,8 +258,13 @@ db.exec(initSql, () => {
     }
   });
   db.all("PRAGMA table_info(seigneuries)", (err, rows) => {
-    if (!err && rows && !rows.some(r => r.name === 'buildings')) {
-      db.run("ALTER TABLE seigneuries ADD COLUMN buildings TEXT DEFAULT '{}' ");
+    if (!err && rows) {
+      if (!rows.some(r => r.name === 'buildings')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN buildings TEXT DEFAULT '{}' ");
+      }
+      if (!rows.some(r => r.name === 'infrastructures')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN infrastructures TEXT DEFAULT '{}' ");
+      }
     }
   });
   db.all("PRAGMA table_info(cultures)", (err, rows) => {
@@ -600,7 +618,7 @@ app.put('/api/inventaire/:id', update('inventaire', inventaireFields));
 
 app.get('/api/seigneuries', requireAdmin, (req, res) => {
   const invSelect = inventaireFields.map(f => `i.${f}`).join(',');
-  db.all(`SELECT s.id, s.baronnie_id, s.seigneur_id, s.population, s.inventaire_id, s.buildings, ${invSelect} FROM seigneuries s JOIN inventaire i ON s.inventaire_id=i.id`, [], (err, rows) => {
+  db.all(`SELECT s.id, s.baronnie_id, s.seigneur_id, s.population, s.inventaire_id, s.buildings, s.infrastructures, ${invSelect} FROM seigneuries s JOIN inventaire i ON s.inventaire_id=i.id`, [], (err, rows) => {
     if (err) return handleError(res, err);
     res.json(rows);
   });
@@ -614,8 +632,8 @@ app.post('/api/seigneuries', requireAdmin, (req, res) => {
   db.run(`INSERT INTO inventaire (${inventaireFields.join(',')}) VALUES (${invPlace})`, invValues, function(err){
     if (err) return handleError(res, err);
     const invId = this.lastID;
-  db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id,buildings) VALUES (?,?,?,?,?)',
-    [...seigValues, invId, '{}'], function(err2){
+  db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id,buildings,infrastructures) VALUES (?,?,?,?,?,?)',
+    [...seigValues, invId, '{}', '{}'], function(err2){
       if (err2) return handleError(res, err2);
       res.json({ id: this.lastID, inventaire_id: invId });
     });
@@ -663,10 +681,10 @@ app.get('/api/my_seigneurie', (req, res) => {
             db.run('INSERT INTO inventaire DEFAULT VALUES', function(err){
               if (err) return handleError(res, err);
               const invId = this.lastID;
-              db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id,buildings) VALUES (NULL,?,?,?,?)',
-                [seig.id, 0, invId, '{}'], function(err){
+              db.run('INSERT INTO seigneuries (baronnie_id,seigneur_id,population,inventaire_id,buildings,infrastructures) VALUES (NULL,?,?,?,?,?,?)',
+                [seig.id, 0, invId, '{}', '{}'], function(err){
                   if (err) return handleError(res, err);
-                  cb({ id: this.lastID, baronnie_id: null, seigneur_id: seig.id, population: 0, inventaire_id: invId, buildings: '{}' });
+                  cb({ id: this.lastID, baronnie_id: null, seigneur_id: seig.id, population: 0, inventaire_id: invId, buildings: '{}', infrastructures: '{}' });
                 });
             });
           }
@@ -674,6 +692,7 @@ app.get('/api/my_seigneurie', (req, res) => {
             db.get('SELECT * FROM inventaire WHERE id=?', [s.inventaire_id], (err, inventaire) => {
               if (err) return handleError(res, err);
               const buildings = s.buildings ? JSON.parse(s.buildings) : {};
+              const infrastructures = s.infrastructures ? JSON.parse(s.infrastructures) : {};
               db.all('SELECT id, type, label, produces, production, workers_per_building FROM building_properties', [], (err2, bprops) => {
                 if (err2) return handleError(res, err2);
                 const props = bprops || [];
@@ -700,37 +719,58 @@ app.get('/api/my_seigneurie', (req, res) => {
                     productionDetails[bp.produces].push({ label: bp.label || bp.type, amount, source: active });
                   }
                 }
-                const slaves = inventaire.esclaves || 0;
-                if (slaves) {
-                  employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
-                }
-                const populationCons = s.population * 15;
-                const slaveCons = slaves * 5;
-                if (populationCons || slaveCons) {
-                  production.vivres = (production.vivres || 0) - (populationCons + slaveCons);
-                  if (!productionDetails.vivres) productionDetails.vivres = [];
-                  if (populationCons) {
-                    productionDetails.vivres.push({ label: 'Population', amount: -populationCons, source: s.population });
+                db.all('SELECT * FROM infrastructure_properties', [], (errI, iprops) => {
+                  if (errI) return handleError(res, errI);
+                  const infraList = iprops || [];
+                  const capacities = { vivres: 500, points_magique: 2000 };
+                  for (const ip of infraList) {
+                    const count = infrastructures[ip.id] || 0;
+                    if (!count) continue;
+                    const effects = safeParse(ip.effects, []);
+                    for (const def of effects) {
+                      let effObj = null;
+                      if (def.type === 'storage') {
+                        effObj = new StorageEffect(def.resource, def.amount || 0);
+                      } else if (def.type === 'production') {
+                        effObj = new ResourceProductionEffect(def.resource, def.amount || 0);
+                      }
+                      if (effObj) {
+                        effObj.apply({ production, productionDetails, capacity: capacities }, count, ip.label || ip.type);
+                      }
+                    }
                   }
-                  if (slaveCons) {
-                    productionDetails.vivres.push({ label: 'Esclaves', amount: -slaveCons, source: slaves });
+                  const slaves = inventaire.esclaves || 0;
+                  if (slaves) {
+                    employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
                   }
-                }
-                const employment = { employed: Math.max(employed - slaves, 0), slaves };
-                function finalize(barony, baronyProps) {
-                  res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings });
-                }
-                if (s.baronnie_id) {
-                  db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
-                    if (err3) return handleError(res, err3);
-                    db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
-                      if (err4) return handleError(res, err4);
-                      finalize(barony, props || {});
+                  const populationCons = s.population * 15;
+                  const slaveCons = slaves * 5;
+                  if (populationCons || slaveCons) {
+                    production.vivres = (production.vivres || 0) - (populationCons + slaveCons);
+                    if (!productionDetails.vivres) productionDetails.vivres = [];
+                    if (populationCons) {
+                      productionDetails.vivres.push({ label: 'Population', amount: -populationCons, source: s.population });
+                    }
+                    if (slaveCons) {
+                      productionDetails.vivres.push({ label: 'Esclaves', amount: -slaveCons, source: slaves });
+                    }
+                  }
+                  const employment = { employed: Math.max(employed - slaves, 0), slaves };
+                  function finalize(barony, baronyProps) {
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities });
+                  }
+                  if (s.baronnie_id) {
+                    db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
+                      if (err3) return handleError(res, err3);
+                      db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
+                        if (err4) return handleError(res, err4);
+                        finalize(barony, props || {});
+                      });
                     });
-                  });
-                } else {
-                  finalize(null, {});
-                }
+                  } else {
+                    finalize(null, {});
+                  }
+                });
               });
             });
           });
@@ -795,6 +835,17 @@ app.put('/api/building_properties/:id', requireAdmin, (req,res)=>{
   update('building_properties', buildingPropFields)(req,res);
 });
 
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','restrictions','description'];
+app.get('/api/infrastructure_properties', (req,res)=>{
+  list('infrastructure_properties')(req,res);
+});
+app.post('/api/infrastructure_properties', requireAdmin, (req,res)=>{
+  create('infrastructure_properties', infraPropFields)(req,res);
+});
+app.put('/api/infrastructure_properties/:id', requireAdmin, (req,res)=>{
+  update('infrastructure_properties', infraPropFields)(req,res);
+});
+
 function safeParse(json, fallback){
   try {
     return json ? JSON.parse(json) : fallback;
@@ -857,6 +908,43 @@ function canConstruct(db, srow, id, qty, cb){
   });
 }
 
+function canConstructInfra(db, srow, id, qty, cb){
+  db.get('SELECT * FROM infrastructure_properties WHERE id=?', [id], (err, iprop) => {
+    if(err) return cb(err);
+    if(!iprop) return cb(new Error('Type inconnu'));
+    if(!srow.baronnie_id) return cb(new Error('Aucune baronnie associée'));
+    const costObj = safeParse(iprop.costs, {});
+    const restrictions = safeParse(iprop.restrictions, []);
+    const costs = {};
+    Object.entries(costObj).forEach(([res, val]) => { costs[res] = (parseInt(val,10) || 0) * qty; });
+    db.get('SELECT * FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err2, props) => {
+      if(err2) return cb(err2);
+      const barProps = props || {};
+      let max = Infinity;
+      if(iprop.max != null){
+        const parsed = parseInt(iprop.max,10);
+        if(!isNaN(parsed)) max = parsed;
+        else if(barProps[iprop.max] != null) max = barProps[iprop.max];
+      }
+      if(Array.isArray(restrictions)){
+        for(const prop of restrictions){
+          if(!barProps[prop]) return cb(new Error('Restriction non satisfaite'));
+        }
+      }
+      const infrastructures = safeParse(srow.infrastructures, {});
+      const built = infrastructures[id] || 0;
+      if(built + qty > max) return cb(new Error('Limite atteinte'));
+      db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
+        if(err3) return cb(err3);
+        for(const [res, val] of Object.entries(costs)){
+          if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
+        }
+        cb(null, { costs, built, infrastructures });
+      });
+    });
+  });
+}
+
 app.post('/api/building', (req,res)=>{
   if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
   const { id, quantity } = req.body;
@@ -880,6 +968,35 @@ app.post('/api/building', (req,res)=>{
           db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inventaire)=>{
             if(err5) return handleError(res, err5);
             res.json({ buildings, inventaire });
+          });
+        });
+      });
+    });
+  });
+});
+
+app.post('/api/infrastructure', (req,res)=>{
+  if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const { id, quantity } = req.body;
+  const iId = parseInt(id,10);
+  const qty = parseInt(quantity,10) || 0;
+  if(!iId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
+  const userId = req.session.user.id;
+  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+    if(err) return handleError(res, err);
+    if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    canConstructInfra(db, srow, iId, qty, (err2, info)=>{
+      if(err2) return res.status(400).json({ error: err2.message });
+      consumeResources(db, srow.id, info.costs, err3 => {
+        if(err3) return handleError(res, err3);
+        const newBuilt = info.built + qty;
+        const infrastructures = info.infrastructures;
+        infrastructures[iId] = newBuilt;
+        db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?', [JSON.stringify(infrastructures), srow.id], function(err4){
+          if(err4) return handleError(res, err4);
+          db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inventaire)=>{
+            if(err5) return handleError(res, err5);
+            res.json({ infrastructures, inventaire });
           });
         });
       });


### PR DESCRIPTION
## Summary
- add infrastructure building definitions and effects
- expose civil and military infrastructure management in UI
- compute storage capacities and resource production from infrastructure effects

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689f70992144832dac6d60df4cd743f6