### PR TITLE
Support tag-based building restrictions

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -28,6 +28,7 @@
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
         <button class="tab-btn" data-tab="batiments">Bâtiments</button>
+        <button class="tab-btn" data-tab="tags">Tags</button>
         <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
       <div class="tab-panels">
@@ -69,6 +70,9 @@
           <div id="tableBuildingProps"></div>
           <h2>Infrastructures Civiles</h2>
           <div id="tableInfraProps"></div>
+        </div>
+        <div id="tab-tags" class="tab-panel">
+          <div id="tableTags"></div>
         </div>
         <div id="tab-baronyprops" class="tab-panel">
           <div id="tableBaronyProps"></div>

--- a/admin.js
+++ b/admin.js
@@ -50,7 +50,7 @@ const baronyPropLabels = {
   effects:'Effets'
 };
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','description'];
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','tags','description'];
 const buildingPropLabels = {
   label:'Nom',
   produces:'Ressource produite',
@@ -60,9 +60,10 @@ const buildingPropLabels = {
   workers_per_building:'Travailleurs/bâtiment',
   absolute_restrictions:'Restrictions absolues',
   infra_restrictions:'Requis',
+  tags:'Tags',
   description:'Description'
 };
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','tags','description'];
 const infraPropLabels = {
   label:'Nom',
   type:'Type',
@@ -72,12 +73,14 @@ const infraPropLabels = {
   costs:'Coûts',
   absolute_restrictions:'Restrictions absolues',
   restrictions:'Requis',
+  tags:'Tags',
   description:'Description',
 };
 const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];
 const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
 let buildingPropsSelect = [];
 let infraPropsSelect = [];
+let tagsSelect = [];
 const maxOptions = [
   ...Array.from({length:10}, (_,i)=>({ id:String(i+1), name:String(i+1) })),
   ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f }))
@@ -293,7 +296,8 @@ function makeRestrictionsInput(val){
       {id:'building', name:'Bâtiment'},
       {id:'infrastructure', name:'Infrastructure'},
       {id:'population', name:'Population'},
-      {id:'resource', name:'Ressource'}
+      {id:'resource', name:'Ressource'},
+      {id:'tag', name:'Tag'}
     ];
     typeOptions.forEach(o=>{
       const op = document.createElement('option');
@@ -375,6 +379,33 @@ function makeRestrictionsInput(val){
         qty.min = '0';
         qty.value = data.value || '';
         valSpan.appendChild(qty);
+      }else if(typeSel.value === 'tag'){
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        tagsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.tag)) op.selected = true;
+          sel.appendChild(op);
+        });
+        keySpan.appendChild(sel);
+        const cmp = document.createElement('select');
+        ['>=','<='].forEach(sym=>{
+          const op = document.createElement('option');
+          op.value = sym;
+          op.textContent = sym;
+          if(sym === data.cmp) op.selected = true;
+          cmp.appendChild(op);
+        });
+        const qty = document.createElement('input');
+        qty.type = 'number';
+        qty.min = '0';
+        qty.value = data.value || '';
+        valSpan.appendChild(cmp);
+        valSpan.appendChild(qty);
       }
     }
     typeSel.addEventListener('change', updateFields);
