### PR TITLE
feat: add variable worker infrastructure effect

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -277,6 +277,78 @@ function openInstantProductionPopup(initial, onSave) {
   });
 }
 
+function openVariableWorkersPopup(initial, onSave) {
+  const overlay = document.createElement('div');
+  overlay.className = 'popup-overlay';
+  const popup = document.createElement('div');
+  popup.className = 'popup';
+
+  const resDiv = document.createElement('div');
+  const resLabel = document.createElement('label');
+  resLabel.textContent = 'Ressource';
+  const resSel = document.createElement('select');
+  const blank = document.createElement('option');
+  blank.value = '';
+  resSel.appendChild(blank);
+  resourceSelect.forEach(o => {
+    const op = document.createElement('option');
+    op.value = o.id;
+    op.textContent = o.name;
+    if (initial.resource === o.id) op.selected = true;
+    resSel.appendChild(op);
+  });
+  resDiv.appendChild(resLabel);
+  resDiv.appendChild(resSel);
+
+  const amtDiv = document.createElement('div');
+  const amtLabel = document.createElement('label');
+  amtLabel.textContent = 'Production / travailleur';
+  const amtInput = document.createElement('input');
+  amtInput.type = 'number';
+  amtInput.min = '0';
+  amtInput.value = initial.amount ?? '';
+  amtDiv.appendChild(amtLabel);
+  amtDiv.appendChild(amtInput);
+
+  const maxDiv = document.createElement('div');
+  const maxLabel = document.createElement('label');
+  maxLabel.textContent = 'Max travailleurs';
+  const maxInput = document.createElement('input');
+  maxInput.type = 'number';
+  maxInput.min = '0';
+  maxInput.value = initial.max_workers ?? '';
+  maxDiv.appendChild(maxLabel);
+  maxDiv.appendChild(maxInput);
+
+  popup.appendChild(resDiv);
+  popup.appendChild(amtDiv);
+  popup.appendChild(maxDiv);
+
+  const btnRow = document.createElement('div');
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.textContent = 'Valider';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Annuler';
+  btnRow.appendChild(saveBtn);
+  btnRow.appendChild(cancelBtn);
+  popup.appendChild(btnRow);
+
+  overlay.appendChild(popup);
+  document.body.appendChild(overlay);
+
+  cancelBtn.addEventListener('click', () => overlay.remove());
+  saveBtn.addEventListener('click', () => {
+    onSave({
+      resource: resSel.value,
+      amount: parseInt(amtInput.value, 10) || 0,
+      max_workers: parseInt(maxInput.value, 10) || 0,
+    });
+    overlay.remove();
+  });
+}
+
 function openRestrictionsPopup(initialVal, onSave) {
   const overlay = document.createElement('div');
   overlay.className = 'popup-overlay';
@@ -535,7 +607,8 @@ function makeEffectsInput(val){
       {id:'production', name:'Production ressource'},
       {id:'building_production', name:'Prod. bâtiment'},
       {id:'idh', name:'IDH'},
-      {id:'instant_production', name:'Prod. instantanée'}
+      {id:'instant_production', name:'Prod. instantanée'},
+      {id:'variable_workers', name:'Travailleurs variables'}
     ];
     typeOptions.forEach(o=>{
       const op = document.createElement('option');
@@ -562,12 +635,19 @@ function makeEffectsInput(val){
       summarySpan.textContent = '';
       try{
         const d = JSON.parse(dataInput.value || '{}');
-        if(d.resource && d.amount){
-          const resObj = resourceSelect.find(r=>r.id === d.resource);
-          const costCount = d.costs ? Object.keys(d.costs).length : 0;
-          summarySpan.textContent = `${d.amount} ${resObj ? resObj.name : d.resource}` +
-            (d.uses_per_month ? `, ${d.uses_per_month}/mois` : '') +
-            (costCount ? `, coûts: ${costCount}` : '');
+        if(typeSel.value === 'instant_production'){
+          if(d.resource && d.amount){
+            const resObj = resourceSelect.find(r=>r.id === d.resource);
+            const costCount = d.costs ? Object.keys(d.costs).length : 0;
+            summarySpan.textContent = `${d.amount} ${resObj ? resObj.name : d.resource}` +
+              (d.uses_per_month ? `, ${d.uses_per_month}/mois` : '') +
+              (costCount ? `, coûts: ${costCount}` : '');
+          }
+        }else if(typeSel.value === 'variable_workers'){
+          if(d.resource && d.amount && d.max_workers != null){
+            const resObj = resourceSelect.find(r=>r.id === d.resource);
+            summarySpan.textContent = `${d.amount} ${resObj ? resObj.name : d.resource} /travailleur, max ${d.max_workers}`;
+          }
         }
       }catch(e){
         summarySpan.textContent = '';
@@ -577,7 +657,11 @@ function makeEffectsInput(val){
     editBtn.addEventListener('click', ()=>{
       let init = {};
       try{ init = JSON.parse(dataInput.value || '{}'); }catch(e){ init = {}; }
-      openInstantProductionPopup(init, d=>{ dataInput.value = JSON.stringify(d); updateSummary(); });
+      if(typeSel.value === 'instant_production'){
+        openInstantProductionPopup(init, d=>{ dataInput.value = JSON.stringify(d); updateSummary(); });
+      }else if(typeSel.value === 'variable_workers'){
+        openVariableWorkersPopup(init, d=>{ dataInput.value = JSON.stringify(d); updateSummary(); });
+      }
     });
 
     function populateFields(){
@@ -604,6 +688,11 @@ function makeEffectsInput(val){
         editBtn.style.display = '';
         if(data.resource){ dataInput.value = JSON.stringify(data); updateSummary(); }
         else { dataInput.value = ''; updateSummary(); }
+      }else if(typeSel.value === 'variable_workers'){
+        summarySpan.style.display = '';
+        editBtn.style.display = '';
+        if(data.resource){ dataInput.value = JSON.stringify(data); updateSummary(); }
+        else { dataInput.value = ''; updateSummary(); }
       }else if(typeSel.value === 'idh'){
         qty.style.display = '';
       }else{
@@ -623,7 +712,7 @@ function makeEffectsInput(val){
     typeSel.addEventListener('change', ()=>{
       data = {};
       populateFields();
-      if(typeSel.value === 'instant_production') editBtn.click();
+      if(typeSel.value === 'instant_production' || typeSel.value === 'variable_workers') editBtn.click();
     });
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
@@ -658,6 +747,12 @@ function makeEffectsInput(val){
         try{ data = JSON.parse(rw.querySelector('input[data-role="data"]').value || '{}'); }catch(e){ data = {}; }
         if(data.resource && data.amount){
           res.push({type, resource: data.resource, amount: data.amount, uses_per_month: data.uses_per_month || 0, costs: data.costs || {}});
+        }
+      }else if(type === 'variable_workers'){
+        let data = {};
+        try{ data = JSON.parse(rw.querySelector('input[data-role="data"]').value || '{}'); }catch(e){ data = {}; }
+        if(data.resource && data.amount && data.max_workers != null){
+          res.push({type, resource: data.resource, amount: data.amount, max_workers: data.max_workers});
         }
       }else if(type === 'idh'){
         const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);

--- a/effects.js
+++ b/effects.js
@@ -102,4 +102,20 @@ class IDHEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect };
+class VariableWorkersEffect extends Effect {
+  constructor(resource, amount) {
+    super();
+    this.resource = resource;
+    this.amount = amount;
+  }
+  apply(ctx, workers, label) {
+    const total = this.amount * workers;
+    if (!ctx.production) ctx.production = {};
+    if (!ctx.productionDetails) ctx.productionDetails = {};
+    ctx.production[this.resource] = (ctx.production[this.resource] || 0) + total;
+    if (!ctx.productionDetails[this.resource]) ctx.productionDetails[this.resource] = [];
+    ctx.productionDetails[this.resource].push({ label, amount: total, source: workers });
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect };

--- a/gestion.js
+++ b/gestion.js
@@ -382,11 +382,13 @@ async function loadAndRender() {
       civilDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='civil'), infrastructures, inv, 'civilInfraTable');
       const table = document.getElementById('civilInfraTable');
       table.addEventListener('click', handleInfraTableClick);
+      table.addEventListener('change', handleInfraTableChange);
     }
     if (miliDiv) {
       miliDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='militaire'), infrastructures, inv, 'militaryInfraTable');
       const table = document.getElementById('militaryInfraTable');
       table.addEventListener('click', handleInfraTableClick);
+      table.addEventListener('change', handleInfraTableChange);
     }
 
     const propsDiv = document.getElementById('baronyProps');
@@ -511,6 +513,52 @@ async function handleInfraTableClick(e) {
   }
 }
 
+async function handleInfraTableChange(e) {
+  if (e.target.classList.contains('var-workers-input')) {
+    const id = e.target.dataset.id;
+    const idx = e.target.dataset.idx;
+    const qty = parseInt(e.target.value,10) || 0;
+    const ip = gameState.ipMap[id];
+    const entry = gameState.infrastructures[id] || gameState.infrastructures[String(id)] || {};
+    const built = typeof entry === 'object' ? (entry.built || 0) : entry;
+    let eff;
+    try { eff = JSON.parse(ip.effects || '[]')[idx]; } catch { eff = null; }
+    if(!eff) return;
+    const maxWorkers = (eff.max_workers || 0) * built;
+    const current = entry[`effect_${idx}_workers`] || 0;
+    const freePop = gameState.s.population + gameState.employment.slaves - gameState.employment.employed + current;
+    if(qty > maxWorkers){
+      alert('Nombre trop élevé');
+      e.target.value = current;
+      updateVarWorkers(e.target);
+      return;
+    }
+    if(qty > freePop){
+      alert('Population non employée insuffisante');
+      e.target.value = current;
+      updateVarWorkers(e.target);
+      return;
+    }
+    try {
+      const resp = await fetch('/api/infrastructure/assign_workers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, index: idx, quantity: qty })
+      });
+      if(resp.ok){
+        await loadAndRender();
+      }else{
+        const msg = await resp.text().catch(()=> '');
+        console.warn('[infra] Assignation refusée', resp.status, msg);
+        alert('Affectation impossible');
+      }
+    } catch(err){
+      console.error('[infra] Erreur réseau affectation', err);
+      alert('Affectation impossible');
+    }
+  }
+}
+
 function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
   const { buildings = {}, infrastructures = {}, s = {}, bpMap = {}, ipMap = {} } = gameState || {};
   let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Requis</th><th>Coût</th><th>Construire</th><th class="multi-col"></th></tr>`;
@@ -621,17 +669,25 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
     let extraHtml = '';
     try {
       const effects = ip.effects ? JSON.parse(ip.effects) : [];
-      const inst = effects.filter(e => e.type === 'instant_production');
       const tables = [];
       if (built > 0) {
-        inst.forEach((eff, idx) => {
-          const remainKey = `effect_${idx}_remaining`;
-          const remaining = entryObj[remainKey] || 0;
-          const label = resourceLabels[eff.resource] || eff.resource;
-          const baseCosts = eff.costs || {};
-          const costStr = Object.entries(baseCosts).map(([r,a])=>{
-            const lbl = resourceLabels[r] || r; return `${lbl}: ${a*remaining}`; }).join(', ');
-          tables.push(`<table class="admin-table instant-prod-table"><tr><th>Production</th><th>Restant</th><th>Nb</th><th>Coût total</th><th>Convertir</th></tr><tr><td class="prod-cell" data-base="${eff.amount}" data-res="${eff.resource}">${eff.amount} ${label}</td><td class="rem-cell">${remaining}</td><td><input type="number" class="inst-nb" min="1" max="${remaining}" value="${remaining}" oninput="updateInstantCost(this)"></td><td class="cost-cell" data-costs='${JSON.stringify(baseCosts)}'>${costStr}</td><td><button class="instant-btn" data-id="${ip.id}" data-idx="${idx}">Convertir</button></td></tr></table>`);
+        effects.forEach((eff, idx) => {
+          if (eff.type === 'instant_production') {
+            const remainKey = `effect_${idx}_remaining`;
+            const remaining = entryObj[remainKey] || 0;
+            const label = resourceLabels[eff.resource] || eff.resource;
+            const baseCosts = eff.costs || {};
+            const costStr = Object.entries(baseCosts).map(([r,a])=>{
+              const lbl = resourceLabels[r] || r; return `${lbl}: ${a*remaining}`; }).join(', ');
+            tables.push(`<table class="admin-table instant-prod-table"><tr><th>Production</th><th>Restant</th><th>Nb</th><th>Coût total</th><th>Convertir</th></tr><tr><td class="prod-cell" data-base="${eff.amount}" data-res="${eff.resource}">${eff.amount} ${label}</td><td class="rem-cell">${remaining}</td><td><input type="number" class="inst-nb" min="1" max="${remaining}" value="${remaining}" oninput="updateInstantCost(this)"></td><td class="cost-cell" data-costs='${JSON.stringify(baseCosts)}'>${costStr}</td><td><button class="instant-btn" data-id="${ip.id}" data-idx="${idx}">Convertir</button></td></tr></table>`);
+          } else if (eff.type === 'variable_workers') {
+            const workerKey = `effect_${idx}_workers`;
+            const assigned = entryObj[workerKey] || 0;
+            const maxWorkers = (eff.max_workers || 0) * built;
+            const label = resourceLabels[eff.resource] || eff.resource;
+            const prodTotal = assigned * (eff.amount || 0);
+            tables.push(`<table class="admin-table var-workers-table"><tr><th>Assignés</th><th>Max</th><th>Production</th></tr><tr><td><input type="number" class="var-workers-input" data-id="${ip.id}" data-idx="${idx}" min="0" max="${maxWorkers}" value="${assigned}" oninput="updateVarWorkers(this)"></td><td>${maxWorkers}</td><td class="vw-prod" data-per="${eff.amount}" data-res="${eff.resource}">${prodTotal} ${label}</td></tr></table>`);
+          }
         });
       }
       if (tables.length) {
@@ -659,6 +715,15 @@ function updateInstantCost(el){
   const amount = parseInt(prodCell.dataset.base,10) || 0;
   const res = resourceLabels[prodCell.dataset.res] || prodCell.dataset.res;
   prodCell.textContent = `${amount*nb} ${res}`;
+}
+
+function updateVarWorkers(el){
+  const tr = el.closest('tr');
+  const prodCell = tr.querySelector('.vw-prod');
+  const per = parseInt(prodCell.dataset.per,10) || 0;
+  const res = resourceLabels[prodCell.dataset.res] || prodCell.dataset.res;
+  const nb = parseInt(el.value,10) || 0;
+  prodCell.textContent = `${nb*per} ${res}`;
 }
 
 function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}) {

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -783,22 +783,34 @@ app.get('/api/my_seigneurie', (req, res) => {
                     const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
                     const count = typeof entry === 'object' ? (entry.built || 0) : entry;
                     if (!count) continue;
+                    const entryObj = typeof entry === 'object' ? entry : {};
                     const effects = safeParse(ip.effects, []);
-                    for (const def of effects) {
+                    effects.forEach((def, idx) => {
                       let effObj = null;
                       if (def.type === 'storage') {
                         effObj = new StorageEffect(def.resource, def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'production') {
                         effObj = new ResourceProductionEffect(def.resource, def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'building_production') {
                         effObj = new BuildingProductionEffect(def.building, def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'idh') {
                         effObj = new IDHEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'variable_workers') {
+                        const max = (def.max_workers || 0) * count;
+                        let assigned = entryObj[`effect_${idx}_workers`] || 0;
+                        if (assigned > max) assigned = max;
+                        if (assigned) {
+                          employed += assigned;
+                          employmentDetails.push({ label: ip.label || ip.type, amount: assigned, source: assigned });
+                        }
+                        effObj = new VariableWorkersEffect(def.resource, def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, assigned, ip.label || ip.type);
                       }
-                      if (effObj) {
-                        effObj.apply(effectCtx, count, ip.label || ip.type);
-                      }
-                    }
+                    });
                   }
                   const slaves = inventaire.esclaves || 0;
                   if (slaves) {
@@ -1362,6 +1374,77 @@ app.post('/api/infrastructure/instant_production', (req,res)=>{
                 res.json({ infrastructures: infra, inventaire });
               });
             });
+          });
+        });
+      });
+    });
+  });
+});
+
+app.post('/api/infrastructure/assign_workers', (req,res) => {
+  if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const { id, index, quantity } = req.body;
+  const iId = Number.parseInt(id, 10);
+  const idx = Number.parseInt(index, 10);
+  const qty = Number.parseInt(quantity, 10) || 0;
+  if (Number.isNaN(iId) || Number.isNaN(idx) || qty < 0) return res.status(400).json({ error: 'Quantité invalide' });
+  const userId = req.session.user.id;
+  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
+    if(err) return handleError(res, err);
+    if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const infrastructures = safeParse(srow.infrastructures, {});
+    const buildings = safeParse(srow.buildings, {});
+    db.all('SELECT id, label, workers_per_building FROM building_properties', [], (err2, bprops) => {
+      if(err2) return handleError(res, err2);
+      db.all('SELECT id, label, effects FROM infrastructure_properties', [], (err3, iprops) => {
+        if(err3) return handleError(res, err3);
+        const ipMap = Object.fromEntries((iprops || []).map(p => [String(p.id), p]));
+        const ip = ipMap[String(iId)];
+        if(!ip) return res.status(400).json({ error: 'Infrastructure introuvable' });
+        const effects = safeParse(ip.effects, []);
+        const def = effects[idx];
+        if(!def || def.type !== 'variable_workers') return res.status(400).json({ error: 'Effet introuvable' });
+        const existing = infrastructures[iId] || infrastructures[String(iId)] || {};
+        const built = typeof existing === 'object' ? (existing.built || 0) : existing;
+        const max = (def.max_workers || 0) * built;
+        if(qty > max) return res.status(400).json({ error: 'Au-delà du maximum' });
+        let employed = 0;
+        const employmentDetails = [];
+        for(const bp of bprops || []){
+          const info = buildings[bp.id] || { built:0, active:0 };
+          const workers = (info.active || 0) * (bp.workers_per_building || 0);
+          employed += workers;
+          if(workers) employmentDetails.push({ label: bp.label || bp.type, amount: workers, source: info.active || 0 });
+        }
+        for(const [iid, ent] of Object.entries(infrastructures)){
+          const prop = ipMap[String(iid)];
+          if(!prop) continue;
+          const builtCount = typeof ent === 'object' ? (ent.built || 0) : ent;
+          const entObj = typeof ent === 'object' ? ent : {};
+          const effs = safeParse(prop.effects, []);
+          effs.forEach((ef, eidx) => {
+            if(ef.type === 'variable_workers'){
+              const key = `effect_${eidx}_workers`;
+              const assigned = (iId === Number(iid) && eidx === idx) ? qty : (entObj[key] || 0);
+              if(assigned){
+                employed += assigned;
+                employmentDetails.push({ label: prop.label || prop.type, amount: assigned, source: assigned });
+              }
+            }
+          });
+        }
+        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
+          if(err4) return handleError(res, err4);
+          const slaves = inv ? (inv.esclaves || 0) : 0;
+          const totalPop = srow.population + slaves;
+          if(employed > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
+          if(slaves) employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
+          const employment = { employed: Math.max(employed - slaves, 0), slaves };
+          const newEntry = typeof existing === 'object' ? { ...existing, [`effect_${idx}_workers`]: qty } : { built, [`effect_${idx}_workers`]: qty };
+          infrastructures[iId] = newEntry;
+          db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?', [JSON.stringify(infrastructures), srow.id], function(err5){
+            if(err5) return handleError(res, err5);
+            res.json({ infrastructures, employment, employmentDetails });
           });
         });
       });

--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,10 @@ th.multi-col {
   margin-bottom: 0;
 }
 
+.var-workers-table {
+  margin-bottom: 0;
+}
+
 .qty-control {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add variable worker effect class and server support
- enable assigning workers to infrastructure for extra production
- admin UI to configure variable worker effects

## Testing
- `node --check effects.js`
- `node --check server.js`
- `node --check gestion.js`
- `node --check admin.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3a42df3b8832dbc937ade4abd3b42