### PR TITLE
Improve production tooltips and merge building bonuses

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -52,9 +52,17 @@ class BuildingProductionEffect extends Effect {
     const added = totalBonus * active;
     if (!ctx.production) ctx.production = {};
     if (!ctx.productionDetails) ctx.productionDetails = {};
-    ctx.production[bp.produces] = (ctx.production[bp.produces] || 0) + added;
-    if (!ctx.productionDetails[bp.produces]) ctx.productionDetails[bp.produces] = [];
-    ctx.productionDetails[bp.produces].push({ label, amount: added, source: count });
+    const res = bp.produces;
+    ctx.production[res] = (ctx.production[res] || 0) + added;
+    if (!ctx.productionDetails[res]) ctx.productionDetails[res] = [];
+    const arr = ctx.productionDetails[res];
+    const buildLabel = bp.label || bp.type;
+    const existing = arr.find(d => d.label === buildLabel);
+    if (existing) {
+      existing.amount += added;
+    } else {
+      arr.push({ label: buildLabel, amount: added, source: active });
+    }
   }
 }
 

--- a/gestion.js
+++ b/gestion.js
@@ -161,7 +161,7 @@ async function loadAndRender() {
           if (bonusProd) {
             const rows = [`<tr><td>Base</td><td>${spanAmount(baseProd)}</td></tr>`];
             for (const det of bonusDetails) {
-              rows.push(`<tr><td>${det.label}</td><td>${spanAmount(det.amount)}</td></tr>`);
+              rows.push(`<tr><td>${formatDetailLabel(det.label)}</td><td>${spanAmount(det.amount)}</td></tr>`);
             }
             prod = `<span class="tooltip">${per} ${prodLabel}<table class="tooltip-table">${rows.join('')}</table></span>`;
           } else {
@@ -475,7 +475,15 @@ function buildTable(list, showMax = false, inv = {}, production = {}, production
       production[key] !== undefined
         ? production[key]
         : details.reduce((sum, s) => sum + s.amount, 0);
-    const prodHtml = total ? spanAmount(total) : '';
+    let prodHtml = '';
+    if (total) {
+      if (details.length) {
+        const rows = details.map(d => `<tr><td>${formatDetailLabel(d.label)}</td><td>${spanAmount(d.amount)}</td></tr>`);
+        prodHtml = `<span class="tooltip">${spanAmount(total)}<table class="tooltip-table">${rows.join('')}</table></span>`;
+      } else {
+        prodHtml = spanAmount(total);
+      }
+    }
     html += `<tr><td>${label}</td><td>${qty}</td><td>${prodHtml}</td>`;
     if (showMax) html += `<td>${capacity[key] !== undefined ? capacity[key] : ''}</td>`;
     html += '</tr>';
@@ -487,6 +495,10 @@ function spanAmount(val) {
   const sign = val > 0 ? '+' : '';
   const cls = val > 0 ? 'prod-positive' : 'prod-negative';
   return `<span class="${cls}">${sign}${val}</span>`;
+}
+
+function formatDetailLabel(label) {
+  return label === 'Baronnie' ? 'Bonus Baronnie' : label;
 }
 
 function formatRestriction(name, qty) {


### PR DESCRIPTION
## Summary
- Show detailed production/consumption tooltips in resource summary
- Merge building production bonuses into their buildings and rename barony bonuses

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f89dce0c8832d98191873daf0157c