@@ -393,10 +424,13 @@ function makeRestrictionsInput(val){
     if(obj.resources){
       Object.entries(obj.resources).forEach(([r,v])=> addRow('resource',{resource:r,value:v}));
     }
+    if(obj.tags){
+      obj.tags.forEach(t=> addRow('tag',{tag:t.tag || t.tag_id, cmp:t.cmp, value:t.value}));
+    }
     if(obj.population){
       addRow('population',{value:obj.population});
     }
-    if(!obj.buildings && !obj.infrastructures && !obj.resources && !obj.population){
+    if(!obj.buildings && !obj.infrastructures && !obj.resources && !obj.population && !obj.tags){
       addRow();
     }
   }catch(e){
@@ -407,6 +441,7 @@ function makeRestrictionsInput(val){
     const buildings = {};
     const infrastructures = {};
     const resources = {};
+    const tags = [];
     let population;
     list.querySelectorAll('.restriction-row').forEach(rw=>{
       const type = rw.querySelector('select').value;
@@ -432,12 +467,22 @@ function makeRestrictionsInput(val){
         const r = sel.value;
         const q = parseInt(inp.value,10);
         if(r && q) resources[r] = q;
+      }else if(type === 'tag'){
+        const spans = rw.querySelectorAll('span');
+        const tagSel = spans[0].querySelector('select');
+        const cmpSel = spans[1].querySelector('select');
+        const inp = spans[1].querySelector('input');
+        const t = tagSel.value;
+        const cmp = cmpSel.value;
+        const q = parseInt(inp.value,10);
+        if(t && cmp && !isNaN(q)) tags.push({ tag: t, cmp, value: q });
       }
     });
     if(Object.keys(buildings).length) res.buildings = buildings;
     if(Object.keys(infrastructures).length) res.infrastructures = infrastructures;
     if(Object.keys(resources).length) res.resources = resources;
     if(population != null) res.population = population;
+    if(tags.length) res.tags = tags;
     return JSON.stringify(res);
   };
   return container;
@@ -723,6 +768,24 @@ function renderTable(container, rows, opts){
     if(field === 'effects'){
       return makeEffectsInput(val);
     }
+    if(field === 'tags'){
+      const sel = document.createElement('select');
+      sel.multiple = true;
+      let arr = [];
+      try {
+        const parsed = JSON.parse(val || '[]');
+        if(Array.isArray(parsed)) arr = parsed.map(v=>String(v));
+      } catch {}
+      tagsSelect.forEach(o=>{
+        const op = document.createElement('option');
+        op.value = o.id;
+        op.textContent = o.name;
+        if(arr.includes(String(o.id))) op.selected = true;
+        sel.appendChild(op);
+      });
+      sel.getValue = ()=> JSON.stringify(Array.from(sel.selectedOptions).map(o=> parseInt(o.value,10)));
+      return sel;
+    }
     if(field === 'description'){
       const textarea = document.createElement('textarea');
       textarea.value = val ?? '';
@@ -845,7 +908,7 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps, infraProps] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps, infraProps, tags] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
@@ -862,6 +925,7 @@ async function loadAll(){
     fetchJSON('/api/barony_properties'),
     fetchJSON('/api/building_properties'),
     fetchJSON('/api/infrastructure_properties'),
+    fetchJSON('/api/tags'),
   ]);
 
   const seigneursSelect = seigneurs.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -969,6 +1033,14 @@ async function loadAll(){
     fields:['name','user_id','religion_id','overlord_id'],
     selects:{user_id:userSelectFn, religion_id:religionsSelect, overlord_id:seigneursSelect},
     labels:{name:'Nom', user_id:'Utilisateur', religion_id:'Religion', overlord_id:'Suzerain'}
+  });
+
+  tagsSelect = tags.slice().sort((a,b)=>a.label.localeCompare(b.label)).map(t=>({ id:t.id, name:t.label }));
+  const tagsById = tags.slice().sort((a,b)=>a.id - b.id);
+  renderTable(document.getElementById('tableTags'), tagsById, {
+    endpoint:'tags',
+    fields:['label'],
+    labels:{label:'Nom'}
   });
 
   buildingPropsSelect = buildingProps.map(b => ({ id: b.id, name: b.label || b.type }));

--- a/gestion.js
+++ b/gestion.js
@@ -38,7 +38,13 @@ const baronyPropLabels = {
   high_sea_boat_limit:'Limite de Bateau en haute mer'
 };
 
+function safeParse(json, fallback){
+  try { return json ? JSON.parse(json) : fallback; } catch { return fallback; }
+}
+
 let gameState = {};
