### PR TITLE
Ajout des raccourcis de liaison dans l’éditeur de carte

### DIFF
--- a/mapEditor.html
+++ b/mapEditor.html
@@ -37,8 +37,8 @@
       <button id="deleteBarony" class="control-btn">Supprimer</button>
       <button id="toggleMap" class="control-btn">Changer fond</button>
       <button id="selectBarony" class="control-btn">Sélectionner</button>
-      <button id="linkBarony" class="control-btn">Lier</button>
-      <button id="unlinkBarony" class="control-btn">Délier</button>
+      <button id="linkBarony" class="control-btn" title="Lier (Ctrl)">Lier</button>
+      <button id="unlinkBarony" class="control-btn" title="Délier (Ctrl+Alt)">Délier</button>
       <span id="authArea" class="auth-area"></span>
     </div>
     <div id="tools" class="tools-row">

--- a/script.js
+++ b/script.js
@@ -271,6 +271,19 @@
     if (currentSelectedId) linkMode = 'unlink';
   });
 
+  // Raccourcis clavier : Ctrl pour lier, Ctrl+Alt pour délier
+  function updateLinkModeByKeys(e) {
+    if (e.ctrlKey && e.altKey) {
+      linkMode = currentSelectedId ? 'unlink' : null;
+    } else if (e.ctrlKey) {
+      linkMode = currentSelectedId ? 'link' : null;
+    } else {
+      linkMode = null;
+    }
+  }
+  window.addEventListener('keydown', updateLinkModeByKeys);
+  window.addEventListener('keyup', updateLinkModeByKeys);
+
   // Canvas context
   const ctx = pixelCanvas.getContext('2d');
   pixelCanvas.width = originalWidth;


### PR DESCRIPTION
## Summary
- Ajouter les raccourcis clavier Ctrl et Ctrl+Alt pour lier ou délier les baronnies
- Indiquer ces raccourcis dans l’interface de l’éditeur de carte

## Testing
- `npm test` *(script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a2928c3a00832d860f8e6dfb67ddd4