### PR TITLE
Implement construction choice & instant production UI

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -466,30 +466,54 @@ function renderTable(container, rows, opts){
       addBtn.type = 'button';
       addBtn.textContent = '+';
       container.appendChild(addBtn);
-      function addRow(res = '', qty = ''){
+      function addRow(res = '', qty = '', opts = []){
         const row = document.createElement('div');
         row.className = 'cost-row';
         const sel = document.createElement('select');
         const blank = document.createElement('option');
         blank.value = '';
         sel.appendChild(blank);
-        Object.entries(inventaireLabels).forEach(([k,l])=>{
+        resourceSelect.forEach(o=>{
           const op = document.createElement('option');
-          op.value = k;
-          op.textContent = l;
-          if(k === res) op.selected = true;
+          op.value = o.id;
+          op.textContent = o.name;
+          if(o.id === res) op.selected = true;
           sel.appendChild(op);
         });
         const qtyInput = document.createElement('input');
         qtyInput.type = 'number';
         qtyInput.min = '0';
         qtyInput.value = qty;
+        const choiceDiv = document.createElement('div');
+        const choiceList = document.createElement('div');
+        choiceDiv.appendChild(choiceList);
+        const addChoiceBtn = document.createElement('button');
+        addChoiceBtn.type = 'button';
+        addChoiceBtn.textContent = '+';
+        choiceDiv.appendChild(addChoiceBtn);
+        function addChoice(val=''){
+          const rw = document.createElement('div');
+          const s = document.createElement('select');
+          const bl = document.createElement('option');
+          bl.value=''; s.appendChild(bl);
+          resourceSelect.filter(r=>r.id!=='choice').forEach(o=>{
+            const op=document.createElement('option');
+            op.value=o.id; op.textContent=o.name; if(o.id===val) op.selected=true; s.appendChild(op);
+          });
+          const rm=document.createElement('button'); rm.type='button'; rm.textContent='-'; rm.addEventListener('click',()=>rw.remove());
+          rw.appendChild(s); rw.appendChild(rm); choiceList.appendChild(rw);
+        }
+        addChoiceBtn.addEventListener('click',()=>addChoice());
+        if(opts.length){ opts.forEach(o=>addChoice(o)); } else { addChoice(); }
+        choiceDiv.style.display = res==='choice' ? '' : 'none';
+        sel.addEventListener('change',()=>{ choiceDiv.style.display = sel.value==='choice'? '' : 'none'; });
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
         removeBtn.textContent = '-';
         removeBtn.addEventListener('click', ()=> row.remove());
         row.appendChild(sel);
         row.appendChild(qtyInput);
+        row.appendChild(choiceDiv);
         row.appendChild(removeBtn);
         list.appendChild(row);
       }
@@ -498,7 +522,13 @@ function renderTable(container, rows, opts){
         const obj = JSON.parse(val || '{}');
         const entries = Object.entries(obj);
         if(entries.length){
-          entries.forEach(([r,q])=> addRow(r,q));
+          entries.forEach(([r,q])=>{
+            if(r==='choice' && q && q.options){
+              addRow('choice', q.amount || '', q.options);
+            } else {
+              addRow(r,q);
+            }
+          });
         } else {
           addRow();
         }
@@ -509,8 +539,14 @@ function renderTable(container, rows, opts){
         const res = {};
         list.querySelectorAll('.cost-row').forEach(rw=>{
           const k = rw.querySelector('select').value;
-          const q = parseInt(rw.querySelector('input').value,10);
-          if(k && q) res[k] = q;
+          const q = parseInt(rw.querySelector('input[type="number"]').value,10);
+          if(k === 'choice'){
+            const opts = [];
+            rw.querySelectorAll('div select').forEach(s=>{ if(s.value) opts.push(s.value); });
+            if(opts.length && q) res.choice = { options: opts, amount: q };
+          } else if(k && q){
+            res[k] = q;
+          }
         });
         return JSON.stringify(res);
       };
@@ -578,9 +614,10 @@ function renderTable(container, rows, opts){
       return textarea;
     }
     if(opts.selects && opts.selects[field]){
-      const select = document.createElement('select');
       let optList = opts.selects[field];
       if (typeof optList === 'function') optList = optList(item);
+      const container = document.createElement('div');
+      const select = document.createElement('select');
       const blank = document.createElement('option');
       blank.value = '';
       if (opts.nullLabels && opts.nullLabels[field]) {
@@ -589,14 +626,61 @@ function renderTable(container, rows, opts){
         blank.textContent = '';
       }
       select.appendChild(blank);
+      let choiceOpts = [];
+      let selectedVal = val;
+      if(typeof val === 'string'){ try{ const obj = JSON.parse(val); if(obj && obj.choice){ selectedVal = 'choice'; choiceOpts = obj.choice; } }catch{} }
       optList.forEach(o=>{
         const op = document.createElement('option');
         op.value = o.id;
         op.textContent = o.name;
-        if(String(o.id) === String(val)) op.selected = true;
+        if(String(o.id) === String(selectedVal)) op.selected = true;
         select.appendChild(op);
       });
-      return select;
+      container.appendChild(select);
+      const choiceDiv = document.createElement('div');
+      choiceDiv.style.display = select.value === 'choice' ? '' : 'none';
+      const choiceList = document.createElement('div');
+      choiceDiv.appendChild(choiceList);
+      const addChoiceBtn = document.createElement('button');
+      addChoiceBtn.type = 'button';
+      addChoiceBtn.textContent = '+';
+      choiceDiv.appendChild(addChoiceBtn);
+      function addChoiceRow(val=''){
+        const row = document.createElement('div');
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        resourceSelect.filter(r=>r.id!=='choice').forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(o.id===val) op.selected = true;
+          sel.appendChild(op);
+        });
+        const rm = document.createElement('button');
+        rm.type = 'button';
+        rm.textContent = '-';
+        rm.addEventListener('click',()=>row.remove());
+        row.appendChild(sel);
+        row.appendChild(rm);
+        choiceList.appendChild(row);
+      }
+      addChoiceBtn.addEventListener('click',()=>addChoiceRow());
+      if(choiceOpts.length){ choiceOpts.forEach(r=>addChoiceRow(r)); } else { addChoiceRow(); }
+      container.appendChild(choiceDiv);
+      select.addEventListener('change',()=>{
+        choiceDiv.style.display = select.value === 'choice' ? '' : 'none';
+      });
+      container.getValue = ()=>{
+        if(select.value === 'choice'){
+          const opts = [];
+          choiceList.querySelectorAll('select').forEach(s=>{ if(s.value) opts.push(s.value); });
+          return JSON.stringify({choice:opts});
+        }
+        return select.value ? (isNaN(select.value) ? select.value : parseInt(select.value,10)) : null;
+      };
+      return container;
     }
     if(opts.colorFields && opts.colorFields.includes(field)){
       const input = document.createElement('input');

--- a/gestion.js
+++ b/gestion.js
@@ -148,7 +148,25 @@ async function loadAndRender() {
       let html = '<table class="admin-table" id="buildingsTable">';
       html += '<tr><th>Nom</th><th>Production</th><th>Employés</th><th>Requis</th><th>Construits</th><th>Max</th><th>Activer</th><th>Prod. Tot.</th><th>Emp. Tot.</th><th>Coût</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
-        const prodLabel = resourceLabels[bp.produces] || bp.produces || '';
+        let prodLabel = '';
+        let prodChoices = [];
+        if (bp.produces) {
+          try {
+            const obj = JSON.parse(bp.produces);
+            if (obj && obj.choice) {
+              prodChoices = obj.choice;
+              prodLabel = 'Choix';
+            } else {
+              prodLabel = resourceLabels[bp.produces] || bp.produces || '';
+            }
+          } catch {
+            prodLabel = resourceLabels[bp.produces] || bp.produces || '';
+          }
+        }
+        const info = buildings[bp.id] || { built: 0, active: 0 };
+        if (prodChoices.length && info.produces) {
+          prodLabel = resourceLabels[info.produces] || info.produces;
+        }
         const baseProd = bp.production || 0;
         let bonusProd = buildingBonuses[bp.id] || buildingBonuses[String(bp.id)] || 0;
         const bonusDetails = buildingBonusDetails[bp.id] || buildingBonusDetails[String(bp.id)] || [];
@@ -168,7 +186,6 @@ async function loadAndRender() {
             prod = `${per} ${prodLabel}`;
           }
         }
-        const info = buildings[bp.id] || { built: 0, active: 0 };
         const built = info.built || 0;
         const active = info.active || 0;
         const workersPer = bp.workers_per_building || 0;
@@ -220,7 +237,8 @@ async function loadAndRender() {
             for (const [iid, qty] of Object.entries(infraR.infrastructures)) {
               const ref = ipMap[String(iid)];
               const name = ref ? (ref.label || ref.type) : iid;
-              const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+              const entry = infrastructures[iid] || infrastructures[String(iid)] || 0;
+              const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
               const ok = builtCount >= qty;
               if (!ok) restrictionsMet = false;
               const color = ok ? '' : ' style="color:red"';
@@ -315,10 +333,26 @@ async function handleBuildingTableClick(e) {
   const table = document.getElementById('buildingsTable');
   if (e.target.classList.contains('build-btn')) {
     const id = e.target.dataset.id;
+    const bp = gameState.bpMap[id];
+    let payload = { id, quantity: 1 };
+    if (bp && bp.produces) {
+      try {
+        const obj = JSON.parse(bp.produces);
+        if (obj && obj.choice) {
+          const info = gameState.buildings[id] || { built: 0 };
+          if (!info.built) {
+            const labelOpts = obj.choice.map(r => resourceLabels[r] || r).join('/');
+            const sel = prompt(`Choisissez la ressource produite: ${labelOpts}`);
+            if (!sel || !obj.choice.includes(sel)) return;
+            payload.props = { produces: sel };
+          }
+        }
+      } catch {}
+    }
     const resp = await fetch('/api/building', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, quantity: 1 })
+      body: JSON.stringify(payload)
     });
     if (resp.ok) {
       await loadAndRender();
@@ -369,6 +403,22 @@ async function handleInfraTableClick(e) {
     } else {
       alert('Construction impossible');
     }
+  } else if (e.target.classList.contains('instant-btn')) {
+    const id = e.target.dataset.id;
+    const idx = e.target.dataset.idx;
+    const row = e.target.closest('tr');
+    const nb = parseInt(row.querySelector('.inst-nb').value,10) || 0;
+    if(nb <= 0) return;
+    const resp = await fetch('/api/infrastructure/instant_production', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, index: idx, quantity: nb })
+    });
+    if(resp.ok){
+      await loadAndRender();
+    }else{
+      alert('Conversion impossible');
+    }
   }
 }
 
@@ -376,7 +426,8 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
   const { buildings = {}, infrastructures = {}, s = {}, bpMap = {}, ipMap = {} } = gameState || {};
   let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Requis</th><th>Coût</th><th>Construire</th></tr>`;
   for (const ip of list) {
-    const built = infraBuilt[ip.id] || 0;
+    const entry = infraBuilt[ip.id] || infraBuilt[String(ip.id)] || 0;
+    const built = typeof entry === 'object' ? (entry.built || 0) : entry;
 
     let maxVal = '';
     let maxReached = false;
@@ -427,7 +478,8 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
         for (const [iid, qty] of Object.entries(restr.infrastructures)) {
           const ref = ipMap[String(iid)];
           const name = ref ? (ref.label || ref.type) : iid;
-          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const entry = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
           const ok = builtCount >= qty;
           if (!ok) restrOk = false;
           const color = ok ? '' : ' style="color:red"';
@@ -459,9 +511,43 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
     } else {
       html += `<td><button class="build-btn infra-build-btn" data-id="${ip.id}"${canBuild ? '' : ' disabled'}>Construire</button></td></tr>`;
     }
+
+    let instantRows = '';
+    try {
+      const effects = ip.effects ? JSON.parse(ip.effects) : [];
+      const inst = effects.filter(e => e.type === 'instant_production');
+      inst.forEach((eff, idx) => {
+        const entry = infraBuilt[ip.id] || infraBuilt[String(ip.id)] || {};
+        const remainKey = `effect_${idx}_remaining`;
+        const remaining = entry[remainKey] || 0;
+        const label = resourceLabels[eff.resource] || eff.resource;
+        const baseCosts = eff.costs || {};
+        const costStr = Object.entries(baseCosts).map(([r,a])=>{
+          const lbl = resourceLabels[r] || r; return `${lbl}: ${a*remaining}`; }).join(', ');
+        instantRows += `<tr class="instant-prod-row" data-id="${ip.id}" data-idx="${idx}"><td></td><td colspan="6"><table class="admin-table"><tr><th>Production</th><th>Restant</th><th>Nb</th><th>Coût total</th><th>Convertir</th></tr><tr><td class="prod-cell" data-base="${eff.amount}" data-res="${eff.resource}">${eff.amount} ${label}</td><td class="rem-cell">${remaining}</td><td><input type="number" class="inst-nb" min="1" max="${remaining}" value="${remaining}" oninput="updateInstantCost(this)"></td><td class="cost-cell" data-costs='${JSON.stringify(baseCosts)}'>${costStr}</td><td><button class="instant-btn" data-id="${ip.id}" data-idx="${idx}">Convertir</button></td></tr></table></td></tr>`;
+      });
+    } catch {}
+    html += instantRows;
   }
   html += '</table>';
   return html;
+}
+
+function updateInstantCost(el){
+  const tr = el.closest('tr');
+  const costCell = tr.querySelector('.cost-cell');
+  const base = JSON.parse(costCell.dataset.costs || '{}');
+  const nb = parseInt(el.value,10) || 0;
+  const parts = [];
+  for(const [r,a] of Object.entries(base)){
+    const label = resourceLabels[r] || r;
+    parts.push(`${label}: ${a*nb}`);
+  }
+  costCell.textContent = parts.join(', ');
+  const prodCell = tr.querySelector('.prod-cell');
+  const amount = parseInt(prodCell.dataset.base,10) || 0;
+  const res = resourceLabels[prodCell.dataset.res] || prodCell.dataset.res;
+  prodCell.textContent = `${amount*nb} ${res}`;
 }
 
 function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}) {

--- a/server.js
+++ b/server.js
@@ -727,11 +727,20 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (bp.type === 'field') {
                     fields = info;
                   }
-                  if (active > 0 && bp.produces && bp.production) {
+                  let prodRes = bp.produces;
+                  if (prodRes) {
+                    try {
+                      const obj = JSON.parse(prodRes);
+                      if (obj && obj.choice) {
+                        prodRes = info.produces;
+                      }
+                    } catch {}
+                  }
+                  if (active > 0 && prodRes && bp.production) {
                     const amount = active * bp.production;
-                    production[bp.produces] = (production[bp.produces] || 0) + amount;
-                    if (!productionDetails[bp.produces]) productionDetails[bp.produces] = [];
-                    productionDetails[bp.produces].push({ label: bp.label || bp.type, amount, source: active });
+                    production[prodRes] = (production[prodRes] || 0) + amount;
+                    if (!productionDetails[prodRes]) productionDetails[prodRes] = [];
+                    productionDetails[prodRes].push({ label: bp.label || bp.type, amount, source: active });
                   }
                 }
                 db.all('SELECT * FROM infrastructure_properties', [], (errI, iprops) => {
@@ -741,7 +750,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                   const buildingProductionBonus = {};
                   const buildingProductionBonusDetails = {};
                   for (const ip of infraList) {
-                    const count = infrastructures[ip.id] || 0;
+                    const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
+                    const count = typeof entry === 'object' ? (entry.built || 0) : entry;
                     if (!count) continue;
                     const effects = safeParse(ip.effects, []);
                     for (const def of effects) {
@@ -927,7 +937,8 @@ function canConstruct(db, srow, id, qty, cb){
       }
       if (infraReq.infrastructures) {
         for (const [iid, count] of Object.entries(infraReq.infrastructures)) {
-          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const entry = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
           if (builtCount < count) return cb(new Error('Restriction non satisfaite'));
         }
       }
@@ -962,6 +973,7 @@ function canConstructInfra(db, srow, id, qty, cb){
     const costObj = safeParse(iprop.costs, {});
     const absReq = safeParse(iprop.absolute_restrictions, []);
     const restrictions = safeParse(iprop.restrictions, {});
+    const effects = safeParse(iprop.effects, []);
     const costs = {};
     Object.entries(costObj).forEach(([res, val]) => { costs[res] = (parseInt(val,10) || 0) * qty; });
     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err2, props) => {
@@ -986,14 +998,16 @@ function canConstructInfra(db, srow, id, qty, cb){
       }
       if(restrictions.infrastructures){
         for(const [iid, count] of Object.entries(restrictions.infrastructures)){
-          const builtCount = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const entry = infrastructures[iid] || infrastructures[String(iid)] || 0;
+          const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
           if(builtCount < count) return cb(new Error('Restriction non satisfaite'));
         }
       }
       if(restrictions.population && (srow.population || 0) < restrictions.population){
         return cb(new Error('Restriction non satisfaite'));
       }
-      const built = infrastructures[id] || 0;
+      const entry = infrastructures[id] || infrastructures[String(id)] || 0;
+      const built = typeof entry === 'object' ? (entry.built || 0) : entry;
       if(built + qty > max) return cb(new Error('Limite atteinte'));
       db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
         if(err3) return cb(err3);
@@ -1005,7 +1019,7 @@ function canConstructInfra(db, srow, id, qty, cb){
         for(const [res, val] of Object.entries(costs)){
           if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
         }
-        cb(null, { costs, built, infrastructures });
+        cb(null, { costs, built, infrastructures, effects });
       });
     });
   });
@@ -1013,7 +1027,7 @@ function canConstructInfra(db, srow, id, qty, cb){
 
 app.post('/api/building', (req,res)=>{
   if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
-  const { id, quantity } = req.body;
+  const { id, quantity, props } = req.body;
   const bId = parseInt(id,10);
   const qty = parseInt(quantity,10) || 0;
   if(!bId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
@@ -1028,7 +1042,8 @@ app.post('/api/building', (req,res)=>{
         const newBuilt = info.built + qty;
         const newActive = info.active + qty;
         const buildings = info.buildings;
-        buildings[bId] = { built: newBuilt, active: newActive };
+        const existing = buildings[bId] || {};
+        buildings[bId] = { built: newBuilt, active: newActive, ...existing, ...(props || {}) };
         db.run('UPDATE seigneuries SET buildings=? WHERE id=?', [JSON.stringify(buildings), srow.id], function(err4){
           if(err4) return handleError(res, err4);
           db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inventaire)=>{
@@ -1043,7 +1058,7 @@ app.post('/api/building', (req,res)=>{
 
 app.post('/api/infrastructure', (req,res)=>{
   if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
-  const { id, quantity } = req.body;
+  const { id, quantity, props } = req.body;
   const iId = parseInt(id,10);
   const qty = parseInt(quantity,10) || 0;
   if(!iId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
@@ -1057,7 +1072,14 @@ app.post('/api/infrastructure', (req,res)=>{
         if(err3) return handleError(res, err3);
         const newBuilt = info.built + qty;
         const infrastructures = info.infrastructures;
-        infrastructures[iId] = newBuilt;
+        const existing = infrastructures[iId] || {};
+        const uses = {};
+        (info.effects || []).forEach((eff, idx) => {
+          if (eff.type === 'instant_production' && eff.uses_per_month != null) {
+            uses[`effect_${idx}_remaining`] = eff.uses_per_month;
+          }
+        });
+        infrastructures[iId] = { built: newBuilt, ...existing, ...uses, ...(props || {}) };
         db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?', [JSON.stringify(infrastructures), srow.id], function(err4){
           if(err4) return handleError(res, err4);
           db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inventaire)=>{
@@ -1108,6 +1130,58 @@ app.post('/api/building/activate', (req,res)=>{
         db.run('UPDATE seigneuries SET buildings=? WHERE id=?', [JSON.stringify(buildings), srow.id], function(err4){
           if(err4) return handleError(res, err4);
           res.json({ building: { id, built, active: qty }, employment, employmentDetails });
+        });
+      });
+    });
+  });
+});
+
+app.post('/api/infrastructure/instant_production', (req,res)=>{
+  if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const { id, index, quantity } = req.body;
+  const iId = parseInt(id,10);
+  const idx = parseInt(index,10);
+  const qty = parseInt(quantity,10) || 0;
+  if(!iId || isNaN(idx) || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
+  const userId = req.session.user.id;
+  db.get('SELECT seigneuries.id as id, seigneuries.inventaire_id, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
+    if(err) return handleError(res, err);
+    if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    db.get('SELECT effects FROM infrastructure_properties WHERE id=?', [iId], (err2, iprop) => {
+      if(err2) return handleError(res, err2);
+      const effects = safeParse(iprop ? iprop.effects : '[]', []);
+      const eff = effects[idx];
+      if(!eff || eff.type !== 'instant_production') return res.status(400).json({ error: 'Effet introuvable' });
+      const infra = safeParse(srow.infrastructures, {});
+      const entry = infra[iId] || infra[String(iId)] || {};
+      const key = `effect_${idx}_remaining`;
+      const remaining = entry[key] || 0;
+      if(qty > remaining) return res.status(400).json({ error: 'Utilisations insuffisantes' });
+      const totalCosts = {};
+      const costObj = eff.costs || {};
+      for(const [resName, amt] of Object.entries(costObj)){
+        totalCosts[resName] = (parseInt(amt,10) || 0) * qty;
+      }
+      db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
+        if(err3) return handleError(res, err3);
+        for(const [resName, amt] of Object.entries(totalCosts)){
+          if((inv[resName] || 0) < amt) return res.status(400).json({ error: 'Ressources insuffisantes' });
+        }
+        consumeResources(db, srow.id, totalCosts, err4 => {
+          if(err4) return handleError(res, err4);
+          const amount = (parseInt(eff.amount,10) || 0) * qty;
+          performTransaction(db, srow.id, eff.resource, amount, err5 => {
+            if(err5) return handleError(res, err5);
+            entry[key] = remaining - qty;
+            infra[iId] = entry;
+            db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?', [JSON.stringify(infra), srow.id], function(err6){
+              if(err6) return handleError(res, err6);
+              db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err7, inventaire)=>{
+                if(err7) return handleError(res, err7);
+                res.json({ infrastructures: infra, inventaire });
+              });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
## Summary
- allow resource dropdowns to define construction choices
- prompt for resource choice when constructing buildings
- display and trigger instant production effects on infrastructures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f960ac148832dbdd833be767c8308