+let tagLabels = {};
+let tagCounts = {};
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -48,15 +54,18 @@ async function init() {
 
 async function loadAndRender() {
   try {
-    const [res, bRes, iRes] = await Promise.all([
+    const [res, bRes, iRes, tRes] = await Promise.all([
       fetch('/api/my_seigneurie'),
       fetch('/api/building_properties'),
-      fetch('/api/infrastructure_properties')
+      fetch('/api/infrastructure_properties'),
+      fetch('/api/tags')
     ]);
     if (!res.ok) throw new Error('Erreur');
     const data = await res.json();
     const allBuildingProps = bRes.ok ? await bRes.json() : [];
     const allInfraProps = iRes.ok ? await iRes.json() : [];
+    const tags = tRes.ok ? await tRes.json() : [];
+    tagLabels = Object.fromEntries(tags.map(t=> [String(t.id), t.label]));
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
@@ -91,6 +100,25 @@ async function loadAndRender() {
         }
       });
     const ipMap = Object.fromEntries(allInfraProps.map(b => [String(b.id), b]));
+
+    tagCounts = {};
+    Object.entries(buildings).forEach(([bid, info]) => {
+      const bp = bpMap[String(bid)];
+      if (!bp) return;
+      const tags = safeParse(bp.tags, []);
+      tags.forEach(tid => {
+        tagCounts[tid] = (tagCounts[tid] || 0) + (info.built || 0);
+      });
+    });
+    Object.entries(infrastructures).forEach(([iid, entry]) => {
+      const ip = ipMap[String(iid)];
+      if (!ip) return;
+      const tags = safeParse(ip.tags, []);
+      const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
+      tags.forEach(tid => {
+        tagCounts[tid] = (tagCounts[tid] || 0) + builtCount;
+      });
+    });
 
     gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails };
 
@@ -275,6 +303,20 @@ async function loadAndRender() {
               const color = ok ? '' : ' style="color:red"';
               parts.push(`<span${color}>Avoir au moins ${qty} ${label}</span>`);
             }
+          }
+          if (infraR.tags) {
+            infraR.tags.forEach(cond => {
+              const tagId = cond.tag || cond.tag_id;
+              const cmp = cond.cmp || cond.op;
+              const qty = cond.value;
+              const name = tagLabels[tagId] || tagId;
+              const count = tagCounts[tagId] || 0;
+              const ok = cmp === '>=' ? count >= qty : count <= qty;
+              if (!ok) restrictionsMet = false;
+              const color = ok ? '' : ' style="color:red"';
+              const cmpText = cmp === '>=' ? 'Avoir au moins' : 'Avoir au plus';
+              parts.push(`<span${color}>${cmpText} ${qty} ${name}</span>`);
+            });
           }
           restrHtml = parts.join('<br>');
         } catch (e) {
@@ -539,6 +581,20 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
           const color = ok ? '' : ' style="color:red"';
           parts.push(`<span${color}>Avoir au moins ${qty} ${label}</span>`);
         }
+      }
+      if (restr.tags) {
+        restr.tags.forEach(cond => {
+          const tagId = cond.tag || cond.tag_id;
+          const cmp = cond.cmp || cond.op;
+          const qty = cond.value;
+          const name = tagLabels[tagId] || tagId;
+          const count = tagCounts[tagId] || 0;
+          const ok = cmp === '>=' ? count >= qty : count <= qty;
+          if (!ok) restrOk = false;
+          const color = ok ? '' : ' style="color:red"';
+          const cmpText = cmp === '>=' ? 'Avoir au moins' : 'Avoir au plus';
+          parts.push(`<span${color}>${cmpText} ${qty} ${name}</span>`);
+        });
       }
       restrHtml = parts.join('<br>');
     } catch {}

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const VALID_TABLES = new Set([
   'users','religions','cultures','seigneurs','empires','kingdoms','archduchies',
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
   'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
-  'building_properties','infrastructure_properties','barony_connections'
+  'building_properties','infrastructure_properties','barony_connections','tags'
 ]);
 
 // create tables if they do not exist
