### PR TITLE
Add magic info table and spell type support

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -87,9 +87,10 @@ const maxOptions = [
   ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f }))
 ];
 
-const spellFields = ['label','costs','effects','description'];
+const spellFields = ['label','type','costs','effects','description'];
 const spellLabels = {
   label:'Nom',
+  type:'Type',
   costs:'Coûts',
   effects:'Effets',
   description:'Description'
@@ -1318,7 +1319,8 @@ async function loadAll(){
   renderTable(document.getElementById('tableSpells'), spellsById, {
     endpoint:'spells',
     fields:spellFields,
-    labels:spellLabels
+    labels:spellLabels,
+    selects:{ type:[{id:'base',name:'Base'},{id:'advanced',name:'Avancé'}] }
   });
 }
 

--- a/effects.js
+++ b/effects.js
@@ -129,4 +129,64 @@ class UnlockPageEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect };
+class SpellSuccessEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.spellSuccessBonus = (ctx.spellSuccessBonus || 0) + total;
+    if (ctx.spellSuccessDetails) ctx.spellSuccessDetails.push({ label, amount: total, source: count });
+  }
+}
+
+class SpellBasicDiscountEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.basicSpellDiscount = (ctx.basicSpellDiscount || 0) + total;
+    if (ctx.basicSpellDiscountDetails) ctx.basicSpellDiscountDetails.push({ label, amount: total, source: count });
+  }
+}
+
+class SpellAdvancedDiscountEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.advancedSpellDiscount = (ctx.advancedSpellDiscount || 0) + total;
+    if (ctx.advancedSpellDiscountDetails) ctx.advancedSpellDiscountDetails.push({ label, amount: total, source: count });
+  }
+}
+
+class SpellRangeEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.spellRangeBonus = (ctx.spellRangeBonus || 0) + total;
+    if (ctx.spellRangeDetails) ctx.spellRangeDetails.push({ label, amount: total, source: count });
+  }
+}
+
+class SpellMaxPerMonthEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.spellMax = (ctx.spellMax || 0) + total;
+    if (ctx.spellMaxDetails) ctx.spellMaxDetails.push({ label, amount: total, source: count });
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect };

--- a/gestion.html
+++ b/gestion.html
@@ -38,6 +38,7 @@
           <div id="baronyProps"></div>
         </div>
         <div id="tab-magie" class="tab-panel" style="display:none">
+          <div id="spellInfo"></div>
           <div id="spellList"></div>
         </div>
       </div>

--- a/gestion.js
+++ b/gestion.js
@@ -137,7 +137,13 @@ async function loadAndRender() {
       });
     });
 
