### PR TITLE
Handle unlimited building and infrastructure limits

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -191,12 +191,13 @@ async function loadAndRender() {
         const workersPer = bp.workers_per_building || 0;
 
         let maxVal = '';
-        if (bp.max !== undefined && bp.max !== null) {
+        if (bp.max !== undefined && bp.max !== null && bp.max !== '') {
           const parsed = parseInt(bp.max, 10);
-          if (!isNaN(parsed)) {
+          if (!isNaN(parsed) && parsed > 0) {
             maxVal = parsed;
           } else if (baronyProps[bp.max] !== undefined) {
-            maxVal = baronyProps[bp.max];
+            const dyn = parseInt(baronyProps[bp.max], 10);
+            if (!isNaN(dyn) && dyn > 0) maxVal = dyn;
           }
         }
 
@@ -431,11 +432,13 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
 
     let maxVal = '';
     let maxReached = false;
-    if (ip.max !== undefined && ip.max !== null) {
+    if (ip.max !== undefined && ip.max !== null && ip.max !== '') {
       const parsed = parseInt(ip.max, 10);
       if (!isNaN(parsed)) {
-        maxVal = parsed;
-        if (built >= parsed) maxReached = true;
+        if (parsed > 0) {
+          maxVal = parsed;
+          if (built >= parsed) maxReached = true;
+        }
       } else {
         maxVal = ip.max;
       }

--- a/server.js
+++ b/server.js
@@ -914,12 +914,13 @@ function canConstruct(db, srow, id, qty, cb){
       if (err2) return cb(err2);
       const barProps = props || {};
       let max = Infinity;
-      if (bprops.max != null) {
+      if (bprops.max != null && bprops.max !== '') {
         const parsed = parseInt(bprops.max, 10);
-        if (!isNaN(parsed)) {
+        if (!isNaN(parsed) && parsed > 0) {
           max = parsed;
         } else if (barProps[bprops.max] != null) {
-          max = barProps[bprops.max];
+          const dyn = parseInt(barProps[bprops.max], 10);
+          if (!isNaN(dyn) && dyn > 0) max = dyn;
         }
       }
       if (Array.isArray(absReq)) {
@@ -980,10 +981,14 @@ function canConstructInfra(db, srow, id, qty, cb){
       if(err2) return cb(err2);
       const barProps = props || {};
       let max = Infinity;
-      if(iprop.max != null){
-        const parsed = parseInt(iprop.max,10);
-        if(!isNaN(parsed)) max = parsed;
-        else if(barProps[iprop.max] != null) max = barProps[iprop.max];
+      if (iprop.max != null && iprop.max !== '') {
+        const parsed = parseInt(iprop.max, 10);
+        if (!isNaN(parsed) && parsed > 0) {
+          max = parsed;
+        } else if (barProps[iprop.max] != null) {
+          const dyn = parseInt(barProps[iprop.max], 10);
+          if (!isNaN(dyn) && dyn > 0) max = dyn;
+        }
       }
       for(const prop of absReq){
         if(!barProps[prop]) return cb(new Error('Restriction non satisfaite'));


### PR DESCRIPTION
## Summary
- Treat empty or zero `max` values as unlimited on the server
- Skip max checks on the client when limit is zero or missing so builds remain possible

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ff45b0f78832d8d0c0b240e0b3891