### PR TITLE
Add IDH breakdown tooltip and admin IDH effect support

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -508,6 +508,7 @@ function makeEffectsInput(val){
       {id:'storage', name:'Stockage'},
       {id:'production', name:'Production ressource'},
       {id:'building_production', name:'Prod. bâtiment'},
+      {id:'idh', name:'IDH'},
       {id:'instant_production', name:'Prod. instantanée'}
     ];
     typeOptions.forEach(o=>{
@@ -577,6 +578,8 @@ function makeEffectsInput(val){
         editBtn.style.display = '';
         if(data.resource){ dataInput.value = JSON.stringify(data); updateSummary(); }
         else { dataInput.value = ''; updateSummary(); }
+      }else if(typeSel.value === 'idh'){
+        qty.style.display = '';
       }else{
         resourceSelect.forEach(o=>{
           const op = document.createElement('option');
@@ -629,6 +632,11 @@ function makeEffectsInput(val){
         try{ data = JSON.parse(rw.querySelector('input[data-role="data"]').value || '{}'); }catch(e){ data = {}; }
         if(data.resource && data.amount){
           res.push({type, resource: data.resource, amount: data.amount, uses_per_month: data.uses_per_month || 0, costs: data.costs || {}});
+        }
+      }else if(type === 'idh'){
+        const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);
+        if(type && !isNaN(amt)){
+          res.push({ type, amount: amt });
         }
       }else{
         const target = rw.querySelector('select[data-role="target"]').value;
@@ -769,22 +777,54 @@ function renderTable(container, rows, opts){
       return makeEffectsInput(val);
     }
     if(field === 'tags'){
-      const sel = document.createElement('select');
-      sel.multiple = true;
-      let arr = [];
+      const container = document.createElement('div');
+      const list = document.createElement('div');
+      container.appendChild(list);
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.textContent = '+';
+      container.appendChild(addBtn);
+      function addRow(tag = ''){
+        const row = document.createElement('div');
+        row.className = 'tag-row';
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        tagsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(tag)) op.selected = true;
+          sel.appendChild(op);
+        });
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.textContent = '-';
+        removeBtn.addEventListener('click', ()=> row.remove());
+        row.appendChild(sel);
+        row.appendChild(removeBtn);
+        list.appendChild(row);
+      }
+      addBtn.addEventListener('click', ()=> addRow());
       try {
-        const parsed = JSON.parse(val || '[]');
-        if(Array.isArray(parsed)) arr = parsed.map(v=>String(v));
-      } catch {}
-      tagsSelect.forEach(o=>{
-        const op = document.createElement('option');
-        op.value = o.id;
-        op.textContent = o.name;
-        if(arr.includes(String(o.id))) op.selected = true;
-        sel.appendChild(op);
-      });
-      sel.getValue = ()=> JSON.stringify(Array.from(sel.selectedOptions).map(o=> parseInt(o.value,10)));
-      return sel;
+        const arr = JSON.parse(val || '[]');
+        if(Array.isArray(arr) && arr.length){
+          arr.forEach(t=> addRow(t));
+        } else {
+          addRow();
+        }
+      } catch {
+        addRow();
+      }
+      container.getValue = ()=>{
+        const res = [];
+        list.querySelectorAll('select').forEach(sel=>{
+          if(sel.value) res.push(parseInt(sel.value,10));
+        });
+        return JSON.stringify(res);
+      };
+      return container;
     }
     if(field === 'description'){
       const textarea = document.createElement('textarea');

--- a/gestion.js
+++ b/gestion.js
@@ -70,13 +70,18 @@ async function loadAndRender() {
     const inv = data.inventaire || {};
     const barony = data.barony || {};
     const idh = data.idh || 0;
+    const idhDetails = data.idhDetails || [];
     let idhClass = '';
     if (idh < 5) {
       idhClass = 'prod-negative';
     } else if (idh >= 10) {
       idhClass = 'prod-positive';
     }
-    const idhHtml = `<span class="${idhClass}">${idh}</span>`;
+    const idhTooltip = idhDetails
+      .map(d => `${d.label}: ${d.amount > 0 ? '+' : ''}${d.amount}`)
+      .join('&#10;')
+      .replace(/"/g, '&quot;');
+    const idhHtml = `<span class="${idhClass}" title="${idhTooltip}">${idh}</span>`;
     const production = data.production || {};
     const productionDetails = data.productionDetails || {};
     const baronyProps = data.baronyProps || {};

--- a/server.js
+++ b/server.js
@@ -768,7 +768,17 @@ app.get('/api/my_seigneurie', (req, res) => {
                   const capacities = { vivres: 500, points_magique: 2000 };
                   const buildingProductionBonus = {};
                   const buildingProductionBonusDetails = {};
-                  const effectCtx = { production, productionDetails, capacity: capacities, buildings, bpMap, buildingProductionBonus, buildingProductionBonusDetails, idh: 5, idhDetails: [] };
+                  const effectCtx = {
+                    production,
+                    productionDetails,
+                    capacity: capacities,
+                    buildings,
+                    bpMap,
+                    buildingProductionBonus,
+                    buildingProductionBonusDetails,
+                    idh: 5,
+                    idhDetails: [{ label: 'Base', amount: 5, source: 1 }]
+                  };
                   for (const ip of infraList) {
                     const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
                     const count = typeof entry === 'object' ? (entry.built || 0) : entry;
@@ -815,27 +825,46 @@ app.get('/api/my_seigneurie', (req, res) => {
                   }
                   const employment = { employed: Math.max(employed - slaves, 0), slaves };
                   function finalize(barony, baronyProps) {
+                    const idhDetails = effectCtx.idhDetails || [];
                     let idh = effectCtx.idh;
                     if (taxRate === 0) {
                       idh += 3;
+                      idhDetails.push({ label: 'Taxes', amount: 3, source: taxRate });
                     } else if (taxRate <= 2) {
                       idh += 2;
+                      idhDetails.push({ label: 'Taxes', amount: 2, source: taxRate });
                     } else if (taxRate <= 4) {
                       idh += 1;
+                      idhDetails.push({ label: 'Taxes', amount: 1, source: taxRate });
                     } else {
-                      idh -= (taxRate - 5);
+                      const malus = -(taxRate - 5);
+                      idh += malus;
+                      idhDetails.push({ label: 'Taxes', amount: malus, source: taxRate });
                     }
-                    idh -= Math.min(Math.floor(s.population / 1000), 5);
-                    if (!seig.religion_id) idh -= 1;
-                    if (barony && seig.religion_id !== barony.religion_pop_id) idh -= 1;
+                    const popPenalty = -Math.min(Math.floor(s.population / 1000), 5);
+                    if (popPenalty) {
+                      idh += popPenalty;
+                      idhDetails.push({ label: 'Population', amount: popPenalty, source: s.population });
+                    }
+                    if (!seig.religion_id) {
+                      idh -= 1;
+                      idhDetails.push({ label: 'Sans religion', amount: -1, source: 1 });
+                    }
+                    if (barony && seig.religion_id !== barony.religion_pop_id) {
+                      idh -= 1;
+                      idhDetails.push({ label: 'Religion différente', amount: -1, source: 1 });
+                    }
                     const totalPop = s.population + slaves;
                     if (totalPop > 0) {
                       let slavePenalty = Math.floor((20 * slaves) / totalPop) - 1;
                       if (slavePenalty < 0) slavePenalty = 0;
                       if (slavePenalty > 5) slavePenalty = 5;
-                      idh -= slavePenalty;
+                      if (slavePenalty) {
+                        idh -= slavePenalty;
+                        idhDetails.push({ label: 'Esclaves', amount: -slavePenalty, source: slaves });
+                      }
                     }
-                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh });
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh, idhDetails });
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {


### PR DESCRIPTION
## Summary
- Display IDH as a tooltip with detailed bonus/malus sources
- Allow configuring IDH bonus effects in admin and simplify tag editing
- Track and expose IDH contribution details on the server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3731df4c8832d9afb7f276af4af4e