### PR TITLE
feat: add barony connections and distance filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
         <option value="kingdom_defacto">Royaume de facto</option>
         <option value="empire">Empire de jure</option>
         <option value="empire_defacto">Empire de facto</option>
+        <option value="distance">Distance</option>
         <option value="occupation">Occupation</option>
       </select>
       <span id="authArea" class="auth-area"></span>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -30,12 +30,15 @@
         <option value="kingdom">Royaume de jure</option>
         <option value="kingdom_defacto">Royaume de facto</option>
         <option value="empire">Empire</option>
+        <option value="distance">Distance</option>
         <option value="occupation">Occupation</option>
       </select>
       <button id="saveToFile" class="control-btn">Enregistrer</button>
       <button id="deleteBarony" class="control-btn">Supprimer</button>
       <button id="toggleMap" class="control-btn">Changer fond</button>
       <button id="selectBarony" class="control-btn">Sélectionner</button>
+      <button id="linkBarony" class="control-btn">Lier</button>
+      <button id="unlinkBarony" class="control-btn">Délier</button>
       <span id="authArea" class="auth-area"></span>
     </div>
     <div id="tools" class="tools-row">

--- a/script.js
+++ b/script.js
@@ -43,7 +43,19 @@
   let seigneurToCounty = {}, seigneurToDuchy = {}, seigneurToKingdom = {};
   let canonicalLandMap = {};
   let canonicalPatterns = {};
+  let baronyAdjacency = {};
   let currentFilter = '';
+
+  function addConnection(a,b){
+    if(!baronyAdjacency[a]) baronyAdjacency[a]=[];
+    if(!baronyAdjacency[b]) baronyAdjacency[b]=[];
+    if(!baronyAdjacency[a].includes(b)) baronyAdjacency[a].push(b);
+    if(!baronyAdjacency[b].includes(a)) baronyAdjacency[b].push(a);
+  }
+  function removeConnection(a,b){
+    if(baronyAdjacency[a]) baronyAdjacency[a]=baronyAdjacency[a].filter(x=>x!==b);
+    if(baronyAdjacency[b]) baronyAdjacency[b]=baronyAdjacency[b].filter(x=>x!==a);
+  }
 
   // Carte de correspondance pixel : pixelMap[y][x] = id (ou 0 si aucun)
   const pixelMap = Array.from({ length: originalHeight }, () => new Array(originalWidth).fill(0));
@@ -119,6 +131,8 @@
   const deleteBtn = document.getElementById('deleteBarony');
   const toggleMapBtn = document.getElementById('toggleMap');
   const selectBtn = document.getElementById('selectBarony');
+  const linkBtn = document.getElementById('linkBarony');
+  const unlinkBtn = document.getElementById('unlinkBarony');
   const infoPanel = document.getElementById('infoPanel');
   const editIdInput = document.getElementById('editId');
   const editNameInput = document.getElementById('editName');
@@ -141,6 +155,7 @@
   let cultureOptions = [];
   let countyOptions = [];
   let viscountyOptions = [];
+  let linkMode = null;
 
   async function loadOptions() {
     const [seigneurs, religions, cultures, counties, viscounties] = await Promise.all([
@@ -180,7 +195,7 @@
   }
 
   async function loadMetaData() {
-    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands] = await Promise.all([
+    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands, connections] = await Promise.all([
       fetch(API_BASE + '/api/baronies').then(r => r.json()),
       fetch(API_BASE + '/api/seigneurs').then(r => r.json()),
       fetch(API_BASE + '/api/religions').then(r => r.json()),
@@ -192,7 +207,8 @@
       fetch(API_BASE + '/api/marquisates').then(r => r.json()),
       fetch(API_BASE + '/api/archduchies').then(r => r.json()),
       fetch(API_BASE + '/api/empires').then(r => r.json()),
-      fetch(API_BASE + '/api/canonical_lands').then(r => r.json())
+      fetch(API_BASE + '/api/canonical_lands').then(r => r.json()),
+      fetch(API_BASE + '/api/barony_connections').then(r => r.json())
     ]);
     baronyMeta = {};
     baronies.forEach(b => { baronyMeta[b.id] = b; });
@@ -224,6 +240,13 @@
       if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
       canonicalLandMap[cl.barony_id].push(cl.religion_id);
     });
+    baronyAdjacency = {};
+    connections.forEach(c => {
+      if (!baronyAdjacency[c.barony_id_1]) baronyAdjacency[c.barony_id_1] = [];
+      if (!baronyAdjacency[c.barony_id_2]) baronyAdjacency[c.barony_id_2] = [];
+      baronyAdjacency[c.barony_id_1].push(c.barony_id_2);
+      baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
+    });
   }
   // Outils
   const brushToolBtn = document.getElementById('brushTool');
