### PR TITLE
Handle zero values in numeric restrictions and improve IDH tooltip

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -450,23 +450,23 @@ function makeRestrictionsInput(val){
         const inp = rw.querySelector('span input');
         const b = sel.value;
         const q = parseInt(inp.value,10);
-        if(b && q) buildings[b] = q;
+        if (b && !isNaN(q)) buildings[b] = q;
       }else if(type === 'infrastructure'){
         const sel = rw.querySelector('span select');
         const inp = rw.querySelector('span input');
         const i = sel.value;
         const q = parseInt(inp.value,10);
-        if(i && q) infrastructures[i] = q;
+        if (i && !isNaN(q)) infrastructures[i] = q;
       }else if(type === 'population'){
         const inp = rw.querySelector('span input');
         const q = parseInt(inp.value,10);
-        if(q) population = q;
+        if (!isNaN(q)) population = q;
       }else if(type === 'resource'){
         const sel = rw.querySelector('span select');
         const inp = rw.querySelector('span input');
         const r = sel.value;
         const q = parseInt(inp.value,10);
-        if(r && q) resources[r] = q;
+        if (r && !isNaN(q)) resources[r] = q;
       }else if(type === 'tag'){
         const spans = rw.querySelectorAll('span');
         const tagSel = spans[0].querySelector('select');

--- a/gestion.js
+++ b/gestion.js
@@ -77,11 +77,15 @@ async function loadAndRender() {
     } else if (idh >= 10) {
       idhClass = 'prod-positive';
     }
-    const idhTooltip = idhDetails
-      .map(d => `${d.label}: ${d.amount > 0 ? '+' : ''}${d.amount}`)
-      .join('&#10;')
-      .replace(/"/g, '&quot;');
-    const idhHtml = `<span class="${idhClass}" title="${idhTooltip}">${idh}</span>`;
+    let idhHtml;
+    if (idhDetails.length) {
+      const rows = idhDetails
+        .map(d => `<tr><td>${formatDetailLabel(d.label)}</td><td>${spanAmount(d.amount)}</td></tr>`)
+        .join('');
+      idhHtml = `<span class="tooltip ${idhClass}">${idh}<table class="tooltip-table">${rows}</table></span>`;
+    } else {
+      idhHtml = `<span class="${idhClass}">${idh}</span>`;
+    }
     const production = data.production || {};
     const productionDetails = data.productionDetails || {};
     const baronyProps = data.baronyProps || {};


### PR DESCRIPTION
## Summary
- Preserve zero values when saving numeric comparison restrictions
- Display detailed tooltip for IDH in management view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a379087598832dbde6a516e7a7b1d7