### PR TITLE
Support building production bonus effects

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -24,7 +24,7 @@ const inventaireLabels = Object.fromEntries([...basicResources, ...luxuryResourc
 const yesNoSelect = [{id:1,name:'Oui'},{id:0,name:'Non'}];
 const baronyPropBoolFields = ['water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin'];
 const baronyPropIntFields = ['field_limit','fishing_limit','high_sea_boat_limit'];
-const baronyPropFields = ['barony_id', ...baronyPropBoolFields, ...baronyPropIntFields];
+const baronyPropFields = ['barony_id', ...baronyPropBoolFields, ...baronyPropIntFields, 'effects'];
 const baronyPropLabels = {
   barony_id:'Baronnie',
   water_access:"Accès à l'eau",
@@ -46,7 +46,8 @@ const baronyPropLabels = {
   has_vin:'Vin',
   field_limit:'Limite de champs',
   fishing_limit:'Limite de Pêche',
-  high_sea_boat_limit:'Limite de Bateau en haute mer'
+  high_sea_boat_limit:'Limite de Bateau en haute mer',
+  effects:'Effets'
 };
 
 const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','description'];
@@ -285,7 +286,8 @@ function makeEffectsInput(val){
     typeSel.appendChild(blank);
     const typeOptions = [
       {id:'storage', name:'Stockage'},
-      {id:'production', name:'Production'}
+      {id:'production', name:'Production ressource'},
+      {id:'building_production', name:'Prod. bâtiment'}
     ];
     typeOptions.forEach(o=>{
       const op = document.createElement('option');
@@ -294,16 +296,34 @@ function makeEffectsInput(val){
       if(o.id === type) op.selected = true;
       typeSel.appendChild(op);
     });
-    const resSel = document.createElement('select');
-    const blankRes = document.createElement('option');
-    blankRes.value = '';
-    resSel.appendChild(blankRes);
-    resourceSelect.forEach(o=>{
-      const op = document.createElement('option');
-      op.value = o.id;
-      op.textContent = o.name;
-      if(String(o.id) === String(data.resource)) op.selected = true;
-      resSel.appendChild(op);
+    const targetSel = document.createElement('select');
+    function populateTarget(){
+      targetSel.innerHTML = '';
+      const blankRes = document.createElement('option');
+      blankRes.value = '';
+      targetSel.appendChild(blankRes);
+      if(typeSel.value === 'building_production'){
+        buildingPropsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.building)) op.selected = true;
+          targetSel.appendChild(op);
+        });
+      }else{
+        resourceSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.resource)) op.selected = true;
+          targetSel.appendChild(op);
+        });
+      }
+    }
+    populateTarget();
+    typeSel.addEventListener('change', ()=>{
+      data = {};
+      populateTarget();
     });
     const qty = document.createElement('input');
     qty.type = 'number';
