### PR TITLE
Ensure multi-col column content is visible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -274,8 +274,11 @@ main {
 .multi-col {
   padding-left: 10px;
   vertical-align: top;
-  display: none;
   border: none !important;
+}
+
+th.multi-col {
+  display: none;
 }
 
 .instant-prod-table {


### PR DESCRIPTION
## Summary
- Show content for the `multi-col` table column by removing `display:none` from cells
- Hide only the header cell for `multi-col` to keep table layout while keeping contents visible

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ff4cad288832d9cbf253867485823