### PR TITLE
Add dynamic restriction and effect management

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -75,6 +75,7 @@ const infraPropLabels = {
 const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];
 const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
 let buildingPropsSelect = [];
+let infraPropsSelect = [];
 const maxOptions = [
   ...Array.from({length:10}, (_,i)=>({ id:String(i+1), name:String(i+1) })),
   ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f }))
@@ -95,6 +96,252 @@ function showSaveIndicator(target) {
   setTimeout(() => {
     el.style.display = 'none';
   }, 2000);
+}
+
+function makeRestrictionsInput(val){
+  const container = document.createElement('div');
+  const list = document.createElement('div');
+  container.appendChild(list);
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.textContent = '+';
+  container.appendChild(addBtn);
+  function addRow(type = '', data = {}){
+    const row = document.createElement('div');
+    row.className = 'restriction-row';
+    const typeSel = document.createElement('select');
+    const blank = document.createElement('option');
+    blank.value = '';
+    typeSel.appendChild(blank);
+    const typeOptions = [
+      {id:'building', name:'Bâtiment'},
+      {id:'infrastructure', name:'Infrastructure'},
+      {id:'population', name:'Population'},
+      {id:'resource', name:'Ressource'}
+    ];
+    typeOptions.forEach(o=>{
+      const op = document.createElement('option');
+      op.value = o.id;
+      op.textContent = o.name;
+      if(o.id === type) op.selected = true;
+      typeSel.appendChild(op);
+    });
+    const keySpan = document.createElement('span');
+    const valSpan = document.createElement('span');
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '-';
+    removeBtn.addEventListener('click', ()=> row.remove());
+    row.appendChild(typeSel);
+    row.appendChild(keySpan);
+    row.appendChild(valSpan);
+    row.appendChild(removeBtn);
+    function updateFields(){
+      keySpan.innerHTML = '';
+      valSpan.innerHTML = '';
+      if(typeSel.value === 'building'){
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        buildingPropsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.building)) op.selected = true;
+          sel.appendChild(op);
+        });
+        keySpan.appendChild(sel);
+        const qty = document.createElement('input');
+        qty.type = 'number';
+        qty.min = '0';
+        qty.value = data.value || '';
+        valSpan.appendChild(qty);
+      }else if(typeSel.value === 'infrastructure'){
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        infraPropsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.infrastructure)) op.selected = true;
+          sel.appendChild(op);
+        });
+        keySpan.appendChild(sel);
+        const qty = document.createElement('input');
+        qty.type = 'number';
+        qty.min = '0';
+        qty.value = data.value || '';
+        valSpan.appendChild(qty);
+      }else if(typeSel.value === 'population'){
+        const qty = document.createElement('input');
+        qty.type = 'number';
+        qty.min = '0';
+        qty.value = data.value || '';
+        valSpan.appendChild(qty);
+      }else if(typeSel.value === 'resource'){
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        resourceSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.resource)) op.selected = true;
+          sel.appendChild(op);
+        });
+        keySpan.appendChild(sel);
+        const qty = document.createElement('input');
+        qty.type = 'number';
+        qty.min = '0';
+        qty.value = data.value || '';
+        valSpan.appendChild(qty);
+      }
+    }
+    typeSel.addEventListener('change', updateFields);
+    updateFields();
+    list.appendChild(row);
+  }
+  addBtn.addEventListener('click', ()=> addRow());
+  try{
+    const obj = JSON.parse(val || '{}');
+    if(obj.buildings){
+      Object.entries(obj.buildings).forEach(([b,v])=> addRow('building',{building:b,value:v}));
+    }
+    if(obj.infrastructures){
+      Object.entries(obj.infrastructures).forEach(([i,v])=> addRow('infrastructure',{infrastructure:i,value:v}));
+    }
+    if(obj.resources){
+      Object.entries(obj.resources).forEach(([r,v])=> addRow('resource',{resource:r,value:v}));
+    }
+    if(obj.population){
+      addRow('population',{value:obj.population});
+    }
+    if(!obj.buildings && !obj.infrastructures && !obj.resources && !obj.population){
+      addRow();
+    }
+  }catch(e){
+    addRow();
+  }
+  container.getValue = ()=>{
+    const res = {};
+    const buildings = {};
+    const infrastructures = {};
+    const resources = {};
+    let population;
+    list.querySelectorAll('.restriction-row').forEach(rw=>{
+      const type = rw.querySelector('select').value;
+      if(type === 'building'){
+        const sel = rw.querySelector('span select');
+        const inp = rw.querySelector('span input');
+        const b = sel.value;
+        const q = parseInt(inp.value,10);
+        if(b && q) buildings[b] = q;
+      }else if(type === 'infrastructure'){
+        const sel = rw.querySelector('span select');
+        const inp = rw.querySelector('span input');
+        const i = sel.value;
+        const q = parseInt(inp.value,10);
+        if(i && q) infrastructures[i] = q;
+      }else if(type === 'population'){
+        const inp = rw.querySelector('span input');
+        const q = parseInt(inp.value,10);
+        if(q) population = q;
+      }else if(type === 'resource'){
+        const sel = rw.querySelector('span select');
+        const inp = rw.querySelector('span input');
+        const r = sel.value;
+        const q = parseInt(inp.value,10);
+        if(r && q) resources[r] = q;
+      }
+    });
+    if(Object.keys(buildings).length) res.buildings = buildings;
+    if(Object.keys(infrastructures).length) res.infrastructures = infrastructures;
+    if(Object.keys(resources).length) res.resources = resources;
+    if(population != null) res.population = population;
+    return JSON.stringify(res);
+  };
+  return container;
+}
+
+function makeEffectsInput(val){
+  const container = document.createElement('div');
+  const list = document.createElement('div');
+  container.appendChild(list);
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.textContent = '+';
+  container.appendChild(addBtn);
+  function addRow(type = '', data = {}){
+    const row = document.createElement('div');
+    row.className = 'effect-row';
+    const typeSel = document.createElement('select');
+    const blank = document.createElement('option');
+    blank.value = '';
+    typeSel.appendChild(blank);
+    const typeOptions = [
+      {id:'storage', name:'Stockage'},
+      {id:'production', name:'Production'}
+    ];
+    typeOptions.forEach(o=>{
+      const op = document.createElement('option');
+      op.value = o.id;
+      op.textContent = o.name;
+      if(o.id === type) op.selected = true;
+      typeSel.appendChild(op);
+    });
+    const resSel = document.createElement('select');
+    const blankRes = document.createElement('option');
+    blankRes.value = '';
+    resSel.appendChild(blankRes);
+    resourceSelect.forEach(o=>{
+      const op = document.createElement('option');
+      op.value = o.id;
+      op.textContent = o.name;
+      if(String(o.id) === String(data.resource)) op.selected = true;
+      resSel.appendChild(op);
+    });
+    const qty = document.createElement('input');
+    qty.type = 'number';
+    qty.min = '0';
+    qty.value = data.amount || '';
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '-';
+    removeBtn.addEventListener('click', ()=> row.remove());
+    row.appendChild(typeSel);
+    row.appendChild(resSel);
+    row.appendChild(qty);
+    row.appendChild(removeBtn);
+    list.appendChild(row);
+  }
+  addBtn.addEventListener('click', ()=> addRow());
+  try{
+    const arr = JSON.parse(val || '[]');
+    if(Array.isArray(arr) && arr.length){
+      arr.forEach(e=> addRow(e.type, {resource:e.resource, amount:e.amount}));
+    }else{
+      addRow();
+    }
+  }catch(e){
+    addRow();
+  }
+  container.getValue = ()=>{
+    const res = [];
+    list.querySelectorAll('.effect-row').forEach(rw=>{
+      const type = rw.children[0].value;
+      const resource = rw.children[1].value;
+      const amt = parseInt(rw.children[2].value,10);
+      if(type && resource && amt){
+        res.push({type, resource, amount: amt});
+      }
+    });
+    return JSON.stringify(res);
+  };
+  return container;
 }
 
 function renderTable(container, rows, opts){
@@ -267,113 +514,11 @@ function renderTable(container, rows, opts){
       };
       return container;
     }