@@ -314,7 +334,7 @@ function makeEffectsInput(val){
     removeBtn.textContent = '-';
     removeBtn.addEventListener('click', ()=> row.remove());
     row.appendChild(typeSel);
-    row.appendChild(resSel);
+    row.appendChild(targetSel);
     row.appendChild(qty);
     row.appendChild(removeBtn);
     list.appendChild(row);
@@ -323,7 +343,7 @@ function makeEffectsInput(val){
   try{
     const arr = JSON.parse(val || '[]');
     if(Array.isArray(arr) && arr.length){
-      arr.forEach(e=> addRow(e.type, {resource:e.resource, amount:e.amount}));
+      arr.forEach(e=> addRow(e.type, e));
     }else{
       addRow();
     }
@@ -334,10 +354,14 @@ function makeEffectsInput(val){
     const res = [];
     list.querySelectorAll('.effect-row').forEach(rw=>{
       const type = rw.children[0].value;
-      const resource = rw.children[1].value;
+      const target = rw.children[1].value;
       const amt = parseInt(rw.children[2].value,10);
-      if(type && resource && amt){
-        res.push({type, resource, amount: amt});
+      if(type && target && amt){
+        if(type === 'building_production'){
+          res.push({type, building: target, amount: amt});
+        }else{
+          res.push({type, resource: target, amount: amt});
+        }
       }
     });
     return JSON.stringify(res);
@@ -759,6 +783,9 @@ async function loadAll(){
     labels:{name:'Nom', user_id:'Utilisateur', religion_id:'Religion', overlord_id:'Suzerain'}
   });
 
+  buildingPropsSelect = buildingProps.map(b => ({ id: b.id, name: b.label || b.type }));
+  infraPropsSelect = infraProps.map(i => ({ id: i.id, name: i.label || i.type }));
+
   const baronyPropsById = baronyProps.slice().sort((a,b)=>a.id - b.id);
   const boolSelects = {};
   baronyPropBoolFields.forEach(f => { boolSelects[f] = yesNoSelect; });
@@ -768,9 +795,6 @@ async function loadAll(){
     selects:{barony_id:baroniesSelect, ...boolSelects},
     labels:baronyPropLabels
   });
-
-  buildingPropsSelect = buildingProps.map(b => ({ id: b.id, name: b.label || b.type }));
-  infraPropsSelect = infraProps.map(i => ({ id: i.id, name: i.label || i.type }));
   const buildingPropsById = buildingProps.slice().sort((a,b)=>a.id - b.id);
   renderTable(document.getElementById('tableBuildingProps'), buildingPropsById, {
     endpoint:'building_properties',

--- a/effects.js
+++ b/effects.js
@@ -31,4 +31,28 @@ class ResourceProductionEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect };
+class BuildingProductionEffect extends Effect {
+  constructor(building, amount) {
+    super();
+    this.building = building;
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const totalBonus = this.amount * count;
+    if (!ctx.buildingProductionBonus) ctx.buildingProductionBonus = {};
+    ctx.buildingProductionBonus[this.building] = (ctx.buildingProductionBonus[this.building] || 0) + totalBonus;
+    const bp = ctx.bpMap ? ctx.bpMap[String(this.building)] : null;
+    if (!bp || !bp.produces) return;
+    const info = ctx.buildings ? (ctx.buildings[this.building] || ctx.buildings[String(this.building)] || {}) : {};
+    const active = info.active || 0;
+    if (active <= 0) return;
+    const added = totalBonus * active;
+    if (!ctx.production) ctx.production = {};
+    if (!ctx.productionDetails) ctx.productionDetails = {};
+    ctx.production[bp.produces] = (ctx.production[bp.produces] || 0) + added;
+    if (!ctx.productionDetails[bp.produces]) ctx.productionDetails[bp.produces] = [];
+    ctx.productionDetails[bp.produces].push({ label, amount: added, source: count });
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect };

--- a/gestion.js
+++ b/gestion.js
@@ -68,6 +68,7 @@ async function loadAndRender() {
     const buildings = data.buildings || {};
     const infrastructures = data.infrastructures || {};
     const capacities = data.capacities || {};
+    const buildingBonuses = data.buildingProductionBonus || {};
     const buildingProps = allBuildingProps.filter(bp => {
       try {
         const arr = bp.absolute_restrictions ? JSON.parse(bp.absolute_restrictions) : [];
@@ -90,7 +91,7 @@ async function loadAndRender() {
       });
     const ipMap = Object.fromEntries(allInfraProps.map(b => [String(b.id), b]));
 
-    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap };
+    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses };
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -147,7 +148,19 @@ async function loadAndRender() {
       html += '<tr><th>Nom</th><th>Production</th><th>Employés</th><th>Requis</th><th>Construits</th><th>Max</th><th>Activer</th><th>Prod. Tot.</th><th>Emp. Tot.</th><th>Coût</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
         const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
-        const prod = bp.production ? `${bp.production} ${prodLabel}` : '';
+        const baseProd = bp.production || 0;
+        const bonusProd = buildingBonuses[bp.id] || buildingBonuses[String(bp.id)] || 0;
+        let prod = '';
+        if (baseProd || bonusProd) {
+          const per = baseProd + bonusProd;
+          if (bonusProd) {
+            const rows = [`<tr><td>Base</td><td>${spanAmount(baseProd)}</td></tr>`];
+            rows.push(`<tr><td>Bonus</td><td>${spanAmount(bonusProd)}</td></tr>`);
+            prod = `<span class="tooltip">${per} ${prodLabel}<table class="tooltip-table">${rows.join('')}</table></span>`;
+          } else {
+            prod = `${per} ${prodLabel}`;
+          }
+        }
         const info = buildings[bp.id] || { built: 0, active: 0 };
         const built = info.built || 0;
         const active = info.active || 0;
@@ -237,8 +250,18 @@ async function loadAndRender() {
 
         const canBuild = hasResources && restrictionsMet && !maxReached;
 
-        const prodTotal = bp.production ? bp.production * active : 0;
-        const prodTotalHtml = prodTotal ? `${prodTotal} ${prodLabel}` : '';
+        const perProd = baseProd + bonusProd;
+        const prodTotal = perProd * active;
+        let prodTotalHtml = '';
+        if (prodTotal) {
+          if (bonusProd) {
+            const rows = [`<tr><td>Base</td><td>${spanAmount(baseProd * active)}</td></tr>`];
+            rows.push(`<tr><td>Bonus</td><td>${spanAmount(bonusProd * active)}</td></tr>`);
+            prodTotalHtml = `<span class="tooltip">${prodTotal} ${prodLabel}<table class="tooltip-table">${rows.join('')}</table></span>`;
+          } else {
+            prodTotalHtml = `${prodTotal} ${prodLabel}`;
+          }
+        }
         const empTotal = workersPer * active;
 
         html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${workersPer}</td><td>${restrHtml}</td><td>${built}</td><td>${maxVal}</td>`;
@@ -361,20 +384,7 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
       }
     }
 
-    let effectsHtml = '';
-    try {
-      const effects = ip.effects ? JSON.parse(ip.effects) : [];
-      const eParts = [];
-      for (const eff of effects) {
-        const label = resourceLabels[eff.resource] || eff.resource;
-        if (eff.type === 'storage') {
-          eParts.push(`Stockage ${label} +${eff.amount}`);
-        } else if (eff.type === 'production') {
-          eParts.push(`Production ${label} +${eff.amount}`);
-        }
-      }
-      effectsHtml = eParts.join('<br>');
-    } catch {}
+    const effectsHtml = ip.description || '';
 
     let costHtml = '';
     let hasRes = true;

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
-const { StorageEffect, ResourceProductionEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -209,6 +209,7 @@ CREATE TABLE IF NOT EXISTS barony_properties (
   field_limit INTEGER DEFAULT 0,
   fishing_limit INTEGER DEFAULT 0,
   high_sea_boat_limit INTEGER DEFAULT 0,
+  effects TEXT,
   FOREIGN KEY(barony_id) REFERENCES baronies(id)
 );
 CREATE TABLE IF NOT EXISTS building_properties (
@@ -343,6 +344,12 @@ db.exec(initSql, () => {
     if (err || !rows) return;
     if (!rows.some(r => r.name === 'absolute_restrictions')) {
       db.run('ALTER TABLE infrastructure_properties ADD COLUMN absolute_restrictions TEXT');
+    }
+  });
+  db.all("PRAGMA table_info(barony_properties)", (err, rows) => {
+    if (err || !rows) return;
+    if (!rows.some(r => r.name === 'effects')) {
+      db.run('ALTER TABLE barony_properties ADD COLUMN effects TEXT');
     }
   });
   // Ensure every barony has a properties row with default values
@@ -703,6 +710,7 @@ app.get('/api/my_seigneurie', (req, res) => {
               db.all('SELECT id, type, label, produces, production, workers_per_building FROM building_properties', [], (err2, bprops) => {
                 if (err2) return handleError(res, err2);
                 const props = bprops || [];
+                const bpMap = Object.fromEntries(props.map(b => [String(b.id), b]));
                 let fields = { built: 0, active: 0 };
                 const production = {};
                 const productionDetails = {};
@@ -730,6 +738,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (errI) return handleError(res, errI);
                   const infraList = iprops || [];
                   const capacities = { vivres: 500, points_magique: 2000 };
+                  const buildingProductionBonus = {};
                   for (const ip of infraList) {
                     const count = infrastructures[ip.id] || 0;
                     if (!count) continue;
@@ -740,9 +749,11 @@ app.get('/api/my_seigneurie', (req, res) => {
                         effObj = new StorageEffect(def.resource, def.amount || 0);
                       } else if (def.type === 'production') {
                         effObj = new ResourceProductionEffect(def.resource, def.amount || 0);
+                      } else if (def.type === 'building_production') {
+                        effObj = new BuildingProductionEffect(def.building, def.amount || 0);
                       }
                       if (effObj) {
-                        effObj.apply({ production, productionDetails, capacity: capacities }, count, ip.label || ip.type);
+                        effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus }, count, ip.label || ip.type);
                       }
                     }
                   }
@@ -764,14 +775,29 @@ app.get('/api/my_seigneurie', (req, res) => {
                   }
                   const employment = { employed: Math.max(employed - slaves, 0), slaves };
                   function finalize(barony, baronyProps) {
-                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities });
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus });
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
                       if (err3) return handleError(res, err3);
+                      const baronyProps = props || {};
+                      const baronyEffects = safeParse(baronyProps.effects, []);
+                      for (const def of baronyEffects) {
+                        let effObj = null;
+                        if (def.type === 'storage') {
+                          effObj = new StorageEffect(def.resource, def.amount || 0);
+                        } else if (def.type === 'production') {
+                          effObj = new ResourceProductionEffect(def.resource, def.amount || 0);
+                        } else if (def.type === 'building_production') {
+                          effObj = new BuildingProductionEffect(def.building, def.amount || 0);
+                        }
+                        if (effObj) {
+                          effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus }, 1, 'Baronnie');
+                        }
+                      }
                       db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
                         if (err4) return handleError(res, err4);
-                        finalize(barony, props || {});
+                        finalize(barony, baronyProps);
                       });
                     });
                   } else {
@@ -820,7 +846,7 @@ app.delete('/api/baronies/:id', (req,res)=>{
   });
 });
 
-const baronyPropFields = ['barony_id','water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin','field_limit','fishing_limit','high_sea_boat_limit'];
+const baronyPropFields = ['barony_id','water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin','field_limit','fishing_limit','high_sea_boat_limit','effects'];
 app.get('/api/barony_properties', requireAdmin, (req,res)=>{
   list('barony_properties')(req,res);
 });


### PR DESCRIPTION
## Summary
- allow defining building production bonuses as effects
- enable barony properties to carry effects with admin UI
- show composite building production and infrastructure descriptions on management page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8085b1bc832daaafa753a1a4ceda