@@ -233,6 +233,7 @@ CREATE TABLE IF NOT EXISTS building_properties (
   workers_per_building INTEGER DEFAULT 1,
   absolute_restrictions TEXT,
   infra_restrictions TEXT,
+  tags TEXT,
   description TEXT
 );
 CREATE TABLE IF NOT EXISTS infrastructure_properties (
@@ -245,7 +246,12 @@ CREATE TABLE IF NOT EXISTS infrastructure_properties (
   costs TEXT,
   absolute_restrictions TEXT,
   restrictions TEXT,
+  tags TEXT,
   description TEXT
+);
+CREATE TABLE IF NOT EXISTS tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  label TEXT UNIQUE
 );
 `;
 
@@ -352,11 +358,17 @@ db.exec(initSql, () => {
     if (!rows.some(r => r.name === 'infra_restrictions')) {
       db.run('ALTER TABLE building_properties ADD COLUMN infra_restrictions TEXT');
     }
+    if (!rows.some(r => r.name === 'tags')) {
+      db.run('ALTER TABLE building_properties ADD COLUMN tags TEXT');
+    }
   });
   db.all("PRAGMA table_info(infrastructure_properties)", (err, rows) => {
     if (err || !rows) return;
     if (!rows.some(r => r.name === 'absolute_restrictions')) {
       db.run('ALTER TABLE infrastructure_properties ADD COLUMN absolute_restrictions TEXT');
+    }
+    if (!rows.some(r => r.name === 'tags')) {
+      db.run('ALTER TABLE infrastructure_properties ADD COLUMN tags TEXT');
     }
   });
   db.all("PRAGMA table_info(barony_properties)", (err, rows) => {
@@ -899,7 +911,18 @@ app.put('/api/barony_properties/:id', requireAdmin, (req,res)=>{
   update('barony_properties', baronyPropFields)(req,res);
 });
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','description'];
+const tagFields = ['label'];
+app.get('/api/tags', (req,res)=>{
+  list('tags')(req,res);
+});
+app.post('/api/tags', requireAdmin, (req,res)=>{
+  create('tags', tagFields)(req,res);
+});
+app.put('/api/tags/:id', requireAdmin, (req,res)=>{
+  update('tags', tagFields)(req,res);
+});
+
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','tags','description'];
 app.get('/api/building_properties', (req,res)=>{
   list('building_properties')(req,res);
 });
@@ -910,7 +933,7 @@ app.put('/api/building_properties/:id', requireAdmin, (req,res)=>{
   update('building_properties', buildingPropFields)(req,res);
 });
 
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','tags','description'];
 app.get('/api/infrastructure_properties', (req,res)=>{
   list('infrastructure_properties')(req,res);
 });
@@ -927,6 +950,45 @@ function safeParse(json, fallback){
   } catch {
     return fallback;
   }
+}
+
+function checkTagRestrictions(db, buildings, infrastructures, tagConds, cb) {
+  db.all('SELECT id, tags FROM building_properties', [], (err, bRows) => {
+    if (err) return cb(err);
+    const bTags = {};
+    (bRows || []).forEach(r => {
+      bTags[r.id] = safeParse(r.tags, []);
+    });
+    db.all('SELECT id, tags FROM infrastructure_properties', [], (err2, iRows) => {
+      if (err2) return cb(err2);
+      const iTags = {};
+      (iRows || []).forEach(r => {
+        iTags[r.id] = safeParse(r.tags, []);
+      });
+      for (const cond of tagConds) {
+        const tagId = parseInt(cond.tag || cond.tag_id, 10);
+        const cmp = cond.cmp || cond.operator || cond.op;
+        const val = parseInt(cond.value, 10) || 0;
+        let count = 0;
+        for (const [bid, info] of Object.entries(buildings)) {
+          const tags = bTags[bid] || bTags[String(bid)] || [];
+          if (tags.includes(tagId)) {
+            count += info.built || 0;
+          }
+        }
+        for (const [iid, entry] of Object.entries(infrastructures)) {
+          const tags = iTags[iid] || iTags[String(iid)] || [];
+          const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
+          if (tags.includes(tagId)) {
+            count += builtCount;
+          }
+        }
+        if (cmp === '>=' && count < val) return cb(new Error('Restriction non satisfaite'));
+        if (cmp === '<=' && count > val) return cb(new Error('Restriction non satisfaite'));
+      }
+      cb(null);
+    });
+  });
 }
 
 function canConstruct(db, srow, id, qty, cb){
@@ -978,22 +1040,32 @@ function canConstruct(db, srow, id, qty, cb){
       if (infraReq.population && (srow.population || 0) < infraReq.population) {
         return cb(new Error('Restriction non satisfaite'));
       }
-      const binfo = buildings[id] || { built: 0, active: 0 };
-      const built = binfo.built;
-      const active = binfo.active;
-      if (built + qty > max) return cb(new Error('Limite atteinte'));
-      db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
-        if (err4) return cb(err4);
-        if (infraReq.resources) {
-          for (const [res, val] of Object.entries(infraReq.resources)) {
-            if ((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+      const finalize = () => {
+        const binfo = buildings[id] || { built: 0, active: 0 };
+        const built = binfo.built;
+        const active = binfo.active;
+        if (built + qty > max) return cb(new Error('Limite atteinte'));
+        db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
+          if (err4) return cb(err4);
+          if (infraReq.resources) {
+            for (const [res, val] of Object.entries(infraReq.resources)) {
+              if ((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+            }
           }
-        }
-        for (const [res, val] of Object.entries(costs)) {
-          if ((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
-        }
-        cb(null, { costs, built, active, buildings, infrastructures, effects });
-      });
+          for (const [res, val] of Object.entries(costs)) {
+            if ((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
+          }
+          cb(null, { costs, built, active, buildings, infrastructures, effects });
+        });
+      };
+      if (Array.isArray(infraReq.tags) && infraReq.tags.length) {
+        checkTagRestrictions(db, buildings, infrastructures, infraReq.tags, err3 => {
+          if (err3) return cb(err3);
+          finalize();
+        });
+      } else {
+        finalize();
+      }
     });
   });
 }
@@ -1043,21 +1115,31 @@ function canConstructInfra(db, srow, id, qty, cb){
       if(restrictions.population && (srow.population || 0) < restrictions.population){
         return cb(new Error('Restriction non satisfaite'));
       }
-      const entry = infrastructures[id] || infrastructures[String(id)] || 0;
-      const built = typeof entry === 'object' ? (entry.built || 0) : entry;
-      if(built + qty > max) return cb(new Error('Limite atteinte'));
-      db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
-        if(err3) return cb(err3);
-        if(restrictions.resources){
-          for(const [res, val] of Object.entries(restrictions.resources)){
-            if((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+      const finalize = () => {
+        const entry = infrastructures[id] || infrastructures[String(id)] || 0;
+        const built = typeof entry === 'object' ? (entry.built || 0) : entry;
+        if(built + qty > max) return cb(new Error('Limite atteinte'));
+        db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv) => {
+          if(err3) return cb(err3);
+          if(restrictions.resources){
+            for(const [res, val] of Object.entries(restrictions.resources)){
+              if((inv[res] || 0) < val) return cb(new Error('Restriction non satisfaite'));
+            }
           }
-        }
-        for(const [res, val] of Object.entries(costs)){
-          if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
-        }
-        cb(null, { costs, built, infrastructures, effects });
-      });
+          for(const [res, val] of Object.entries(costs)){
+            if((inv[res] || 0) < val) return cb(new Error('Ressources insuffisantes'));
+          }
+          cb(null, { costs, built, infrastructures, effects });
+        });
+      };
+      if (Array.isArray(restrictions.tags) && restrictions.tags.length) {
+        checkTagRestrictions(db, buildings, infrastructures, restrictions.tags, err3 => {
+          if (err3) return cb(err3);
+          finalize();
+        });
+      } else {
+        finalize();
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow admins to manage tags for buildings and infrastructures
- link tags to building/infrastructure types and enforce tag-based construction rules
- expose tag management in admin UI with tag selectors

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a344515584832d85c10649b0d5b66a