-    if(field === 'infra_restrictions'){
-      const container = document.createElement('div');
-      const list = document.createElement('div');
-      container.appendChild(list);
-      const addBtn = document.createElement('button');
-      addBtn.type = 'button';
-      addBtn.textContent = '+';
-      container.appendChild(addBtn);
-      function addRow(type = '', data = {}){
-        const row = document.createElement('div');
-        row.className = 'restriction-row';
-        const typeSel = document.createElement('select');
-        const blank = document.createElement('option');
-        blank.value = '';
-        typeSel.appendChild(blank);
-        const typeOptions = [
-          {id:'building', name:'Bâtiment'},
-          {id:'population', name:'Population'}
-        ];
-        typeOptions.forEach(o=>{
-          const op = document.createElement('option');
-          op.value = o.id;
-          op.textContent = o.name;
-          if(o.id === type) op.selected = true;
-          typeSel.appendChild(op);
-        });
-        const keySpan = document.createElement('span');
-        const valSpan = document.createElement('span');
-        const removeBtn = document.createElement('button');
-        removeBtn.type = 'button';
-        removeBtn.textContent = '-';
-        removeBtn.addEventListener('click', ()=> row.remove());
-        row.appendChild(typeSel);
-        row.appendChild(keySpan);
-        row.appendChild(valSpan);
-        row.appendChild(removeBtn);
-        function updateFields(){
-          keySpan.innerHTML = '';
-          valSpan.innerHTML = '';
-          if(typeSel.value === 'building'){
-            const sel = document.createElement('select');
-            const blank = document.createElement('option');
-            blank.value = '';
-            sel.appendChild(blank);
-            buildingPropsSelect.forEach(o=>{
-              const op = document.createElement('option');
-              op.value = o.id;
-              op.textContent = o.name;
-              if(String(o.id) === String(data.building)) op.selected = true;
-              sel.appendChild(op);
-            });
-            keySpan.appendChild(sel);
-            const qty = document.createElement('input');
-            qty.type = 'number';
-            qty.min = '0';
-            qty.value = data.value || '';
-            valSpan.appendChild(qty);
-          } else if(typeSel.value === 'population'){
-            const qty = document.createElement('input');
-            qty.type = 'number';
-            qty.min = '0';
-            qty.value = data.value || '';
-            valSpan.appendChild(qty);
-          }
-        }
-        typeSel.addEventListener('change', updateFields);
-        updateFields();
-        list.appendChild(row);
-      }
-      addBtn.addEventListener('click', ()=> addRow());
-      try{
-        const obj = JSON.parse(val || '{}');
-        if(obj.buildings){
-          Object.entries(obj.buildings).forEach(([b,v])=> addRow('building',{building:b,value:v}));
-        }
-        if(obj.population){
-          addRow('population',{value:obj.population});
-        }
-        if(!obj.buildings && !obj.population){
-          addRow();
-        }
-      } catch(e){
-        addRow();
-      }
-      container.getValue = ()=>{
-        const res = {};
-        const buildings = {};
-        let population;
-        list.querySelectorAll('.restriction-row').forEach(rw=>{
-          const type = rw.querySelector('select').value;
-          if(type === 'building'){
-            const sel = rw.querySelector('span select');
-            const inp = rw.querySelector('span input');
-            const b = sel.value;
-            const q = parseInt(inp.value,10);
-            if(b && q) buildings[b] = q;
-          } else if(type === 'population'){
-            const inp = rw.querySelector('span input');
-            const q = parseInt(inp.value,10);
-            if(q) population = q;
-          }
-        });
-        if(Object.keys(buildings).length) res.buildings = buildings;
-        if(population != null) res.population = population;
-        return JSON.stringify(res);
-      };
-      return container;
+    if(field === 'infra_restrictions' || field === 'restrictions'){
+      return makeRestrictionsInput(val);
+    }
+    if(field === 'effects'){
+      return makeEffectsInput(val);
     }
     if(opts.selects && opts.selects[field]){
       const select = document.createElement('select');
@@ -624,6 +769,7 @@ async function loadAll(){
   });
 
   buildingPropsSelect = buildingProps.map(b => ({ id: b.id, name: b.label || b.type }));
+  infraPropsSelect = infraProps.map(i => ({ id: i.id, name: i.label || i.type }));
   const buildingPropsById = buildingProps.slice().sort((a,b)=>a.id - b.id);
   renderTable(document.getElementById('tableBuildingProps'), buildingPropsById, {
     endpoint:'building_properties',

--- a/gestion.js
+++ b/gestion.js
@@ -79,8 +79,11 @@ async function loadAndRender() {
     const bpMap = Object.fromEntries(allBuildingProps.map(b => [String(b.id), b]));
     const infraProps = allInfraProps.filter(ip => {
       try {
-        const arr = ip.restrictions ? JSON.parse(ip.restrictions) : [];
-        return arr.every(p => baronyProps[p]);
+        const r = ip.restrictions ? JSON.parse(ip.restrictions) : [];
+        if (Array.isArray(r)) {
+          return r.every(p => baronyProps[p]);
+        }
+        return true;
       } catch {
         return true;
       }
@@ -192,11 +195,31 @@ async function loadAndRender() {
               parts.push(`<span${color}>${name}: ${qty}</span>`);
             }
           }
+          if (infraR.infrastructures) {
+            for (const [iid, qty] of Object.entries(infraR.infrastructures)) {
+              const ref = ipMap[String(iid)];
+              const name = ref ? (ref.label || ref.type) : iid;
+              const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+              const ok = builtCount >= qty;
+              if (!ok) restrictionsMet = false;
+              const color = ok ? '' : ' style="color:red"';
+              parts.push(`<span${color}>${name}: ${qty}</span>`);
+            }
+          }
           if (infraR.population) {
             const ok = (s.population || 0) >= infraR.population;
             if (!ok) restrictionsMet = false;
             const color = ok ? '' : ' style="color:red"';
             parts.push(`<span${color}>Population: ${infraR.population}</span>`);
+          }
+          if (infraR.resources) {
+            for (const [res, qty] of Object.entries(infraR.resources)) {
+              const label = resourceLabels[res] || res;
+              const ok = (inv[res] || 0) >= qty;
+              if (!ok) restrictionsMet = false;
+              const color = ok ? '' : ' style="color:red"';
+              parts.push(`<span${color}>${label}: ${qty}</span>`);
+            }
           }
           restrHtml = parts.join('<br>');
         } catch (e) {
@@ -318,7 +341,8 @@ async function handleInfraTableClick(e) {
 }
 
 function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
-  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Coût</th><th>Construire</th></tr>`;
+  const { buildings = {}, infrastructures = {}, s = {}, bpMap = {}, ipMap = {} } = gameState || {};
+  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Restrictions</th><th>Construits</th><th>Coût</th><th>Construire</th></tr>`;
   for (const ip of list) {
     const built = infraBuilt[ip.id] || 0;
     let costHtml = '';
@@ -335,7 +359,54 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
       }
       costHtml = parts.join('<br>');
     } catch {}
-    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${built}</td><td>${costHtml}</td><td><button class="infra-build-btn" data-id="${ip.id}"${hasRes ? '' : ' disabled'}>Construire</button></td></tr>`;
+
+    let restrHtml = '';
+    let restrOk = true;
+    try {
+      const restr = ip.restrictions ? JSON.parse(ip.restrictions) : {};
+      const parts = [];
+      if (restr.buildings) {
+        for (const [bid, qty] of Object.entries(restr.buildings)) {
+          const ref = bpMap[String(bid)];
+          const name = ref ? (ref.label || ref.type) : bid;
+          const builtInfo = buildings[bid] || buildings[String(bid)] || {};
+          const ok = (builtInfo.built || 0) >= qty;
+          if (!ok) restrOk = false;
+          const color = ok ? '' : ' style="color:red"';
+          parts.push(`<span${color}>${name}: ${qty}</span>`);
+        }
+      }
+      if (restr.infrastructures) {
+        for (const [iid, qty] of Object.entries(restr.infrastructures)) {
+          const ref = ipMap[String(iid)];
+          const name = ref ? (ref.label || ref.type) : iid;
+          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const ok = builtCount >= qty;
+          if (!ok) restrOk = false;
+          const color = ok ? '' : ' style="color:red"';
+          parts.push(`<span${color}>${name}: ${qty}</span>`);
+        }
+      }
+      if (restr.population) {
+        const ok = (s.population || 0) >= restr.population;
+        if (!ok) restrOk = false;
+        const color = ok ? '' : ' style="color:red"';
+        parts.push(`<span${color}>Population: ${restr.population}</span>`);
+      }
+      if (restr.resources) {
+        for (const [res, qty] of Object.entries(restr.resources)) {
+          const label = resourceLabels[res] || res;
+          const ok = (inv[res] || 0) >= qty;
+          if (!ok) restrOk = false;
+          const color = ok ? '' : ' style="color:red"';
+          parts.push(`<span${color}>${label}: ${qty}</span>`);
+        }
+      }
+      restrHtml = parts.join('<br>');
+    } catch {}
+
+    const canBuild = hasRes && restrOk;
+    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${restrHtml}</td><td>${built}</td><td>${costHtml}</td><td><button class="infra-build-btn" data-id="${ip.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
   }
   html += '</table>';
   return html;

--- a/server.js
+++ b/server.js
@@ -884,9 +884,16 @@ function canConstruct(db, srow, id, qty, cb){
         }
       }
       const buildings = safeParse(srow.buildings, {});
+      const infrastructures = safeParse(srow.infrastructures, {});
       if (infraReq.buildings) {
         for (const [bid, count] of Object.entries(infraReq.buildings)) {
           const builtCount = buildings[bid] ? (buildings[bid].built || 0) : 0;
+          if (builtCount < count) return cb(new Error('Restriction non satisfaite'));
+        }
+      }
+      if (infraReq.infrastructures) {
+        for (const [iid, count] of Object.entries(infraReq.infrastructures)) {
+          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
           if (builtCount < count) return cb(new Error('Restriction non satisfaite'));
         }
       }
@@ -899,10 +906,15 @@ function canConstruct(db, srow, id, qty, cb){
       if (built + qty > max) return cb(new Error('Limite atteinte'));
       db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
         if (err4) return cb(err4);
+        if (infraReq.resources) {
+          for (const [res, val] of Object.entries(infraReq.resources)) {
+            if ((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+          }
+        }
         for (const [res, val] of Object.entries(costs)) {
           if ((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
         }
-        cb(null, { costs, built, active, buildings });
+        cb(null, { costs, built, active, buildings, infrastructures });
       });
     });
   });
@@ -914,7 +926,7 @@ function canConstructInfra(db, srow, id, qty, cb){
     if(!iprop) return cb(new Error('Type inconnu'));
     if(!srow.baronnie_id) return cb(new Error('Aucune baronnie associée'));
     const costObj = safeParse(iprop.costs, {});
-    const restrictions = safeParse(iprop.restrictions, []);
+    const restrictions = safeParse(iprop.restrictions, {});
     const costs = {};
     Object.entries(costObj).forEach(([res, val]) => { costs[res] = (parseInt(val,10) || 0) * qty; });
     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err2, props) => {
@@ -930,6 +942,39 @@ function canConstructInfra(db, srow, id, qty, cb){
         for(const prop of restrictions){
           if(!barProps[prop]) return cb(new Error('Restriction non satisfaite'));
         }
+      } else {
+        const buildings = safeParse(srow.buildings, {});
+        const infrastructures = safeParse(srow.infrastructures, {});
+        if(restrictions.buildings){
+          for(const [bid, count] of Object.entries(restrictions.buildings)){
+            const builtCount = buildings[bid] ? (buildings[bid].built || 0) : 0;
+            if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
+          }
+        }
+        if(restrictions.infrastructures){
+          for(const [iid, count] of Object.entries(restrictions.infrastructures)){
+            const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+            if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
+          }
+        }
+        if(restrictions.population && (srow.population || 0) < restrictions.population){
+          return cb(new Error('Restriction non satisfaite'));
+        }
+        const built = infrastructures[id] || 0;
+        if(built + qty > max) return cb(new Error('Limite atteinte'));
+        db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
+          if(err3) return cb(err3);
+          if(restrictions.resources){
+            for(const [res, val] of Object.entries(restrictions.resources)){
+              if((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+            }
+          }
+          for(const [res, val] of Object.entries(costs)){
+            if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
+          }
+          cb(null, { costs, built, infrastructures });
+        });
+        return;
       }
       const infrastructures = safeParse(srow.infrastructures, {});
       const built = infrastructures[id] || 0;
@@ -952,7 +997,7 @@ app.post('/api/building', (req,res)=>{
   const qty = parseInt(quantity,10) || 0;
   if(!bId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
   const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     canConstruct(db, srow, bId, qty, (err2, info)=>{
@@ -982,7 +1027,7 @@ app.post('/api/infrastructure', (req,res)=>{
   const qty = parseInt(quantity,10) || 0;
   if(!iId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
   const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     canConstructInfra(db, srow, iId, qty, (err2, info)=>{

--- a/styles.css
+++ b/styles.css
@@ -287,22 +287,26 @@ main {
 }
 
 .cost-row,
-.restriction-row {
+.restriction-row,
+.effect-row {
   display: flex;
   align-items: center;
   gap: 4px;
   margin-bottom: 4px;
 }
 .cost-row select,
-.restriction-row select {
+.restriction-row select,
+.effect-row select {
   flex: 1;
 }
 .cost-row input,
-.restriction-row input {
+.restriction-row input,
+.effect-row input {
   width: 60px;
 }
 .cost-row button,
-.restriction-row button {
+.restriction-row button,
+.effect-row button {
   padding: 0 6px;
 }
 


### PR DESCRIPTION
## Summary
- Add reusable restriction widget shared by building and infrastructure tables
- Introduce dynamic effects editor for infrastructures
- Support infrastructure and resource based restrictions on server and client

## Testing
- `node --check admin.js && node --check server.js && node --check gestion.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f77dcce64832daad1cf074b11bcb8