### PR TITLE
Add new spell effects for variable and random resource creation

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -14,6 +14,8 @@ const luxuryResources = [
 
 const resourceLabels = Object.fromEntries([...basicResources, ...luxuryResources]);
 
+let currentSpells = [];
+
 const baronyPropBoolFields = ['water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin'];
 const baronyPropLabels = {
   water_access:"Accès à l'eau",
@@ -878,10 +880,12 @@ function buildPropsTable(props) {
 
 async function castSpell(id) {
   try {
+    const qtyInput = document.querySelector(`input.spell-qty[data-id="${id}"]`);
+    const amount = qtyInput ? parseInt(qtyInput.value, 10) || 0 : 0;
     const resp = await fetch('/api/cast_spell', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id })
+      body: JSON.stringify({ id, amount })
     });
     if (resp.ok) {
       const data = await resp.json();
@@ -911,6 +915,7 @@ function renderSpellInfo() {
 }
 
 function renderSpells(spells) {
+  currentSpells = spells;
   const container = document.getElementById('spellList');
   if (!container) return;
   const rows = spells.filter(s => s.type === 'base').map(s => {
@@ -924,6 +929,7 @@ function renderSpells(spells) {
       }).join(', ');
     } catch {}
     let effStr = '';
+    let qtyField = '';
     try {
       const effs = JSON.parse(s.effects || '[]');
       effStr = effs.map(e => {
@@ -936,12 +942,19 @@ function renderSpells(spells) {
         if (e.type === 'idh') {
           return `IDH ${e.amount}`;
         }
+        if (e.type === 'variable_production') {
+          qtyField = `<input type="number" class="spell-qty" data-id="${s.id}" min="1" ${e.max ? `max="${e.max}"` : ''}>`;
+          return `Jusqu'à ${e.max} ${resourceLabels[e.resource] || e.resource} (${e.ratio} / PM)`;
+        }
+        if (e.type === 'random_luxury') {
+          return `${e.amount} ressource de luxe aléatoire`;
+        }
         return e.type;
       }).join(', ');
     } catch {}
-    return `<tr><td>${s.label}</td><td>${costStr}</td><td>${effStr}</td><td><button class="cast-spell" data-id="${s.id}">Lancer</button></td></tr>`;
+    return `<tr><td>${s.label}</td><td>${costStr}</td><td>${effStr}</td><td>${qtyField}</td><td><button class="cast-spell" data-id="${s.id}">Lancer</button></td></tr>`;
   }).join('');
-  container.innerHTML = `<table class="admin-table"><tr><th>Nom</th><th>Coût</th><th>Effets</th><th></th></tr>${rows}</table>`;
+  container.innerHTML = `<table class="admin-table"><tr><th>Nom</th><th>Coût</th><th>Effets</th><th>Quantité</th><th></th></tr>${rows}</table>`;
   container.querySelectorAll('button.cast-spell').forEach(btn => {
     btn.addEventListener('click', () => castSpell(btn.dataset.id));
   });

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const session = require('express-session');
 const SQLiteStore = require('connect-sqlite3')(session);
 const bcrypt = require('bcryptjs');
 const { inventaireFields, performTransaction } = require('./transactions');
+const luxuryResources = ['fourrure','ivoire','soie','huile','teinture','epices','sel','perle','encens','vin','pierre_precieuse'];
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
@@ -1091,6 +1092,7 @@ app.post('/api/cast_spell', (req,res)=>{
   if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
   const spellId = parseInt(req.body.id, 10);
   if (!spellId) return res.status(400).json({ error: 'ID invalide' });
+  const requestedAmount = parseInt(req.body.amount, 10) || 0;
   const userId = req.session.user.id;
   db.get('SELECT seigneuries.id, seigneuries.baronnie_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.spells_cast, seigneuries.spell_month FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
     if (err) return handleError(res, err);
@@ -1159,17 +1161,39 @@ app.post('/api/cast_spell', (req,res)=>{
           if (discount) {
             costs = Object.fromEntries(Object.entries(costs).map(([r,a]) => [r, Math.round(a * (100 - discount) / 100)]));
           }
+          const effDefs = safeParse(spell.effects, []);
+          let chosenAmount = 0;
+          const varEff = effDefs.find(e => e.type === 'variable_production');
+          if (varEff && requestedAmount > 0) {
+            const ratio = varEff.ratio || 1;
+            const max = varEff.max || 0;
+            chosenAmount = Math.min(requestedAmount, max || requestedAmount);
+            const pmCost = Math.ceil(chosenAmount / ratio);
+            costs.points_magique = (costs.points_magique || 0) + pmCost;
+          }
           consumeResources(db, seigneurieId, costs, err5 => {
             if (err5) return handleError(res, err5);
             const successChance = 75 + (effectCtx.spellSuccessBonus || 0);
             const success = Math.random() * 100 < successChance;
-            const effects = success ? safeParse(spell.effects, []) : [];
+            const effects = success ? effDefs : [];
             let idx = 0;
             function applyNext() {
               if (idx >= effects.length) return finish();
               const e = effects[idx++];
               if (e.type === 'production') {
                 performTransaction(db, seigneurieId, e.resource, e.amount || 0, err6 => {
+                  if (err6) return handleError(res, err6);
+                  applyNext();
+                });
+              } else if (e.type === 'variable_production') {
+                if (!chosenAmount) return applyNext();
+                performTransaction(db, seigneurieId, e.resource, chosenAmount, err6 => {
+                  if (err6) return handleError(res, err6);
+                  applyNext();
+                });
+              } else if (e.type === 'random_luxury') {
+                const resName = luxuryResources[Math.floor(Math.random()*luxuryResources.length)];
+                performTransaction(db, seigneurieId, resName, e.amount || 0, err6 => {
                   if (err6) return handleError(res, err6);
                   applyNext();
                 });


### PR DESCRIPTION
## Summary
- support variable resource production spells with per-PM ratio and max amount
- allow spells to generate random luxury resources
- add UI for entering spell quantity and displaying new effects

## Testing
- `node --check server.js`
- `node --check gestion.js`


------
https://chatgpt.com/codex/tasks/task_e_68a535fef454832d9267538febbe209e