### PR TITLE
Remove resource selection during building

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -75,7 +75,7 @@ const infraPropLabels = {
   description:'Description',
 };
 const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];
-const resourceSelect = [{ id: 'choice', name: 'Choix à la construction' }, ...Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }))];
+const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
 let buildingPropsSelect = [];
 let infraPropsSelect = [];
 const maxOptions = [
@@ -108,7 +108,7 @@ function createCostEditor(val) {
   addBtn.type = 'button';
   addBtn.textContent = '+';
   container.appendChild(addBtn);
-  function addRow(res = '', qty = '', opts = []) {
+  function addRow(res = '', qty = '') {
     const row = document.createElement('div');
     row.className = 'cost-row';
     const sel = document.createElement('select');
@@ -126,51 +126,12 @@ function createCostEditor(val) {
     qtyInput.type = 'number';
     qtyInput.min = '0';
     qtyInput.value = qty;
-    const choiceDiv = document.createElement('div');
-    const choiceList = document.createElement('div');
-    choiceDiv.appendChild(choiceList);
-    const addChoiceBtn = document.createElement('button');
-    addChoiceBtn.type = 'button';
-    addChoiceBtn.textContent = '+';
-    choiceDiv.appendChild(addChoiceBtn);
-    function addChoice(val = '') {
-      const rw = document.createElement('div');
-      const s = document.createElement('select');
-      const bl = document.createElement('option');
-      bl.value = '';
-      s.appendChild(bl);
-      resourceSelect.filter(r => r.id !== 'choice').forEach(o => {
-        const op = document.createElement('option');
-        op.value = o.id;
-        op.textContent = o.name;
-        if (o.id === val) op.selected = true;
-        s.appendChild(op);
-      });
-      const rm = document.createElement('button');
-      rm.type = 'button';
-      rm.textContent = '-';
-      rm.addEventListener('click', () => rw.remove());
-      rw.appendChild(s);
-      rw.appendChild(rm);
-      choiceList.appendChild(rw);
-    }
-    addChoiceBtn.addEventListener('click', () => addChoice());
-    if (opts.length) {
-      opts.forEach(o => addChoice(o));
-    } else {
-      addChoice();
-    }
-    choiceDiv.style.display = res === 'choice' ? '' : 'none';
-    sel.addEventListener('change', () => {
-      choiceDiv.style.display = sel.value === 'choice' ? '' : 'none';
-    });
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.textContent = '-';
     removeBtn.addEventListener('click', () => row.remove());
     row.appendChild(sel);
     row.appendChild(qtyInput);
-    row.appendChild(choiceDiv);
     row.appendChild(removeBtn);
     list.appendChild(row);
   }
@@ -179,13 +140,7 @@ function createCostEditor(val) {
     const obj = JSON.parse(val || '{}');
     const entries = Object.entries(obj);
     if (entries.length) {
-      entries.forEach(([r, q]) => {
-        if (r === 'choice' && q && q.options) {
-          addRow('choice', q.amount || '', q.options);
-        } else {
-          addRow(r, q);
-        }
-      });
+      entries.forEach(([r, q]) => addRow(r, q));
     } else {
       addRow();
     }
@@ -197,13 +152,7 @@ function createCostEditor(val) {
     list.querySelectorAll('.cost-row').forEach(rw => {
       const k = rw.querySelector('select').value;
       const q = parseInt(rw.querySelector('input[type="number"]').value, 10);
-      if (k === 'choice') {
-        const opts = [];
-        rw.querySelectorAll('div select').forEach(s => {
-          if (s.value) opts.push(s.value);
-        });
-        if (opts.length && q) res.choice = { options: opts, amount: q };
-      } else if (k && q) {
+      if (k && q) {
         res[k] = q;
       }
     });
@@ -782,7 +731,6 @@ function renderTable(container, rows, opts){
     if(opts.selects && opts.selects[field]){
       let optList = opts.selects[field];
       if (typeof optList === 'function') optList = optList(item);
-      const container = document.createElement('div');
       const select = document.createElement('select');
       const blank = document.createElement('option');
       blank.value = '';
@@ -792,61 +740,15 @@ function renderTable(container, rows, opts){
         blank.textContent = '';
       }
       select.appendChild(blank);
-      let choiceOpts = [];
-      let selectedVal = val;
-      if(typeof val === 'string'){ try{ const obj = JSON.parse(val); if(obj && obj.choice){ selectedVal = 'choice'; choiceOpts = obj.choice; } }catch{} }
       optList.forEach(o=>{
         const op = document.createElement('option');
         op.value = o.id;
         op.textContent = o.name;
-        if(String(o.id) === String(selectedVal)) op.selected = true;
+        if(String(o.id) === String(val)) op.selected = true;
         select.appendChild(op);
       });
-      container.appendChild(select);
-      const choiceDiv = document.createElement('div');
-      choiceDiv.style.display = select.value === 'choice' ? '' : 'none';
-      const choiceList = document.createElement('div');
-      choiceDiv.appendChild(choiceList);
-      const addChoiceBtn = document.createElement('button');
-      addChoiceBtn.type = 'button';
-      addChoiceBtn.textContent = '+';
-      choiceDiv.appendChild(addChoiceBtn);
-      function addChoiceRow(val=''){
-        const row = document.createElement('div');
-        const sel = document.createElement('select');
-        const blank = document.createElement('option');
-        blank.value = '';
-        sel.appendChild(blank);
-        resourceSelect.filter(r=>r.id!=='choice').forEach(o=>{
-          const op = document.createElement('option');
-          op.value = o.id;
-          op.textContent = o.name;
-          if(o.id===val) op.selected = true;
-          sel.appendChild(op);
-        });
-        const rm = document.createElement('button');
-        rm.type = 'button';
-        rm.textContent = '-';
-        rm.addEventListener('click',()=>row.remove());
-        row.appendChild(sel);
-        row.appendChild(rm);
-        choiceList.appendChild(row);
-      }
-      addChoiceBtn.addEventListener('click',()=>addChoiceRow());
-      if(choiceOpts.length){ choiceOpts.forEach(r=>addChoiceRow(r)); } else { addChoiceRow(); }
-      container.appendChild(choiceDiv);
-      select.addEventListener('change',()=>{
-        choiceDiv.style.display = select.value === 'choice' ? '' : 'none';
-      });
-      container.getValue = ()=>{
-        if(select.value === 'choice'){
-          const opts = [];
-          choiceList.querySelectorAll('select').forEach(s=>{ if(s.value) opts.push(s.value); });
-          return JSON.stringify({choice:opts});
-        }
-        return select.value ? (isNaN(select.value) ? select.value : parseInt(select.value,10)) : null;
-      };
-      return container;
+      select.getValue = ()=> select.value ? (isNaN(select.value) ? select.value : parseInt(select.value,10)) : null;
+      return select;
     }
     if(opts.colorFields && opts.colorFields.includes(field)){
       const input = document.createElement('input');

--- a/gestion.js
+++ b/gestion.js
@@ -178,24 +178,10 @@ async function loadAndRender() {
       html += '<tr><th>Nom</th><th>Production</th><th>Employés</th><th>Requis</th><th>Construits</th><th>Max</th><th>Activer</th><th>Prod. Tot.</th><th>Emp. Tot.</th><th>Coût</th><th>Construire</th></tr>';
       for (const bp of buildingProps) {
         let prodLabel = '';
-        let prodChoices = [];
         if (bp.produces) {
-          try {
-            const obj = JSON.parse(bp.produces);
-            if (obj && obj.choice) {
-              prodChoices = obj.choice;
-              prodLabel = 'Choix';
-            } else {
-              prodLabel = resourceLabels[bp.produces] || bp.produces || '';
-            }
-          } catch {
-            prodLabel = resourceLabels[bp.produces] || bp.produces || '';
-          }
+          prodLabel = resourceLabels[bp.produces] || bp.produces || '';
         }
         const info = buildings[bp.id] || { built: 0, active: 0 };
-        if (prodChoices.length && info.produces) {
-          prodLabel = resourceLabels[info.produces] || info.produces;
-        }
         const baseProd = bp.production || 0;
         let bonusProd = buildingBonuses[bp.id] || buildingBonuses[String(bp.id)] || 0;
         const bonusDetails = buildingBonusDetails[bp.id] || buildingBonusDetails[String(bp.id)] || [];
@@ -363,33 +349,8 @@ async function handleBuildingTableClick(e) {
   const table = document.getElementById('buildingsTable');
   if (e.target.classList.contains('build-btn')) {
     const id = e.target.dataset.id;
-    const bp = gameState.bpMap[id];
     console.log('[build] Bouton de construction cliqué pour', id);
     let payload = { id, quantity: 1 };
-    if (bp && bp.produces) {
-      const prodStr = String(bp.produces).trim();
-      if (prodStr.startsWith('{') || prodStr.startsWith('[')) {
-        try {
-          const obj = JSON.parse(prodStr);
-          if (obj && obj.choice) {
-            const info = gameState.buildings[id] || { built: 0 };
-            if (!info.built) {
-              const choices = obj.choice.map(r => ({ value: r, label: resourceLabels[r] || r }));
-              const labelOpts = choices.map(c => c.label).join('/');
-              const sel = prompt(`Choisissez la ressource produite: ${labelOpts}`);
-              const found = choices.find(c => c.value === sel || c.label.toLowerCase() === String(sel).toLowerCase());
-              if (!found) {
-                console.warn('[build] Choix de ressource invalide', sel);
-                return;
-              }
-              payload.props = { produces: found.value };
-            }
-          }
-        } catch (err) {
-          console.warn('[build] Produces JSON invalide ignoré', err);
-        }
-      }
-    }
     try {
       const resp = await fetch('/api/building', {
         method: 'POST',

--- a/server.js
+++ b/server.js
@@ -742,15 +742,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (bp.type === 'field') {
                     fields = info;
                   }
-                  let prodRes = bp.produces;
-                  if (prodRes) {
-                    try {
-                      const obj = JSON.parse(prodRes);
-                      if (obj && obj.choice) {
-                        prodRes = info.produces;
-                      }
-                    } catch {}
-                  }
+                  const prodRes = bp.produces;
                   if (active > 0 && prodRes && bp.production) {
                     const amount = active * bp.production;
                     production[prodRes] = (production[prodRes] || 0) + amount;


### PR DESCRIPTION
## Summary
- remove 'Choix à la construction' resources
- simplify cost editor and selectors
- drop client/server logic for resource choice

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a342c0fba4832db263a664f3f5c5eb