### PR TITLE
Add absolute restriction handling for infrastructures

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -58,10 +58,10 @@ const buildingPropLabels = {
   max:'Maximum',
   workers_per_building:'Travailleurs/bâtiment',
   absolute_restrictions:'Restrictions absolues',
-  infra_restrictions:'Restrictions infrastructure',
+  infra_restrictions:'Requis',
   description:'Description'
 };
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','restrictions','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
 const infraPropLabels = {
   label:'Nom',
   type:'Type',
@@ -69,7 +69,8 @@ const infraPropLabels = {
   workers_per_building:'Travailleurs/bâtiment',
   effects:'Effets',
   costs:'Coûts',
-  restrictions:'Restrictions',
+  absolute_restrictions:'Restrictions absolues',
+  restrictions:'Requis',
   description:'Description',
 };
 const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];

--- a/gestion.js
+++ b/gestion.js
@@ -77,17 +77,17 @@ async function loadAndRender() {
       }
     });
     const bpMap = Object.fromEntries(allBuildingProps.map(b => [String(b.id), b]));
-    const infraProps = allInfraProps.filter(ip => {
-      try {
-        const r = ip.restrictions ? JSON.parse(ip.restrictions) : [];
-        if (Array.isArray(r)) {
-          return r.every(p => baronyProps[p]);
+      const infraProps = allInfraProps.filter(ip => {
+        try {
+          const arr = ip.absolute_restrictions ? JSON.parse(ip.absolute_restrictions) : [];
+          if (Array.isArray(arr)) {
+            return arr.every(p => baronyProps[p]);
+          }
+          return true;
+        } catch {
+          return true;
         }
-        return true;
-      } catch {
-        return true;
-      }
-    });
+      });
     const ipMap = Object.fromEntries(allInfraProps.map(b => [String(b.id), b]));
 
     gameState = { s, employment, buildings, infrastructures, bpMap, ipMap };
@@ -144,7 +144,7 @@ async function loadAndRender() {
     const freePop = s.population + employment.slaves - employment.employed;
     if (prodDiv) {
       let html = '<table class="admin-table" id="buildingsTable">';
-      html += '<tr><th>Nom</th><th>Production</th><th>Employés</th><th>Restrictions</th><th>Construits</th><th>Max</th><th>Activer</th><th>Prod. Tot.</th><th>Emp. Tot.</th><th>Coût</th><th>Construire</th></tr>';
+      html += '<tr><th>Nom</th><th>Production</th><th>Employés</th><th>Requis</th><th>Construits</th><th>Max</th><th>Activer</th><th>Prod. Tot.</th><th>Emp. Tot.</th><th>Coût</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
         const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
         const prod = bp.production ? `${bp.production} ${prodLabel}` : '';
@@ -345,7 +345,7 @@ async function handleInfraTableClick(e) {
 
 function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
   const { buildings = {}, infrastructures = {}, s = {}, bpMap = {}, ipMap = {} } = gameState || {};
-  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Restrictions</th><th>Coût</th><th>Construire</th></tr>`;
+  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Requis</th><th>Coût</th><th>Construire</th></tr>`;
   for (const ip of list) {
     const built = infraBuilt[ip.id] || 0;
 

--- a/server.js
+++ b/server.js
@@ -232,6 +232,7 @@ CREATE TABLE IF NOT EXISTS infrastructure_properties (
   workers_per_building INTEGER DEFAULT 0,
   effects TEXT,
   costs TEXT,
+  absolute_restrictions TEXT,
   restrictions TEXT,
   description TEXT
 );
@@ -336,6 +337,12 @@ db.exec(initSql, () => {
     }
     if (!rows.some(r => r.name === 'infra_restrictions')) {
       db.run('ALTER TABLE building_properties ADD COLUMN infra_restrictions TEXT');
+    }
+  });
+  db.all("PRAGMA table_info(infrastructure_properties)", (err, rows) => {
+    if (err || !rows) return;
+    if (!rows.some(r => r.name === 'absolute_restrictions')) {
+      db.run('ALTER TABLE infrastructure_properties ADD COLUMN absolute_restrictions TEXT');
     }
   });
   // Ensure every barony has a properties row with default values
@@ -835,7 +842,7 @@ app.put('/api/building_properties/:id', requireAdmin, (req,res)=>{
   update('building_properties', buildingPropFields)(req,res);
 });
 
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','restrictions','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
 app.get('/api/infrastructure_properties', (req,res)=>{
   list('infrastructure_properties')(req,res);
 });
@@ -926,6 +933,7 @@ function canConstructInfra(db, srow, id, qty, cb){
     if(!iprop) return cb(new Error('Type inconnu'));
     if(!srow.baronnie_id) return cb(new Error('Aucune baronnie associée'));
     const costObj = safeParse(iprop.costs, {});
+    const absReq = safeParse(iprop.absolute_restrictions, []);
     const restrictions = safeParse(iprop.restrictions, {});
     const costs = {};
     Object.entries(costObj).forEach(([res, val]) => { costs[res] = (parseInt(val,10) || 0) * qty; });
@@ -938,49 +946,35 @@ function canConstructInfra(db, srow, id, qty, cb){
         if(!isNaN(parsed)) max = parsed;
         else if(barProps[iprop.max] != null) max = barProps[iprop.max];
       }
-      if(Array.isArray(restrictions)){
-        for(const prop of restrictions){
-          if(!barProps[prop]) return cb(new Error('Restriction non satisfaite'));
-        }
-      } else {
-        const buildings = safeParse(srow.buildings, {});
-        const infrastructures = safeParse(srow.infrastructures, {});
-        if(restrictions.buildings){
-          for(const [bid, count] of Object.entries(restrictions.buildings)){
-            const builtCount = buildings[bid] ? (buildings[bid].built || 0) : 0;
-            if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
-          }
-        }
-        if(restrictions.infrastructures){
-          for(const [iid, count] of Object.entries(restrictions.infrastructures)){
-            const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
-            if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
-          }
-        }
-        if(restrictions.population && (srow.population || 0) < restrictions.population){
-          return cb(new Error('Restriction non satisfaite'));
-        }
-        const built = infrastructures[id] || 0;
-        if(built + qty > max) return cb(new Error('Limite atteinte'));
-        db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
-          if(err3) return cb(err3);
-          if(restrictions.resources){
-            for(const [res, val] of Object.entries(restrictions.resources)){
-              if((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
-            }
-          }
-          for(const [res, val] of Object.entries(costs)){
-            if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
-          }
-          cb(null, { costs, built, infrastructures });
-        });
-        return;
+      for(const prop of absReq){
+        if(!barProps[prop]) return cb(new Error('Restriction non satisfaite'));
       }
+      const buildings = safeParse(srow.buildings, {});
       const infrastructures = safeParse(srow.infrastructures, {});
+      if(restrictions.buildings){
+        for(const [bid, count] of Object.entries(restrictions.buildings)){
+          const builtCount = buildings[bid] ? (buildings[bid].built || 0) : 0;
+          if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
+        }
+      }
+      if(restrictions.infrastructures){
+        for(const [iid, count] of Object.entries(restrictions.infrastructures)){
+          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
+        }
+      }
+      if(restrictions.population && (srow.population || 0) < restrictions.population){
+        return cb(new Error('Restriction non satisfaite'));
+      }
       const built = infrastructures[id] || 0;
       if(built + qty > max) return cb(new Error('Limite atteinte'));
       db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
         if(err3) return cb(err3);
+        if(restrictions.resources){
+          for(const [res, val] of Object.entries(restrictions.resources)){
+            if((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+          }
+        }
         for(const [res, val] of Object.entries(costs)){
           if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
         }


### PR DESCRIPTION
## Summary
- add absolute restrictions to infrastructure properties and enforce them server-side
- rename restrictions columns to "Requis" and expose absolute restrictions in admin UI

## Testing
- `node -c admin.js`
- `node -c gestion.js`
- `node -c server.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f7da548d0832d96faf11550cc4978