### PR TITLE
Add unlockable magic page and spell management

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -28,6 +28,7 @@
         <button class="tab-btn" data-tab="viscounties">Vicomtés</button>
         <button class="tab-btn" data-tab="seigneuries">Seigneuries</button>
         <button class="tab-btn" data-tab="batiments">Bâtiments</button>
+        <button class="tab-btn" data-tab="spells">Sorts</button>
         <button class="tab-btn" data-tab="tags">Tags</button>
         <button class="tab-btn" data-tab="baronyprops">Propriétés baronnies</button>
       </div>
@@ -70,6 +71,9 @@
           <div id="tableBuildingProps"></div>
           <h2>Infrastructures Civiles</h2>
           <div id="tableInfraProps"></div>
+        </div>
+        <div id="tab-spells" class="tab-panel">
+          <div id="tableSpells"></div>
         </div>
         <div id="tab-tags" class="tab-panel">
           <div id="tableTags"></div>

--- a/admin.js
+++ b/admin.js
@@ -86,6 +86,14 @@ const maxOptions = [
   ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f }))
 ];
 
+const spellFields = ['label','costs','effects','description'];
+const spellLabels = {
+  label:'Nom',
+  costs:'Coûts',
+  effects:'Effets',
+  description:'Description'
+};
+
 async function fetchJSON(url, options){
   const resp = await fetch(API_BASE + url, options);
   return resp.json();
@@ -608,7 +616,8 @@ function makeEffectsInput(val){
       {id:'building_production', name:'Prod. bâtiment'},
       {id:'idh', name:'IDH'},
       {id:'instant_production', name:'Prod. instantanée'},
-      {id:'variable_workers', name:'Travailleurs variables'}
+      {id:'variable_workers', name:'Travailleurs variables'},
+      {id:'unlock_page', name:'Débloque page'}
     ];
     typeOptions.forEach(o=>{
       const op = document.createElement('option');
@@ -619,6 +628,9 @@ function makeEffectsInput(val){
     });
     const targetSel = document.createElement('select');
     targetSel.dataset.role = 'target';
+    const pageInput = document.createElement('input');
+    pageInput.type = 'text';
+    pageInput.dataset.role = 'page';
     const qty = document.createElement('input');
     qty.type = 'number';
     qty.min = '0';
@@ -670,6 +682,7 @@ function makeEffectsInput(val){
       blankRes.value = '';
       targetSel.appendChild(blankRes);
       targetSel.style.display = 'none';
+      pageInput.style.display = 'none';
       qty.style.display = 'none';
       summarySpan.style.display = 'none';
       editBtn.style.display = 'none';
@@ -695,6 +708,9 @@ function makeEffectsInput(val){
         else { dataInput.value = ''; updateSummary(); }
       }else if(typeSel.value === 'idh'){
         qty.style.display = '';
+      }else if(typeSel.value === 'unlock_page'){
+        pageInput.style.display = '';
+        pageInput.value = data.page || '';
       }else{
         resourceSelect.forEach(o=>{
           const op = document.createElement('option');
@@ -720,6 +736,7 @@ function makeEffectsInput(val){
     removeBtn.addEventListener('click', ()=> row.remove());
     row.appendChild(typeSel);
     row.appendChild(targetSel);
+    row.appendChild(pageInput);
     row.appendChild(qty);
     row.appendChild(summarySpan);
     row.appendChild(editBtn);
@@ -758,6 +775,11 @@ function makeEffectsInput(val){
         const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);
         if(type && !isNaN(amt)){
           res.push({ type, amount: amt });
+        }
+      }else if(type === 'unlock_page'){
+        const page = rw.querySelector('input[data-role="page"]').value;
+        if(page){
+          res.push({type, page});
         }
       }else{
         const target = rw.querySelector('select[data-role="target"]').value;
@@ -1120,7 +1142,7 @@ function renderTable(container, rows, opts){
 }
 
 async function loadAll(){
-  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps, infraProps, tags] = await Promise.all([
+  const [seigneurs, religions, cultures, kingdoms, counties, duchies, viscounties, marquisates, archduchies, empires, users, seigneuries, baronies, baronyProps, buildingProps, infraProps, spells, tags] = await Promise.all([
     fetchJSON('/api/seigneurs'),
     fetchJSON('/api/religions'),
     fetchJSON('/api/cultures'),
@@ -1137,6 +1159,7 @@ async function loadAll(){
     fetchJSON('/api/barony_properties'),
     fetchJSON('/api/building_properties'),
     fetchJSON('/api/infrastructure_properties'),
+    fetchJSON('/api/spells'),
     fetchJSON('/api/tags'),
   ]);
 
@@ -1280,6 +1303,13 @@ async function loadAll(){
     fields:infraPropFields,
     labels:infraPropLabels,
     selects:{type:typeSelect}
+  });
+
+  const spellsById = spells.slice().sort((a,b)=>a.id - b.id);
+  renderTable(document.getElementById('tableSpells'), spellsById, {
+    endpoint:'spells',
+    fields:spellFields,
+    labels:spellLabels
   });
 }
 

--- a/effects.js
+++ b/effects.js
@@ -118,4 +118,15 @@ class VariableWorkersEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect };
+class UnlockPageEffect extends Effect {
+  constructor(page) {
+    super();
+    this.page = page;
+  }
+  apply(ctx) {
+    if (!ctx.unlockedPages) ctx.unlockedPages = {};
+    ctx.unlockedPages[this.page] = true;
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect };

--- a/gestion.html
+++ b/gestion.html
@@ -19,6 +19,7 @@
         <button class="tab-btn" data-tab="infra">Infrastructures Civiles</button>
         <button class="tab-btn" data-tab="infraMili">Infrastructures Militaires</button>
         <button class="tab-btn" data-tab="proprietes">Propriétés</button>
+        <button class="tab-btn" data-tab="magie" style="display:none">Magie</button>
       </div>
       <div class="tab-panels">
         <div id="tab-sommaire" class="tab-panel active">
@@ -36,6 +37,9 @@
         <div id="tab-proprietes" class="tab-panel">
           <div id="baronyProps"></div>
         </div>
+        <div id="tab-magie" class="tab-panel" style="display:none">
+          <div id="spellList"></div>
+        </div>
       </div>
     </div>
   </main>
@@ -47,7 +51,7 @@
       const panels = document.querySelectorAll('.tab-panel');
 
       let savedTab = localStorage.getItem('gestionActiveTab');
-      const availableTabs = Array.from(buttons).map(btn => btn.dataset.tab);
+      const availableTabs = Array.from(buttons).filter(btn => btn.style.display !== 'none').map(btn => btn.dataset.tab);
       if (!savedTab || !availableTabs.includes(savedTab)) {
         savedTab = 'sommaire';
       }

--- a/gestion.js
+++ b/gestion.js
@@ -208,6 +208,25 @@ async function loadAndRender() {
     basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails, capacities);
     luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails, capacities);
 
+    if (data.unlockedPages && data.unlockedPages.magie) {
+      const magieBtn = document.querySelector('.tab-btn[data-tab="magie"]');
+      const magiePanel = document.getElementById('tab-magie');
+      if (magieBtn && magiePanel) {
+        magieBtn.style.display = '';
+        magiePanel.style.display = '';
+        try {
+          const spellsRes = await fetch('/api/spells');
+          const spells = spellsRes.ok ? await spellsRes.json() : [];
+          renderSpells(spells);
+          if (localStorage.getItem('gestionActiveTab') === 'magie') {
+            magieBtn.click();
+          }
+        } catch (e) {
+          console.error('Erreur chargement sorts', e);
+        }
+      }
+    }
+
     const prodDiv = document.getElementById('productionInfra');
     const civilDiv = document.getElementById('civilInfra');
     const miliDiv = document.getElementById('militaryInfra');
@@ -848,5 +867,56 @@ function buildPropsTable(props) {
   }
   html += '</table>';
   return html;
+}
+
+async function castSpell(id) {
+  try {
+    const resp = await fetch('/api/cast_spell', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    });
+    if (resp.ok) {
+      await loadAndRender();
+    } else {
+      alert('Impossible de lancer le sort');
+    }
+  } catch (e) {
+    console.error('Erreur lancement sort', e);
+    alert('Impossible de lancer le sort');
+  }
+}
+
+function renderSpells(spells) {
+  const container = document.getElementById('spellList');
+  if (!container) return;
+  const rows = spells.map(s => {
+    let costStr = '';
+    try {
+      const costs = JSON.parse(s.costs || '{}');
+      costStr = Object.entries(costs).map(([r,a]) => `${a} ${resourceLabels[r] || r}`).join(', ');
+    } catch {}
+    let effStr = '';
+    try {
+      const effs = JSON.parse(s.effects || '[]');
+      effStr = effs.map(e => {
+        if (e.type === 'production') {
+          return `${e.amount} ${resourceLabels[e.resource] || e.resource}`;
+        }
+        if (e.type === 'unlock_page') {
+          return `Débloque ${e.page}`;
+        }
+        if (e.type === 'idh') {
+          return `IDH ${e.amount}`;
+        }
+        return e.type;
+      }).join(', ');
+    } catch {}
+    return `<tr><td>${s.label}</td><td>${costStr}</td><td>${effStr}</td><td><button class="cast-spell" data-id="${s.id}">Lancer</button></td></tr>`;
+  }).join('');
+  container.innerHTML = `<table class="admin-table"><tr><th>Nom</th><th>Coût</th><th>Effets</th><th></th></tr>${rows}</table>`;
+  container.querySelectorAll('button.cast-spell').forEach(btn => {
+    btn.addEventListener('click', () => castSpell(btn.dataset.id));
+  });
 }
 

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -17,7 +17,7 @@ const VALID_TABLES = new Set([
   'users','religions','cultures','seigneurs','empires','kingdoms','archduchies',
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
   'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
-  'building_properties','infrastructure_properties','barony_connections','tags'
+  'building_properties','infrastructure_properties','barony_connections','tags','spells'
 ]);
 
 // create tables if they do not exist
@@ -247,6 +247,13 @@ CREATE TABLE IF NOT EXISTS infrastructure_properties (
   absolute_restrictions TEXT,
   restrictions TEXT,
   tags TEXT,
+  description TEXT
+);
+CREATE TABLE IF NOT EXISTS spells (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  label TEXT,
+  costs TEXT,
+  effects TEXT,
   description TEXT
 );
 CREATE TABLE IF NOT EXISTS tags (
@@ -777,7 +784,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                     buildingProductionBonus,
                     buildingProductionBonusDetails,
                     idh: 5,
-                    idhDetails: [{ label: 'Base', amount: 5, source: 1 }]
+                    idhDetails: [{ label: 'Base', amount: 5, source: 1 }],
+                    unlockedPages: {}
                   };
                   for (const ip of infraList) {
                     const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
@@ -798,6 +806,9 @@ app.get('/api/my_seigneurie', (req, res) => {
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'idh') {
                         effObj = new IDHEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'unlock_page') {
+                        effObj = new UnlockPageEffect(def.page);
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'variable_workers') {
                         const max = (def.max_workers || 0) * count;
@@ -876,7 +887,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                         idhDetails.push({ label: 'Esclaves', amount: -slavePenalty, source: slaves });
                       }
                     }
-                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh, idhDetails });
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh, idhDetails, unlockedPages: effectCtx.unlockedPages });
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
@@ -893,6 +904,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                           effObj = new BuildingProductionEffect(def.building, def.amount || 0);
                         } else if (def.type === 'idh') {
                           effObj = new IDHEffect(def.amount || 0);
+                        } else if (def.type === 'unlock_page') {
+                          effObj = new UnlockPageEffect(def.page);
                         }
                         if (effObj) {
                           effObj.apply(effectCtx, 1, 'Baronnie');
@@ -1008,6 +1021,52 @@ app.post('/api/infrastructure_properties', requireAdmin, (req,res)=>{
 });
 app.put('/api/infrastructure_properties/:id', requireAdmin, (req,res)=>{
   update('infrastructure_properties', infraPropFields)(req,res);
+});
+
+const spellFields = ['label','costs','effects','description'];
+app.get('/api/spells', (req,res)=>{
+  list('spells')(req,res);
+});
+app.post('/api/spells', requireAdmin, (req,res)=>{
+  create('spells', spellFields)(req,res);
+});
+app.put('/api/spells/:id', requireAdmin, (req,res)=>{
+  update('spells', spellFields)(req,res);
+});
+
+app.post('/api/cast_spell', (req,res)=>{
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const spellId = parseInt(req.body.id, 10);
+  if (!spellId) return res.status(400).json({ error: 'ID invalide' });
+  const userId = req.session.user.id;
+  db.get('SELECT seigneuries.id FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, row) => {
+    if (err) return handleError(res, err);
+    if (!row) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const seigneurieId = row.id;
+    db.get('SELECT * FROM spells WHERE id=?', [spellId], (err2, spell) => {
+      if (err2) return handleError(res, err2);
+      if (!spell) return res.status(404).json({ error: 'Sort introuvable' });
+      const costs = safeParse(spell.costs, {});
+      consumeResources(db, seigneurieId, costs, err3 => {
+        if (err3) return handleError(res, err3);
+        const effects = safeParse(spell.effects, []);
+        let idx = 0;
+        function applyNext() {
+          if (idx >= effects.length) return res.json({ ok: true });
+          const e = effects[idx++];
+          if (e.type === 'production') {
+            performTransaction(db, seigneurieId, e.resource, e.amount || 0, err4 => {
+              if (err4) return handleError(res, err4);
+              applyNext();
+            });
+          } else {
+            applyNext();
+          }
+        }
+        applyNext();
+      });
+    });
+  });
 });
 
 function safeParse(json, fallback){


### PR DESCRIPTION
## Summary
- add UnlockPageEffect and propagate unlocked pages from server
- introduce spells table and API to create and cast spells
- expose Magic page and admin Spells tab to manage and use spells

## Testing
- `node --check effects.js`
- `node --check server.js`
- `node --check gestion.js`
- `node --check admin.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a518605794832d97b40b05ad52cbb7