### PR TITLE
feat: add infrastructure production multiplier effect

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -616,6 +616,7 @@ function makeEffectsInput(val, allowedTypes){
       {id:'storage', name:'Stockage'},
       {id:'production', name:'Production ressource'},
       {id:'building_production', name:'Prod. bâtiment'},
+      {id:'infra_production', name:'Mult. infrastructure'},
       {id:'idh', name:'IDH'},
       {id:'instant_production', name:'Prod. instantanée'},
       {id:'variable_workers', name:'Travailleurs variables'},
@@ -718,6 +719,16 @@ function makeEffectsInput(val, allowedTypes){
           op.value = o.id;
           op.textContent = o.name;
           if(String(o.id) === String(data.building)) op.selected = true;
+          targetSel.appendChild(op);
+        });
+        targetSel.style.display = '';
+        qty.style.display = '';
+      }else if(typeSel.value === 'infra_production'){
+        infraPropsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.infrastructure)) op.selected = true;
           targetSel.appendChild(op);
         });
         targetSel.style.display = '';
@@ -849,6 +860,8 @@ function makeEffectsInput(val, allowedTypes){
         if(type && target && amt){
           if(type === 'building_production'){
             res.push({type, building: target, amount: amt});
+          }else if(type === 'infra_production'){
+            res.push({type, infrastructure: target, amount: amt});
           }else{
             res.push({type, resource: target, amount: amt});
           }

--- a/effects.js
+++ b/effects.js
@@ -28,6 +28,11 @@ class ResourceProductionEffect extends Effect {
     ctx.production[this.resource] = (ctx.production[this.resource] || 0) + total;
     if (!ctx.productionDetails[this.resource]) ctx.productionDetails[this.resource] = [];
     ctx.productionDetails[this.resource].push({ label, amount: total, source: count });
+    if (ctx.currentInfraId) {
+      if (!ctx.infraProductionByInfra) ctx.infraProductionByInfra = {};
+      if (!ctx.infraProductionByInfra[ctx.currentInfraId]) ctx.infraProductionByInfra[ctx.currentInfraId] = [];
+      ctx.infraProductionByInfra[ctx.currentInfraId].push({ resource: this.resource, amount: total, label, source: count });
+    }
   }
 }
 
@@ -63,6 +68,25 @@ class BuildingProductionEffect extends Effect {
     } else {
       arr.push({ label: buildLabel, amount: added, source: active });
     }
+    if (ctx.currentInfraId) {
+      if (!ctx.infraProductionByInfra) ctx.infraProductionByInfra = {};
+      if (!ctx.infraProductionByInfra[ctx.currentInfraId]) ctx.infraProductionByInfra[ctx.currentInfraId] = [];
+      ctx.infraProductionByInfra[ctx.currentInfraId].push({ resource: res, amount: added, label: buildLabel, source: active });
+    }
+  }
+}
+
+class InfraProductionEffect extends Effect {
+  constructor(infrastructure, multiplier) {
+    super();
+    this.infrastructure = infrastructure;
+    this.multiplier = multiplier;
+  }
+  apply(ctx, count) {
+    if (!ctx.infrastructureProductionMultipliers) ctx.infrastructureProductionMultipliers = {};
+    const current = ctx.infrastructureProductionMultipliers[this.infrastructure] || 1;
+    const total = Math.pow(this.multiplier, count);
+    ctx.infrastructureProductionMultipliers[this.infrastructure] = current * total;
   }
 }
 
@@ -115,6 +139,11 @@ class VariableWorkersEffect extends Effect {
     ctx.production[this.resource] = (ctx.production[this.resource] || 0) + total;
     if (!ctx.productionDetails[this.resource]) ctx.productionDetails[this.resource] = [];
     ctx.productionDetails[this.resource].push({ label, amount: total, source: workers });
+    if (ctx.currentInfraId) {
+      if (!ctx.infraProductionByInfra) ctx.infraProductionByInfra = {};
+      if (!ctx.infraProductionByInfra[ctx.currentInfraId]) ctx.infraProductionByInfra[ctx.currentInfraId] = [];
+      ctx.infraProductionByInfra[ctx.currentInfraId].push({ resource: this.resource, amount: total, label, source: workers });
+    }
   }
 }
 