@@ -240,6 +263,12 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(pixelData)
     });
+  });
+  if (linkBtn) linkBtn.addEventListener('click', () => {
+    if (currentSelectedId) linkMode = 'link';
+  });
+  if (unlinkBtn) unlinkBtn.addEventListener('click', () => {
+    if (currentSelectedId) linkMode = 'unlink';
   });
 
   // Canvas context
@@ -362,6 +391,37 @@
       initColorMap();
       updateLegend(null);
       if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
+      drawAll();
+      return;
+    }
+    if (type === 'distance') {
+      colorMap = {};
+      if (!currentSelectedId) {
+        drawAll();
+        return;
+      }
+      const distances = {};
+      const queue = [currentSelectedId];
+      distances[currentSelectedId] = 0;
+      while (queue.length > 0) {
+        const cur = queue.shift();
+        const next = baronyAdjacency[cur] || [];
+        next.forEach(n => {
+          if (distances[n] === undefined) {
+            distances[n] = distances[cur] + 1;
+            queue.push(n);
+          }
+        });
+      }
+      Object.keys(baronyMeta).forEach(id => {
+        const d = distances[id];
+        if (d === undefined) return;
+        const hue = (d * 40) % 360;
+        const [r, g, b] = hslToRgb(hue, 65, 65);
+        colorMap[id] = [r, g, b, 100];
+      });
+      if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
+      updateLegend(null);
       drawAll();
       return;
     }
@@ -524,7 +584,7 @@
     currentSelectedId = id;
     if (!id) {
       if (infoPanel) infoPanel.style.display = 'none';
-      drawAll();
+      if (currentFilter) applyFilter(currentFilter); else drawAll();
       return;
     }
     if (!baronyMeta[id]) {
@@ -555,8 +615,9 @@
       if (editChurch) editChurch.value = info.church_religion_id || '';
       if (editCathedral) editCathedral.value = info.cathedral_religion_id || '';
       if (editPlayer) editPlayer.checked = !!info.player;
+    }).finally(()=>{
+      if (currentFilter) applyFilter(currentFilter); else drawAll();
     });
-    drawAll();
   }
 
   // Mettre à jour ID/nom de la baronnie sélectionnée
@@ -834,6 +895,26 @@
     const [x, y] = getMapCoordinates(e);
     if (x < 0 || y < 0 || x >= originalWidth || y >= originalHeight) return;
     const idAtPixel = pixelMap[y][x];
