### PR TITLE
Allow multiline descriptions for building and infrastructure

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -545,6 +545,11 @@ function renderTable(container, rows, opts){
     if(field === 'effects'){
       return makeEffectsInput(val);
     }
+    if(field === 'description'){
+      const textarea = document.createElement('textarea');
+      textarea.value = val ?? '';
+      return textarea;
+    }
     if(opts.selects && opts.selects[field]){
       const select = document.createElement('select');
       let optList = opts.selects[field];
@@ -601,6 +606,8 @@ function renderTable(container, rows, opts){
             payload[f] = el.getValue();
           } else if(opts.selects && opts.selects[f]){
             payload[f] = el.value ? (isNaN(el.value) ? el.value : parseInt(el.value,10)) : null;
+          } else if(f === 'description'){
+            payload[f] = el.value;
           } else {
             payload[f] = el.value.trim();
           }
@@ -636,6 +643,8 @@ function renderTable(container, rows, opts){
           payload[f] = el.getValue();
         } else if(opts.selects && opts.selects[f]){
           payload[f] = el.value ? (isNaN(el.value) ? el.value : parseInt(el.value,10)) : null;
+        } else if(f === 'description'){
+          payload[f] = el.value;
         } else {
           payload[f] = el.value.trim();
         }

--- a/gestion.js
+++ b/gestion.js
@@ -384,7 +384,7 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
       }
     }
 
-    const effectsHtml = ip.description || '';
+    const effectsHtml = (ip.description || '').replace(/\n/g, '<br>');
 
     let costHtml = '';
     let hasRes = true;


### PR DESCRIPTION
## Summary
- Enable multiline description fields in admin via textarea and preserve newlines when saving.
- Render infrastructure descriptions with line breaks in management view.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8389089c832d8ed80f410e43c67b