@@ -189,4 +218,4 @@ class SpellMaxPerMonthEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect };
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect };

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const luxuryResources = ['fourrure','ivoire','soie','huile','teinture','epices',
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -802,6 +802,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                     bpMap,
                     buildingProductionBonus,
                     buildingProductionBonusDetails,
+                    infraProductionMultipliers: {},
+                    infraProductionByInfra: {},
                     idh: 5,
                     idhDetails: [{ label: 'Base', amount: 5, source: 1 }],
                     unlockedPages: {},
@@ -812,9 +814,10 @@ app.get('/api/my_seigneurie', (req, res) => {
                     spellMax: 0
                   };
                   for (const ip of infraList) {
+                    effectCtx.currentInfraId = ip.id;
                     const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
                     const count = typeof entry === 'object' ? (entry.built || 0) : entry;
-                    if (!count) continue;
+                    if (!count) { delete effectCtx.currentInfraId; continue; }
                     const workers = count * (ip.workers_per_building || 0);
                     if (workers) {
                       employed += workers;
@@ -832,6 +835,9 @@ app.get('/api/my_seigneurie', (req, res) => {
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'building_production') {
                         effObj = new BuildingProductionEffect(def.building, def.amount || 0);
+                        if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                      } else if (def.type === 'infra_production') {
+                        effObj = new InfraProductionEffect(def.infrastructure, def.amount || 1);
                         if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                       } else if (def.type === 'idh') {
                         effObj = new IDHEffect(def.amount || 0);
@@ -866,6 +872,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                         if (effObj) effObj.apply(effectCtx, assigned, ip.label || ip.type);
                       }
                     });
+                    delete effectCtx.currentInfraId;
                   }
                   const slaves = inventaire.esclaves || 0;
                   if (slaves) {
@@ -892,6 +899,24 @@ app.get('/api/my_seigneurie', (req, res) => {
                   }
                   const employment = { employed: Math.max(employed - slaves, 0), slaves };
                   function finalize(barony, baronyProps) {
+                    if (effectCtx.infrastructureProductionMultipliers && effectCtx.infraProductionByInfra) {
+                      Object.entries(effectCtx.infrastructureProductionMultipliers).forEach(([iid, mult]) => {
+                        if (mult === 1) return;
+                        const arr = effectCtx.infraProductionByInfra[iid];
+                        if (!arr) return;
+                        arr.forEach(entry => {
+                          const added = entry.amount * (mult - 1);
+                          production[entry.resource] = (production[entry.resource] || 0) + added;
+                          if (!productionDetails[entry.resource]) productionDetails[entry.resource] = [];
+                          const detail = productionDetails[entry.resource].find(d => d.label === entry.label);
+                          if (detail) {
+                            detail.amount += added;
+                          } else {
+                            productionDetails[entry.resource].push({ label: entry.label, amount: entry.amount * mult, source: entry.source });
+                          }
+                        });
+                      });
+                    }
                     const idhDetails = effectCtx.idhDetails || [];
                     let idh = effectCtx.idh;
                     if (taxRate === 0) {
@@ -951,6 +976,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                           effObj = new ResourceProductionEffect(def.resource, def.amount || 0);
                         } else if (def.type === 'building_production') {
                           effObj = new BuildingProductionEffect(def.building, def.amount || 0);
+                        } else if (def.type === 'infra_production') {
+                          effObj = new InfraProductionEffect(def.infrastructure, def.amount || 1);
                         } else if (def.type === 'idh') {
                           effObj = new IDHEffect(def.amount || 0);
                         } else if (def.type === 'unlock_page') {


### PR DESCRIPTION
## Summary
- add infra production multiplier effect type and logic
- support new effect in admin dropdowns

## Testing
- `npm test`
- `node --check server.js`
- `node --check admin.js`
- `node --check effects.js`


------
https://chatgpt.com/codex/tasks/task_e_68a541b88028832d9c5a37eb77c75d7d