### PR TITLE
Fix admin row clearing after save

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1170,8 +1170,15 @@ function renderTable(container, rows, opts){
         }
       });
       if (opts.beforeSave) opts.beforeSave(payload, item);
-      const updated = await fetchJSON(`/api/${opts.endpoint}/${item.id}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      const resp = await fetchJSON(`/api/${opts.endpoint}/${item.id}`, {
+        method:'PUT',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify(payload)
+      });
       showSaveIndicator(btn.parentElement);
+      const updated = resp && typeof resp === 'object' && 'id' in resp
+        ? resp
+        : { ...item, ...payload };
       const idx = rows.findIndex(r=>r.id === item.id);
       if(idx !== -1) rows[idx] = updated;
       const newRow = renderRow(updated);


### PR DESCRIPTION
## Summary
- Preserve edited row contents in admin table after saving

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5f444f1c4832d82983f0505d9bfc8