### PR TITLE
Persist sessions across restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bcryptjs": "^2.4.3",
     "express": "^4.19.2",
     "express-session": "^1.17.3",
+    "connect-sqlite3": "^0.9.0",
     "sqlite3": "^5.1.6",
     "winston": "^3.17.0"
   }

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const sqlite3 = require('sqlite3');
 const zlib = require('zlib');
 const path = require('path');
 const session = require('express-session');
+const SQLiteStore = require('connect-sqlite3')(session);
 const bcrypt = require('bcryptjs');
 const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
@@ -377,10 +378,12 @@ if (!sessionSecret) {
   logger.warn('SESSION_SECRET environment variable not set; using fallback secret');
 }
 app.use(session({
+  store: new SQLiteStore({ db: 'sessions.db', dir: '.' }),
   secret: sessionSecret || 'dev-secret',
   resave: false,
   saveUninitialized: false,
   cookie: {
+    maxAge: 30 * 24 * 60 * 60 * 1000,
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict'


### PR DESCRIPTION
## Summary
- Store sessions in SQLite and set long-lived cookies to keep users logged in after server restarts
- Add `connect-sqlite3` dependency for persistent session storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/connect-sqlite3)*
- `node server.js` *(fails: Cannot find module 'connect-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68a2842ecbd4832da7781d25694c496d