### PR TITLE
Adjust resource summary tooltip and rename tab

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -15,13 +15,13 @@
   <main class="gestion-main">
     <div class="tab-container" style="overflow:auto;flex:1">
       <div class="tab-buttons">
-        <button class="tab-btn active" data-tab="ressources">Ressources</button>
+        <button class="tab-btn active" data-tab="sommaire">Sommaire</button>
         <button class="tab-btn" data-tab="infra">Infrastructures Civiles</button>
         <button class="tab-btn" data-tab="infraMili">Infrastructures Militaires</button>
         <button class="tab-btn" data-tab="proprietes">Propriétés</button>
       </div>
       <div class="tab-panels">
-        <div id="tab-ressources" class="tab-panel active">
+        <div id="tab-sommaire" class="tab-panel active">
           <div id="summary"></div>
         </div>
         <div id="tab-infra" class="tab-panel">
@@ -49,7 +49,7 @@
       let savedTab = localStorage.getItem('gestionActiveTab');
       const availableTabs = Array.from(buttons).map(btn => btn.dataset.tab);
       if (!savedTab || !availableTabs.includes(savedTab)) {
-        savedTab = 'ressources';
+        savedTab = 'sommaire';
       }
 
       buttons.forEach(btn => {

--- a/gestion.js
+++ b/gestion.js
@@ -465,21 +465,61 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
 }
 
 function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}) {
+  const {
+    buildings = {},
+    bpMap = {},
+    buildingBonuses = {},
+    buildingBonusDetails = {}
+  } = gameState;
+
+  const buildingLabelSet = new Set(Object.values(bpMap).map(bp => bp.label || bp.type));
+  const bonusSourceLabels = new Set();
+  for (const arr of Object.values(buildingBonusDetails)) {
+    for (const det of arr) bonusSourceLabels.add(det.label);
+  }
+
+  const buildingContribs = {};
+  for (const [id, bp] of Object.entries(bpMap)) {
+    const res = bp.produces;
+    if (!res) continue;
+    const info = buildings[id] || buildings[String(id)] || {};
+    const active = info.active || 0;
+    if (!active) continue;
+    const base = bp.production || 0;
+    let bonus = buildingBonuses[id] || buildingBonuses[String(id)] || 0;
+    const bonusDetails = buildingBonusDetails[id] || buildingBonusDetails[String(id)] || [];
+    if (!bonus && bonusDetails.length) {
+      bonus = bonusDetails.reduce((sum, b) => sum + b.amount, 0);
+    }
+    const per = base + bonus;
+    if (!per) continue;
+    const amount = per * active;
+    const lbl = `${active} ${bp.label || bp.type}`;
+    if (!buildingContribs[res]) buildingContribs[res] = [];
+    buildingContribs[res].push({ label: lbl, amount });
+  }
+
   let html = '<tr><th>Ressource</th><th>Quantité</th><th>Production</th>';
   if (showMax) html += '<th>Maximum</th>';
   html += '</tr>';
   for (const [key, label] of list) {
     const qty = inv[key] ?? 0;
     const details = productionDetails[key] || [];
+    const rows = [];
+    if (buildingContribs[key]) rows.push(...buildingContribs[key]);
+    for (const d of details) {
+      if (buildingLabelSet.has(d.label) || bonusSourceLabels.has(d.label)) continue;
+      rows.push({ label: formatDetailLabel(d.label), amount: d.amount });
+    }
     const total =
       production[key] !== undefined
         ? production[key]
-        : details.reduce((sum, s) => sum + s.amount, 0);
+        : rows.reduce((sum, s) => sum + s.amount, 0);
     let prodHtml = '';
     if (total) {
-      if (details.length) {
-        const rows = details.map(d => `<tr><td>${formatDetailLabel(d.label)}</td><td>${spanAmount(d.amount)}</td></tr>`);
-        prodHtml = `<span class="tooltip">${spanAmount(total)}<table class="tooltip-table">${rows.join('')}</table></span>`;
+      if (rows.length) {
+        const tableRows = rows.map(r => `<tr><td>${r.label}</td><td>${spanAmount(r.amount)}</td></tr>`);
+        prodHtml = `<span class="tooltip">${spanAmount(total)}<table class="tooltip-table">${tableRows.join('')}</table></span>`;
       } else {
         prodHtml = spanAmount(total);
       }


### PR DESCRIPTION
## Summary
- Rename "Ressources" tab to "Sommaire" in management page
- Exclude bonus-providing infrastructures from resource production tooltips and aggregate with producing buildings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f959cd400832d8accdc9e262f96c6