+    if (linkMode && currentSelectedId && idAtPixel && idAtPixel !== currentSelectedId) {
+      const body = JSON.stringify({ barony_id_1: currentSelectedId, barony_id_2: idAtPixel });
+      if (linkMode === 'link') {
+        fetch(API_BASE + '/api/barony_connections', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body })
+          .then(() => {
+            addConnection(currentSelectedId, idAtPixel);
+            if (currentFilter === 'distance') applyFilter('distance'); else drawAll();
+          });
+      } else if (linkMode === 'unlink') {
+        fetch(API_BASE + '/api/barony_connections', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body })
+          .then(() => {
+            removeConnection(currentSelectedId, idAtPixel);
+            if (currentFilter === 'distance') applyFilter('distance'); else drawAll();
+          });
+      }
+      linkMode = null;
+      return;
+    } else if (linkMode) {
+      linkMode = null;
+    }
     // Hors mode édition : simplement afficher la baronnie sous le curseur
     if (!editMode) {
       if (idAtPixel) {

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const VALID_TABLES = new Set([
   'users','religions','cultures','seigneurs','empires','kingdoms','archduchies',
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
   'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
-  'building_properties','infrastructure_properties'
+  'building_properties','infrastructure_properties','barony_connections'
 ]);
 
 // create tables if they do not exist
@@ -135,6 +135,14 @@ CREATE TABLE IF NOT EXISTS canonical_lands (
   PRIMARY KEY(religion_id, barony_id),
   FOREIGN KEY(religion_id) REFERENCES religions(id),
   FOREIGN KEY(barony_id) REFERENCES baronies(id)
+);
+CREATE TABLE IF NOT EXISTS barony_connections (
+  barony_id_1 INTEGER NOT NULL,
+  barony_id_2 INTEGER NOT NULL,
+  CHECK (barony_id_1 < barony_id_2),
+  PRIMARY KEY(barony_id_1, barony_id_2),
+  FOREIGN KEY(barony_id_1) REFERENCES baronies(id),
+  FOREIGN KEY(barony_id_2) REFERENCES baronies(id)
 );
 CREATE TABLE IF NOT EXISTS inventaire (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1209,6 +1217,37 @@ app.post('/api/canonical_lands', create('canonical_lands',['religion_id','barony
 app.delete('/api/canonical_lands', (req, res) => {
   const { religion_id, barony_id } = req.query;
   db.run('DELETE FROM canonical_lands WHERE religion_id=? AND barony_id=?', [religion_id, barony_id], function(err){
+    if(err) return handleError(res, err);
+    res.json({deleted: this.changes});
+  });
+});
+
+// Barony adjacency API
+app.get('/api/barony_connections', (req,res)=>{
+  list('barony_connections')(req,res);
+});
+app.post('/api/barony_connections', requireAdmin, (req,res)=>{
+  let { barony_id_1, barony_id_2 } = req.body;
+  barony_id_1 = parseInt(barony_id_1);
+  barony_id_2 = parseInt(barony_id_2);
+  if(!barony_id_1 || !barony_id_2 || barony_id_1 === barony_id_2){
+    return res.status(400).json({error:'Invalid barony ids'});
+  }
+  const [id1,id2] = barony_id_1 < barony_id_2 ? [barony_id_1, barony_id_2] : [barony_id_2, barony_id_1];
+  db.run('INSERT OR IGNORE INTO barony_connections (barony_id_1, barony_id_2) VALUES (?,?)',[id1,id2],function(err){
+    if(err) return handleError(res, err);
+    res.json({added: this.changes});
+  });
+});
+app.delete('/api/barony_connections', requireAdmin, (req,res)=>{
+  let { barony_id_1, barony_id_2 } = req.body;
+  barony_id_1 = parseInt(barony_id_1);
+  barony_id_2 = parseInt(barony_id_2);
+  if(!barony_id_1 || !barony_id_2){
+    return res.status(400).json({error:'Invalid barony ids'});
+  }
+  const [id1,id2] = barony_id_1 < barony_id_2 ? [barony_id_1, barony_id_2] : [barony_id_2, barony_id_1];
+  db.run('DELETE FROM barony_connections WHERE barony_id_1=? AND barony_id_2=?',[id1,id2],function(err){
     if(err) return handleError(res, err);
     res.json({deleted: this.changes});
   });

--- a/viewer.js
+++ b/viewer.js
@@ -21,6 +21,7 @@
   let seigneurToViscounty = {}, seigneurToCounty = {}, seigneurToMarquisate = {}, seigneurToDuchy = {}, seigneurToArchduchy = {}, seigneurToKingdom = {}, seigneurToEmpire = {};
   let canonicalLandMap = {};
   let canonicalPatterns = {};
+  let baronyAdjacency = {};
   let currentFilter = '';
 
   async function loadPixelData() {
@@ -32,7 +33,7 @@
   }
 
   async function loadMetaData() {
-    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands] = await Promise.all([
+    const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands, connections] = await Promise.all([
       fetch(API_BASE + '/api/baronies').then(r => r.json()),
       fetch(API_BASE + '/api/seigneurs').then(r => r.json()),
       fetch(API_BASE + '/api/religions').then(r => r.json()),
@@ -44,7 +45,8 @@
       fetch(API_BASE + '/api/marquisates').then(r => r.json()),
       fetch(API_BASE + '/api/archduchies').then(r => r.json()),
       fetch(API_BASE + '/api/empires').then(r => r.json()),
-      fetch(API_BASE + '/api/canonical_lands').then(r => r.json())
+      fetch(API_BASE + '/api/canonical_lands').then(r => r.json()),
+      fetch(API_BASE + '/api/barony_connections').then(r => r.json())
     ]);
     baronyMeta = {};
     baronies.forEach(b => { baronyMeta[b.id] = b; });
@@ -79,6 +81,13 @@
     canonicalLands.forEach(cl => {
       if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
       canonicalLandMap[cl.barony_id].push(cl.religion_id);
+    });
+    baronyAdjacency = {};
+    connections.forEach(c => {
+      if (!baronyAdjacency[c.barony_id_1]) baronyAdjacency[c.barony_id_1] = [];
+      if (!baronyAdjacency[c.barony_id_2]) baronyAdjacency[c.barony_id_2] = [];
+      baronyAdjacency[c.barony_id_1].push(c.barony_id_2);
+      baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
     });
   }
 
@@ -295,7 +304,7 @@
     currentSelectedId = id;
     if (!id) {
       if (infoPanel) infoPanel.style.display = 'none';
-      drawAll();
+      if (currentFilter) applyFilter(currentFilter); else drawAll();
       return;
     }
     if (!colorMap[id]) colorMap[id] = generateColor(id);
@@ -330,7 +339,7 @@
       infoCanonical.textContent = canon.map(rid => religionMap[rid]?.name || '').filter(Boolean).join(', ');
       infoPanel.style.display = 'block';
     }
-    drawAll();
+    if (currentFilter) applyFilter(currentFilter); else drawAll();
   }
 
   function handleCanvasClick(e) {
@@ -375,6 +384,37 @@
       initColorMap();
       updateLegend(null);
       if (currentSelectedId) colorMap[currentSelectedId][3] = 180;
+      drawAll();
+      return;
+    }
+    if (type === 'distance') {
+      colorMap = {};
+      if (!currentSelectedId) {
+        drawAll();
+        return;
+      }
+      const distances = {};
+      const queue = [currentSelectedId];
+      distances[currentSelectedId] = 0;
+      while (queue.length > 0) {
+        const cur = queue.shift();
+        const next = baronyAdjacency[cur] || [];
+        next.forEach(n => {
+          if (distances[n] === undefined) {
+            distances[n] = distances[cur] + 1;
+            queue.push(n);
+          }
+        });
+      }
+      Object.keys(baronyMeta).forEach(id => {
+        const d = distances[id];
+        if (d === undefined) return;
+        const hue = (d * 40) % 360;
+        const [r, g, b] = hslToRgb(hue, 65, 65);
+        colorMap[id] = [r, g, b, 100];
+      });
+      if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
+      updateLegend(null);
       drawAll();
       return;
     }


### PR DESCRIPTION
## Summary
- add `barony_connections` table and REST endpoints
- link/unlink baronies in editor and color by graph distance
- color viewer maps by barony distance

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a288805ff0832db16883fefa28c42d