### PR TITLE
Improve production tooltips and build buttons

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -41,6 +41,9 @@ class BuildingProductionEffect extends Effect {
     const totalBonus = this.amount * count;
     if (!ctx.buildingProductionBonus) ctx.buildingProductionBonus = {};
     ctx.buildingProductionBonus[this.building] = (ctx.buildingProductionBonus[this.building] || 0) + totalBonus;
+    if (!ctx.buildingProductionBonusDetails) ctx.buildingProductionBonusDetails = {};
+    if (!ctx.buildingProductionBonusDetails[this.building]) ctx.buildingProductionBonusDetails[this.building] = [];
+    ctx.buildingProductionBonusDetails[this.building].push({ label, amount: totalBonus, source: count });
     const bp = ctx.bpMap ? ctx.bpMap[String(this.building)] : null;
     if (!bp || !bp.produces) return;
     const info = ctx.buildings ? (ctx.buildings[this.building] || ctx.buildings[String(this.building)] || {}) : {};

--- a/gestion.js
+++ b/gestion.js
@@ -69,6 +69,7 @@ async function loadAndRender() {
     const infrastructures = data.infrastructures || {};
     const capacities = data.capacities || {};
     const buildingBonuses = data.buildingProductionBonus || {};
+    const buildingBonusDetails = data.buildingProductionBonusDetails || {};
     const buildingProps = allBuildingProps.filter(bp => {
       try {
         const arr = bp.absolute_restrictions ? JSON.parse(bp.absolute_restrictions) : [];
@@ -91,7 +92,7 @@ async function loadAndRender() {
       });
     const ipMap = Object.fromEntries(allInfraProps.map(b => [String(b.id), b]));
 
-    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses };
+    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails };
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -149,13 +150,19 @@ async function loadAndRender() {
       for (const bp of buildingProps) {
         const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
         const baseProd = bp.production || 0;
-        const bonusProd = buildingBonuses[bp.id] || buildingBonuses[String(bp.id)] || 0;
+        let bonusProd = buildingBonuses[bp.id] || buildingBonuses[String(bp.id)] || 0;
+        const bonusDetails = buildingBonusDetails[bp.id] || buildingBonusDetails[String(bp.id)] || [];
+        if (!bonusProd && bonusDetails.length) {
+          bonusProd = bonusDetails.reduce((sum, b) => sum + b.amount, 0);
+        }
         let prod = '';
         if (baseProd || bonusProd) {
           const per = baseProd + bonusProd;
           if (bonusProd) {
             const rows = [`<tr><td>Base</td><td>${spanAmount(baseProd)}</td></tr>`];
-            rows.push(`<tr><td>Bonus</td><td>${spanAmount(bonusProd)}</td></tr>`);
+            for (const det of bonusDetails) {
+              rows.push(`<tr><td>${det.label}</td><td>${spanAmount(det.amount)}</td></tr>`);
+            }
             prod = `<span class="tooltip">${per} ${prodLabel}<table class="tooltip-table">${rows.join('')}</table></span>`;
           } else {
             prod = `${per} ${prodLabel}`;
@@ -248,19 +255,13 @@ async function loadAndRender() {
           }
         }
 
-        const canBuild = hasResources && restrictionsMet && !maxReached;
+        const canBuild = hasResources && restrictionsMet;
 
         const perProd = baseProd + bonusProd;
         const prodTotal = perProd * active;
         let prodTotalHtml = '';
         if (prodTotal) {
-          if (bonusProd) {
-            const rows = [`<tr><td>Base</td><td>${spanAmount(baseProd * active)}</td></tr>`];
-            rows.push(`<tr><td>Bonus</td><td>${spanAmount(bonusProd * active)}</td></tr>`);
-            prodTotalHtml = `<span class="tooltip">${prodTotal} ${prodLabel}<table class="tooltip-table">${rows.join('')}</table></span>`;
-          } else {
-            prodTotalHtml = `${prodTotal} ${prodLabel}`;
-          }
+          prodTotalHtml = `${prodTotal} ${prodLabel}`;
         }
         const empTotal = workersPer * active;
 
@@ -275,7 +276,12 @@ async function loadAndRender() {
         } else {
           html += '<td></td>';
         }
-        html += `<td>${prodTotalHtml}</td><td>${empTotal}</td><td>${costHtml}</td><td><button class="build-btn" data-id="${bp.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
+        html += `<td>${prodTotalHtml}</td><td>${empTotal}</td><td>${costHtml}</td>`;
+        if (maxReached) {
+          html += '<td></td></tr>';
+        } else {
+          html += `<td><button class="build-btn" data-id="${bp.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
+        }
       }
       html += '</table>';
       prodDiv.innerHTML = html;
@@ -446,8 +452,13 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
       restrHtml = parts.join('<br>');
     } catch {}
 
-    const canBuild = hasRes && restrOk && !maxReached;
-    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${built}</td><td>${maxVal}</td><td>${effectsHtml}</td><td>${restrHtml}</td><td>${costHtml}</td><td><button class="infra-build-btn" data-id="${ip.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
+    const canBuild = hasRes && restrOk;
+    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${built}</td><td>${maxVal}</td><td>${effectsHtml}</td><td>${restrHtml}</td><td>${costHtml}</td>`;
+    if (maxReached) {
+      html += '<td></td></tr>';
+    } else {
+      html += `<td><button class="build-btn infra-build-btn" data-id="${ip.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
+    }
   }
   html += '</table>';
   return html;

--- a/server.js
+++ b/server.js
@@ -739,6 +739,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                   const infraList = iprops || [];
                   const capacities = { vivres: 500, points_magique: 2000 };
                   const buildingProductionBonus = {};
+                  const buildingProductionBonusDetails = {};
                   for (const ip of infraList) {
                     const count = infrastructures[ip.id] || 0;
                     if (!count) continue;
@@ -753,7 +754,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                         effObj = new BuildingProductionEffect(def.building, def.amount || 0);
                       }
                       if (effObj) {
-                        effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus }, count, ip.label || ip.type);
+                        effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus, buildingProductionBonusDetails }, count, ip.label || ip.type);
                       }
                     }
                   }
@@ -775,7 +776,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                   }
                   const employment = { employed: Math.max(employed - slaves, 0), slaves };
                   function finalize(barony, baronyProps) {
-                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus });
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails });
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
@@ -792,7 +793,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                           effObj = new BuildingProductionEffect(def.building, def.amount || 0);
                         }
                         if (effObj) {
-                          effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus }, 1, 'Baronnie');
+                          effObj.apply({ production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus, buildingProductionBonusDetails }, 1, 'Baronnie');
                         }
                       }
                       db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {


### PR DESCRIPTION
## Summary
- Show bonus source names in production tooltips and simplify total production column
- Disable infrastructure build buttons consistently and hide build buttons at max
- Provide building bonus details from server for accurate tooltip rendering

## Testing
- `node --check server.js`
- `node --check gestion.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f862a302c832dad5e278d6d5f9724