-    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails };
+    const spellSuccess = data.spellSuccess || 75;
+    const basicSpellDiscount = data.basicSpellDiscount || 0;
+    const advancedSpellDiscount = data.advancedSpellDiscount || 0;
+    const spellRange = data.spellRange || 5;
+    const spellMax = data.spellMax || 0;
+    const spellsCast = data.spellsCast || 0;
+    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails, spellSuccess, basicSpellDiscount, advancedSpellDiscount, spellRange, spellMax, spellsCast };
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
@@ -214,6 +220,7 @@ async function loadAndRender() {
       if (magieBtn && magiePanel) {
         magieBtn.style.display = '';
         magiePanel.style.display = '';
+        renderSpellInfo();
         try {
           const spellsRes = await fetch('/api/spells');
           const spells = spellsRes.ok ? await spellsRes.json() : [];
@@ -877,9 +884,12 @@ async function castSpell(id) {
       body: JSON.stringify({ id })
     });
     if (resp.ok) {
+      const data = await resp.json();
+      alert(data.success ? 'Sort réussi' : 'Le sort a échoué');
       await loadAndRender();
     } else {
-      alert('Impossible de lancer le sort');
+      const data = await resp.json().catch(() => ({}));
+      alert(data.error || 'Impossible de lancer le sort');
     }
   } catch (e) {
     console.error('Erreur lancement sort', e);
@@ -887,14 +897,31 @@ async function castSpell(id) {
   }
 }
 
+function renderSpellInfo() {
+  const container = document.getElementById('spellInfo');
+  if (!container) return;
+  const { spellSuccess = 75, basicSpellDiscount = 0, advancedSpellDiscount = 0, spellRange = 5, spellMax = 0, spellsCast = 0 } = gameState;
+  container.innerHTML = `<table class="admin-table"><tr><th colspan="2">Informations générales</th></tr>
+    <tr><td>Taux de réussite des sorts de base</td><td>${spellSuccess}%</td></tr>
+    <tr><td>Rabais sur les sorts de base</td><td>${basicSpellDiscount}%</td></tr>
+    <tr><td>Rabais sur les sorts avancés</td><td>${advancedSpellDiscount}%</td></tr>
+    <tr><td>Portée des sorts</td><td>${spellRange}</td></tr>
+    <tr><td>Sorts jettables</td><td>${spellsCast} / ${spellMax}</td></tr>
+  </table>`;
+}
+
 function renderSpells(spells) {
   const container = document.getElementById('spellList');
   if (!container) return;
-  const rows = spells.map(s => {
+  const rows = spells.filter(s => s.type === 'base').map(s => {
     let costStr = '';
     try {
       const costs = JSON.parse(s.costs || '{}');
-      costStr = Object.entries(costs).map(([r,a]) => `${a} ${resourceLabels[r] || r}`).join(', ');
+      const discount = gameState.basicSpellDiscount || 0;
+      costStr = Object.entries(costs).map(([r,a]) => {
+        const val = Math.round(a * (100 - discount) / 100);
+        return `${val} ${resourceLabels[r] || r}`;
+      }).join(', ');
     } catch {}
     let effStr = '';
     try {

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const { inventaireFields, performTransaction } = require('./transactions');
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -184,6 +184,8 @@ CREATE TABLE IF NOT EXISTS seigneuries (
   inventaire_id INTEGER,
   buildings TEXT DEFAULT '{}',
   infrastructures TEXT DEFAULT '{}',
+  spells_cast INTEGER DEFAULT 0,
+  spell_month TEXT,
   FOREIGN KEY(baronnie_id) REFERENCES baronies(id),
   FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id),
   FOREIGN KEY(inventaire_id) REFERENCES inventaire(id)
@@ -252,6 +254,7 @@ CREATE TABLE IF NOT EXISTS infrastructure_properties (
 CREATE TABLE IF NOT EXISTS spells (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   label TEXT,
+  type TEXT,
   costs TEXT,
   effects TEXT,
   description TEXT
@@ -292,6 +295,12 @@ db.exec(initSql, () => {
       }
       if (!rows.some(r => r.name === 'tax_rate')) {
         db.run("ALTER TABLE seigneuries ADD COLUMN tax_rate INTEGER DEFAULT 5");
+      }
+      if (!rows.some(r => r.name === 'spells_cast')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN spells_cast INTEGER DEFAULT 0");
+      }
+      if (!rows.some(r => r.name === 'spell_month')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN spell_month TEXT");
       }
     }
   });
@@ -382,6 +391,12 @@ db.exec(initSql, () => {
     if (err || !rows) return;
     if (!rows.some(r => r.name === 'effects')) {
       db.run('ALTER TABLE barony_properties ADD COLUMN effects TEXT');
+    }
+  });
+  db.all("PRAGMA table_info(spells)", (err, rows) => {
+    if (err || !rows) return;
+    if (!rows.some(r => r.name === 'type')) {
+      db.run('ALTER TABLE spells ADD COLUMN type TEXT');
     }
   });
   // Ensure every barony has a properties row with default values
@@ -773,6 +788,9 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (errI) return handleError(res, errI);
                   const infraList = iprops || [];
                   const capacities = { vivres: 500, points_magique: 2000 };
+                  const currentMonth = new Date().toISOString().slice(0,7);
+                  let spellsCast = s.spells_cast || 0;
+                  if (s.spell_month !== currentMonth) spellsCast = 0;
                   const buildingProductionBonus = {};
                   const buildingProductionBonusDetails = {};
                   const effectCtx = {
@@ -785,7 +803,12 @@ app.get('/api/my_seigneurie', (req, res) => {
                     buildingProductionBonusDetails,
                     idh: 5,
                     idhDetails: [{ label: 'Base', amount: 5, source: 1 }],
-                    unlockedPages: {}
+                    unlockedPages: {},
+                    spellSuccessBonus: 0,
+                    basicSpellDiscount: 0,
+                    advancedSpellDiscount: 0,
+                    spellRangeBonus: 0,
+                    spellMax: 0
                   };
                   for (const ip of infraList) {
                     const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
@@ -809,6 +832,21 @@ app.get('/api/my_seigneurie', (req, res) => {
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'unlock_page') {
                         effObj = new UnlockPageEffect(def.page);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'spell_success') {
+                        effObj = new SpellSuccessEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'spell_basic_discount') {
+                        effObj = new SpellBasicDiscountEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'spell_advanced_discount') {
+                        effObj = new SpellAdvancedDiscountEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'spell_range') {
+                        effObj = new SpellRangeEffect(def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'spell_max_per_month') {
+                        effObj = new SpellMaxPerMonthEffect(def.amount || 0);
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'variable_workers') {
                         const max = (def.max_workers || 0) * count;
@@ -887,7 +925,12 @@ app.get('/api/my_seigneurie', (req, res) => {
                         idhDetails.push({ label: 'Esclaves', amount: -slavePenalty, source: slaves });
                       }
                     }
-                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh, idhDetails, unlockedPages: effectCtx.unlockedPages });
+                    const spellSuccess = 75 + (effectCtx.spellSuccessBonus || 0);
+                    const basicSpellDiscount = effectCtx.basicSpellDiscount || 0;
+                    const advancedSpellDiscount = effectCtx.advancedSpellDiscount || 0;
+                    const spellRange = 5 + (effectCtx.spellRangeBonus || 0);
+                    const spellMax = effectCtx.spellMax || 0;
+                    res.json({ seigneurie: s, barony, inventaire, production, productionDetails, fields, baronyProps, employment, employmentDetails, buildings, infrastructures, capacities, buildingProductionBonus, buildingProductionBonusDetails, idh, idhDetails, unlockedPages: effectCtx.unlockedPages, spellSuccess, basicSpellDiscount, advancedSpellDiscount, spellRange, spellMax, spellsCast });
                   }
                   if (s.baronnie_id) {
                     db.get('SELECT * FROM barony_properties WHERE barony_id=?', [s.baronnie_id], (err3, props) => {
@@ -906,6 +949,16 @@ app.get('/api/my_seigneurie', (req, res) => {
                           effObj = new IDHEffect(def.amount || 0);
                         } else if (def.type === 'unlock_page') {
                           effObj = new UnlockPageEffect(def.page);
+                        } else if (def.type === 'spell_success') {
+                          effObj = new SpellSuccessEffect(def.amount || 0);
+                        } else if (def.type === 'spell_basic_discount') {
+                          effObj = new SpellBasicDiscountEffect(def.amount || 0);
+                        } else if (def.type === 'spell_advanced_discount') {
+                          effObj = new SpellAdvancedDiscountEffect(def.amount || 0);
+                        } else if (def.type === 'spell_range') {
+                          effObj = new SpellRangeEffect(def.amount || 0);
+                        } else if (def.type === 'spell_max_per_month') {
+                          effObj = new SpellMaxPerMonthEffect(def.amount || 0);
                         }
                         if (effObj) {
                           effObj.apply(effectCtx, 1, 'Baronnie');
@@ -1023,7 +1076,7 @@ app.put('/api/infrastructure_properties/:id', requireAdmin, (req,res)=>{
   update('infrastructure_properties', infraPropFields)(req,res);
 });
 
-const spellFields = ['label','costs','effects','description'];
+const spellFields = ['label','type','costs','effects','description'];
 app.get('/api/spells', (req,res)=>{
   list('spells')(req,res);
 });
@@ -1039,31 +1092,105 @@ app.post('/api/cast_spell', (req,res)=>{
   const spellId = parseInt(req.body.id, 10);
   if (!spellId) return res.status(400).json({ error: 'ID invalide' });
   const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, row) => {
+  db.get('SELECT seigneuries.id, seigneuries.baronnie_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.spells_cast, seigneuries.spell_month FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
     if (err) return handleError(res, err);
-    if (!row) return res.status(400).json({ error: 'Seigneurie introuvable' });
-    const seigneurieId = row.id;
-    db.get('SELECT * FROM spells WHERE id=?', [spellId], (err2, spell) => {
+    if (!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const seigneurieId = srow.id;
+    const infrastructures = safeParse(srow.infrastructures, {});
+    const currentMonth = new Date().toISOString().slice(0,7);
+    let casts = srow.spells_cast || 0;
+    let spellMonth = srow.spell_month;
+    if (spellMonth !== currentMonth) { casts = 0; spellMonth = currentMonth; }
+    db.all('SELECT id, label, effects FROM infrastructure_properties', [], (err2, iprops) => {
       if (err2) return handleError(res, err2);
-      if (!spell) return res.status(404).json({ error: 'Sort introuvable' });
-      const costs = safeParse(spell.costs, {});
-      consumeResources(db, seigneurieId, costs, err3 => {
-        if (err3) return handleError(res, err3);
-        const effects = safeParse(spell.effects, []);
-        let idx = 0;
-        function applyNext() {
-          if (idx >= effects.length) return res.json({ ok: true });
-          const e = effects[idx++];
-          if (e.type === 'production') {
-            performTransaction(db, seigneurieId, e.resource, e.amount || 0, err4 => {
-              if (err4) return handleError(res, err4);
-              applyNext();
-            });
-          } else {
-            applyNext();
+      const effectCtx = { spellSuccessBonus:0, basicSpellDiscount:0, advancedSpellDiscount:0, spellRangeBonus:0, spellMax:0 };
+      (iprops || []).forEach(ip => {
+        const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
+        const count = typeof entry === 'object' ? (entry.built || 0) : entry;
+        if (!count) return;
+        const effects = safeParse(ip.effects, []);
+        effects.forEach(def => {
+          let effObj = null;
+          if (def.type === 'spell_success') {
+            effObj = new SpellSuccessEffect(def.amount || 0);
+          } else if (def.type === 'spell_basic_discount') {
+            effObj = new SpellBasicDiscountEffect(def.amount || 0);
+          } else if (def.type === 'spell_advanced_discount') {
+            effObj = new SpellAdvancedDiscountEffect(def.amount || 0);
+          } else if (def.type === 'spell_range') {
+            effObj = new SpellRangeEffect(def.amount || 0);
+          } else if (def.type === 'spell_max_per_month') {
+            effObj = new SpellMaxPerMonthEffect(def.amount || 0);
           }
-        }
-        applyNext();
+          if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+        });
+      });
+      const applyBarony = cb => {
+        if (!srow.baronnie_id) return cb();
+        db.get('SELECT effects FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err3, bprops) => {
+          if (err3) return handleError(res, err3);
+          const beffs = safeParse(bprops && bprops.effects, []);
+          beffs.forEach(def => {
+            let effObj = null;
+            if (def.type === 'spell_success') {
+              effObj = new SpellSuccessEffect(def.amount || 0);
+            } else if (def.type === 'spell_basic_discount') {
+              effObj = new SpellBasicDiscountEffect(def.amount || 0);
+            } else if (def.type === 'spell_advanced_discount') {
+              effObj = new SpellAdvancedDiscountEffect(def.amount || 0);
+            } else if (def.type === 'spell_range') {
+              effObj = new SpellRangeEffect(def.amount || 0);
+            } else if (def.type === 'spell_max_per_month') {
+              effObj = new SpellMaxPerMonthEffect(def.amount || 0);
+            }
+            if (effObj) effObj.apply(effectCtx, 1, 'Baronnie');
+          });
+          cb();
+        });
+      };
+      applyBarony(() => {
+        const max = effectCtx.spellMax || 0;
+        if (max && casts >= max) return res.status(400).json({ error: 'Limite de sorts atteinte' });
+        db.get('SELECT * FROM spells WHERE id=?', [spellId], (err4, spell) => {
+          if (err4) return handleError(res, err4);
+          if (!spell) return res.status(404).json({ error: 'Sort introuvable' });
+          let costs = safeParse(spell.costs, {});
+          const discount = spell.type === 'base' ? effectCtx.basicSpellDiscount || 0 : effectCtx.advancedSpellDiscount || 0;
+          if (discount) {
+            costs = Object.fromEntries(Object.entries(costs).map(([r,a]) => [r, Math.round(a * (100 - discount) / 100)]));
+          }
+          consumeResources(db, seigneurieId, costs, err5 => {
+            if (err5) return handleError(res, err5);
+            const successChance = 75 + (effectCtx.spellSuccessBonus || 0);
+            const success = Math.random() * 100 < successChance;
+            const effects = success ? safeParse(spell.effects, []) : [];
+            let idx = 0;
+            function applyNext() {
+              if (idx >= effects.length) return finish();
+              const e = effects[idx++];
+              if (e.type === 'production') {
+                performTransaction(db, seigneurieId, e.resource, e.amount || 0, err6 => {
+                  if (err6) return handleError(res, err6);
+                  applyNext();
+                });
+              } else {
+                applyNext();
+              }
+            }
+            function finish() {
+              casts += 1;
+              db.run('UPDATE seigneuries SET spells_cast=?, spell_month=? WHERE id=?', [casts, spellMonth, seigneurieId], err7 => {
+                if (err7) return handleError(res, err7);
+                res.json({ success });
+              });
+            }
+            if (success) {
+              applyNext();
+            } else {
+              finish();
+            }
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- show general magic metrics and spell list on Magie page
- introduce spell type field and admin UI to manage it
- support spell success chance, discounts, range, and monthly limits with building effects

## Testing
- `node --check server.js`
- `node --check gestion.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a532babc54832d8b1283dd46fd32f5