### PR TITLE
feat: toggle admin mode and edit seigneurie data

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -54,7 +54,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   if (user && controls && authArea) {
-    if (user.is_admin && current !== 'admin.html') {
+    const adminActive = user.is_admin && user.act_as_admin !== false;
+    if (adminActive && current !== 'admin.html') {
       const adminBtn = document.createElement('button');
       adminBtn.className = 'control-btn';
       adminBtn.textContent = 'Admin';
@@ -68,7 +69,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       gestionBtn.onclick = () => location.href = 'gestion.html';
       controls.insertBefore(gestionBtn, authArea);
     }
-    if (current !== 'mapEditor.html') {
+    if (adminActive && current !== 'mapEditor.html') {
       const editorBtn = document.createElement('button');
       editorBtn.className = 'control-btn';
       editorBtn.textContent = 'Éditeur';

--- a/gestion.html
+++ b/gestion.html
@@ -44,6 +44,13 @@
       </div>
     </div>
   </main>
+  <dialog id="confirmDialog" class="confirm-dialog">
+    <p id="confirmMessage"></p>
+    <div class="dialog-buttons">
+      <button id="confirmCancel" class="control-btn">Annuler</button>
+      <button id="confirmOk" class="control-btn danger">Confirmer</button>
+    </div>
+  </dialog>
   <script src="auth.js"></script>
   <script src="gestion.js"></script>
   <script>

--- a/gestion.js
+++ b/gestion.js
@@ -47,10 +47,57 @@ function safeParse(json, fallback){
 let gameState = {};
 let tagLabels = {};
 let tagCounts = {};
+let currentUser = null;
+
+function showConfirm(message){
+  return new Promise(resolve => {
+    const dialog = document.getElementById('confirmDialog');
+    const msgEl = document.getElementById('confirmMessage');
+    const okBtn = document.getElementById('confirmOk');
+    const cancelBtn = document.getElementById('confirmCancel');
+    msgEl.textContent = message;
+    const clean = result => {
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      dialog.close();
+      resolve(result);
+    };
+    const onOk = () => clean(true);
+    const onCancel = () => clean(false);
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    dialog.showModal();
+  });
+}
+
+async function adminUpdate(fields){
+  if(!gameState.s) return;
+  const payload = { id: gameState.s.id, ...fields };
+  try {
+    const res = await fetch('/api/admin/seigneurie_update', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if(res.ok){
+      await loadAndRender();
+    } else {
+      alert('Mise à jour impossible');
+    }
+  } catch {
+    alert('Mise à jour impossible');
+  }
+}
 
 document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
+  try {
+    const res = await fetch('/api/me');
+    currentUser = res.ok ? await res.json() : null;
+  } catch {
+    currentUser = null;
+  }
   await loadAndRender();
 }
 
@@ -71,6 +118,7 @@ async function loadAndRender() {
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
+    const isAdmin = currentUser && currentUser.is_admin && currentUser.act_as_admin !== false;
     const idh = data.idh || 0;
     const idhDetails = data.idhDetails || [];
     let idhClass = '';
@@ -183,19 +231,50 @@ async function loadAndRender() {
       `<option value="${i}" ${i === (s.tax_rate ?? 5) ? 'selected' : ''}>${i}</option>`
     ).join('');
 
+    const popField = isAdmin ? `<input type="number" id="popInput" value="${s.population}" style="width:6em">` : s.population;
+    const slaveField = isAdmin ? `<input type="number" id="slaveInput" value="${employment.slaves}" style="width:6em">` : employment.slaves;
+    const relField = isAdmin ? `<select id="religionSelect"></select>` : (barony.religion_name || 'Inconnue');
+    const cultField = isAdmin ? `<select id="cultureSelect"></select>` : (barony.culture_name || 'Inconnue');
     popSummary.innerHTML = `
       <h2>Population</h2>
       <table class="admin-table">
         <tr><th>Info</th><th>Nombre</th></tr>
-        <tr><td>Population totale</td><td>${s.population}</td></tr>
+        <tr><td>Population totale</td><td>${popField}</td></tr>
         <tr><td>Population employée</td><td>${employedHtml}</td></tr>
-        <tr><td>Esclaves</td><td>${employment.slaves}</td></tr>
+        <tr><td>Esclaves</td><td>${slaveField}</td></tr>
         <tr><td>IDH</td><td>${idhHtml}</td></tr>
-        <tr><td>Religion</td><td>${barony.religion_name || 'Inconnue'}</td></tr>
-        <tr><td>Culture</td><td>${barony.culture_name || 'Inconnue'}</td></tr>
+        <tr><td>Religion</td><td>${relField}</td></tr>
+        <tr><td>Culture</td><td>${cultField}</td></tr>
         <tr><td>Taxes (écus)</td><td><select id="taxRate">${taxOptions}</select></td></tr>
       </table>
     `;
+    if(isAdmin){
+      const popInput = document.getElementById('popInput');
+      const slaveInput = document.getElementById('slaveInput');
+      popInput.addEventListener('change', ()=>{
+        const val = parseInt(popInput.value,10) || 0;
+        adminUpdate({ population: val });
+      });
+      slaveInput.addEventListener('change', ()=>{
+        const val = parseInt(slaveInput.value,10) || 0;
+        adminUpdate({ esclaves: val });
+      });
+      try {
+        const [relRes, cultRes] = await Promise.all([fetch('/api/religions'), fetch('/api/cultures')]);
+        const religions = relRes.ok ? await relRes.json() : [];
+        const cultures = cultRes.ok ? await cultRes.json() : [];
+        const relSelect = document.getElementById('religionSelect');
+        const cultSelect = document.getElementById('cultureSelect');
+        relSelect.innerHTML = religions.map(r=>`<option value="${r.id}" ${r.id===barony.religion_pop_id?'selected':''}>${r.name}</option>`).join('');
+        cultSelect.innerHTML = cultures.map(c=>`<option value="${c.id}" ${c.id===barony.culture_id?'selected':''}>${c.name}</option>`).join('');
+        relSelect.addEventListener('change', ()=>{
+          adminUpdate({ religion_id: parseInt(relSelect.value,10) || null });
+        });
+        cultSelect.addEventListener('change', ()=>{
+          adminUpdate({ culture_id: parseInt(cultSelect.value,10) || null });
+        });
+      } catch {}
+    }
 
     const taxSelect = document.getElementById('taxRate');
     if (taxSelect) {
@@ -218,8 +297,18 @@ async function loadAndRender() {
     const basicTable = document.getElementById('basicResourcesTable');
     const luxuryTable = document.getElementById('luxuryResourcesTable');
 
-    basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails, capacities);
-    luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails, capacities);
+    basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails, capacities, isAdmin);
+    luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails, capacities, isAdmin);
+
+    if(isAdmin){
+      document.querySelectorAll('.resource-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+          const key = inp.dataset.key;
+          const val = parseInt(inp.value,10) || 0;
+          adminUpdate({ inventaire: { [key]: val } });
+        });
+      });
+    }
 
     if (data.unlockedPages && data.unlockedPages.magie) {
       const magieBtn = document.querySelector('.tab-btn[data-tab="magie"]');
@@ -385,7 +474,8 @@ async function loadAndRender() {
         }
         const empTotal = workersPer * active;
 
-        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${workersPer}</td><td>${restrHtml}</td><td>${built}</td><td>${maxVal}</td>`;
+        const builtField = isAdmin ? `<input type="number" class="building-built-input" data-id="${bp.id}" value="${built}" style="width:6em">` : built;
+        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${workersPer}</td><td>${restrHtml}</td><td>${builtField}</td><td>${maxVal}</td>`;
         if (built > 0) {
           let maxActivate = built;
           if (bp.workers_per_building) {
@@ -417,13 +507,13 @@ async function loadAndRender() {
     }
 
     if (civilDiv) {
-      civilDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='civil'), infrastructures, inv, 'civilInfraTable');
+      civilDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='civil'), infrastructures, inv, 'civilInfraTable', isAdmin);
       const table = document.getElementById('civilInfraTable');
       table.addEventListener('click', handleInfraTableClick);
       table.addEventListener('change', handleInfraTableChange);
     }
     if (miliDiv) {
-      miliDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='militaire'), infrastructures, inv, 'militaryInfraTable');
+      miliDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='militaire'), infrastructures, inv, 'militaryInfraTable', isAdmin);
       const table = document.getElementById('militaryInfraTable');
       table.addEventListener('click', handleInfraTableClick);
       table.addEventListener('change', handleInfraTableChange);
@@ -465,7 +555,7 @@ async function handleBuildingTableClick(e) {
     }
   } else if (e.target.classList.contains('destroy-btn')) {
     const id = e.target.dataset.id;
-    const ok = confirm("Détruire ce bâtiment ? Les ressources dépensées ne seront pas récupérées. Êtes-vous sûr ?");
+    const ok = await showConfirm('Détruire ce bâtiment ? Les ressources dépensées ne seront pas récupérées. Êtes-vous sûr ?');
     if (!ok) return;
     try {
       const resp = await fetch('/api/building/destroy', {
@@ -518,6 +608,10 @@ async function handleBuildingActivationChange(e) {
       console.error('[build] Erreur réseau lors de l\'activation', err);
       alert('Activation impossible');
     }
+  } else if (e.target.classList.contains('building-built-input')) {
+    const id = e.target.dataset.id;
+    const qty = parseInt(e.target.value,10) || 0;
+    adminUpdate({ buildings: { [id]: qty } });
   }
 }
 
@@ -567,6 +661,27 @@ async function handleInfraTableClick(e) {
       console.error('[infra] Erreur réseau lors de la conversion', err);
       alert('Conversion impossible');
     }
+  } else if (e.target.classList.contains('infra-destroy-btn')) {
+    const id = e.target.dataset.id;
+    const ok = await showConfirm('Détruire cette infrastructure ? Les ressources dépensées ne seront pas récupérées. Êtes-vous sûr ?');
+    if(!ok) return;
+    try {
+      const resp = await fetch('/api/infrastructure/destroy', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ id })
+      });
+      if(resp.ok){
+        await loadAndRender();
+      } else {
+        const msg = await resp.text().catch(()=> '');
+        console.warn('[infra] Destruction refusée', resp.status, msg);
+        alert('Destruction impossible');
+      }
+    } catch (err) {
+      console.error('[infra] Erreur réseau lors de la destruction', err);
+      alert('Destruction impossible');
+    }
   }
 }
 
@@ -613,12 +728,16 @@ async function handleInfraTableChange(e) {
       console.error('[infra] Erreur réseau affectation', err);
       alert('Affectation impossible');
     }
+  } else if (e.target.classList.contains('infra-built-input')) {
+    const id = e.target.dataset.id;
+    const qty = parseInt(e.target.value,10) || 0;
+    adminUpdate({ infrastructures: { [id]: qty } });
   }
 }
 
-function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
+function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId, editable = false) {
   const { buildings = {}, infrastructures = {}, s = {}, bpMap = {}, ipMap = {} } = gameState || {};
-  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Requis</th><th>Coût</th><th>Construire</th><th class="multi-col"></th></tr>`;
+  let html = `<table class="admin-table" id="${tableId}"><tr><th>Nom</th><th>Construits</th><th>Max</th><th>Effets</th><th>Requis</th><th>Coût</th><th>Construire</th><th>Détruire</th><th class="multi-col"></th></tr>`;
   for (const ip of list) {
     const entry = infraBuilt[ip.id] || infraBuilt[String(ip.id)] || 0;
     const built = typeof entry === 'object' ? (entry.built || 0) : entry;
@@ -716,11 +835,17 @@ function buildInfraTable(list, infraBuilt = {}, inv = {}, tableId) {
     } catch {}
 
     const canBuild = hasRes && restrOk;
-    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${built}</td><td>${maxVal}</td><td>${effectsHtml}</td><td>${restrHtml}</td><td>${costHtml}</td>`;
+    const builtField = editable ? `<input type="number" class="infra-built-input" data-id="${ip.id}" value="${built}" style="width:6em">` : built;
+    html += `<tr data-id="${ip.id}"><td>${ip.label}</td><td>${builtField}</td><td>${maxVal}</td><td>${effectsHtml}</td><td>${restrHtml}</td><td>${costHtml}</td>`;
     if (maxReached) {
       html += '<td></td>';
     } else {
       html += `<td><button class="build-btn infra-build-btn" data-id="${ip.id}"${canBuild ? '' : ' disabled'}>Construire</button></td>`;
+    }
+    if (built > 0) {
+      html += `<td><button class="destroy-btn infra-destroy-btn" data-id="${ip.id}">Détruire</button></td>`;
+    } else {
+      html += '<td></td>';
     }
 
     let extraHtml = '';
@@ -783,7 +908,7 @@ function updateVarWorkers(el){
   prodCell.textContent = `${nb*per} ${res}`;
 }
 
-function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}) {
+function buildTable(list, showMax = false, inv = {}, production = {}, productionDetails = {}, capacity = {}, editable = false) {
   const {
     buildings = {},
     bpMap = {},
@@ -843,7 +968,8 @@ function buildTable(list, showMax = false, inv = {}, production = {}, production
         prodHtml = spanAmount(total);
       }
     }
-    html += `<tr><td>${label}</td><td>${qty}</td><td>${prodHtml}</td>`;
+    const qtyHtml = editable ? `<input type="number" class="resource-input" data-key="${key}" value="${qty}" style="width:6em">` : qty;
+    html += `<tr><td>${label}</td><td>${qtyHtml}</td><td>${prodHtml}</td>`;
     if (showMax) html += `<td>${capacity[key] !== undefined ? capacity[key] : ''}</td>`;
     html += '</tr>';
   }

--- a/profile.html
+++ b/profile.html
@@ -35,6 +35,9 @@
 
       <button type="submit" class="control-btn">Mettre à jour</button>
     </form>
+    <div id="adminModeContainer" style="display:none" class="admin-mode">
+      <label><input type="checkbox" id="adminMode"> Mode administrateur</label>
+    </div>
   </main>
   <script src="auth.js"></script>
   <script src="profile.js"></script>

--- a/profile.js
+++ b/profile.js
@@ -9,6 +9,20 @@ document.addEventListener('DOMContentLoaded', async () => {
   form.email.value = user.email || '';
   form.first_name.value = user.first_name || '';
   form.last_name.value = user.last_name || '';
+  if(user.is_admin){
+    const container = document.getElementById('adminModeContainer');
+    const checkbox = document.getElementById('adminMode');
+    container.style.display = 'block';
+    checkbox.checked = user.act_as_admin !== false;
+    checkbox.addEventListener('change', async () => {
+      await fetch('/api/admin_mode', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ admin_mode: checkbox.checked })
+      });
+      location.reload();
+    });
+  }
   form.addEventListener('submit', async e => {
     e.preventDefault();
     if (form.password.value && form.password.value !== form.confirm_password.value) {

--- a/server.js
+++ b/server.js
@@ -436,9 +436,13 @@ app.use(session({
     sameSite: 'strict'
   }
 }));
+function isAdminActive(user){
+  return user && user.is_admin && user.act_as_admin !== false;
+}
+
 app.use((req,res,next)=>{
   const adminPages = ['/admin.html','/mapEditor.html'];
-  if (adminPages.includes(req.path) && (!req.session.user || !req.session.user.is_admin)) {
+  if (adminPages.includes(req.path) && !isAdminActive(req.session.user)) {
     return res.redirect('/');
   }
   if (req.path === '/profile.html' && !req.session.user) {
@@ -454,7 +458,7 @@ app.use((req, res, next) => {
     if (!req.session.user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    if (!req.session.user.is_admin) {
+    if (!isAdminActive(req.session.user)) {
       return res.status(403).json({ error: 'Forbidden' });
     }
   }
@@ -478,7 +482,7 @@ function sanitize(val){
 }
 
 function requireAdmin(req, res, next) {
-  if (!req.session.user || !req.session.user.is_admin) {
+  if (!isAdminActive(req.session.user)) {
     return res.status(403).json({ error: 'Forbidden' });
   }
   next();
@@ -557,7 +561,8 @@ app.post('/api/login', async (req, res) => {
           email: user.email,
           first_name: user.first_name,
           last_name: user.last_name,
-          is_admin: !!user.is_admin
+          is_admin: !!user.is_admin,
+          act_as_admin: true
         };
         res.json({ ok: true });
       } catch (error) {
@@ -586,6 +591,14 @@ app.get('/api/me', async (req, res) => {
   } catch (error) {
     handleError(res, error);
   }
+});
+
+app.post('/api/admin_mode', (req,res) => {
+  if(!req.session.user || !req.session.user.is_admin){
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  req.session.user.act_as_admin = !!req.body.admin_mode;
+  res.json({ ok: true });
 });
 
 app.get('/api/users', (req, res) => {
@@ -1029,6 +1042,60 @@ app.post('/api/tax_rate', (req, res) => {
       if (err2) return handleError(res, err2);
       res.json({ tax_rate: rate });
     });
+  });
+});
+
+app.post('/api/admin/seigneurie_update', requireAdmin, (req,res) => {
+  const { id, population, esclaves, religion_id, culture_id, inventaire, buildings, infrastructures } = req.body;
+  db.get('SELECT inventaire_id, baronnie_id, buildings as bjson, infrastructures as ijson FROM seigneuries WHERE id=?', [id], (err, row) => {
+    if(err) return handleError(res, err);
+    if(!row) return res.status(404).json({ error: 'Introuvable' });
+    const tasks = [];
+    if(population !== undefined){
+      tasks.push(cb => db.run('UPDATE seigneuries SET population=? WHERE id=?',[population,id], cb));
+    }
+    if(buildings){
+      const current = safeParse(row.bjson, {});
+      for(const [bid, val] of Object.entries(buildings)){
+        const info = current[bid] || { built: 0, active: 0 };
+        info.built = val;
+        current[bid] = info;
+      }
+      tasks.push(cb => db.run('UPDATE seigneuries SET buildings=? WHERE id=?',[JSON.stringify(current), id], cb));
+    }
+    if(infrastructures){
+      const curr = safeParse(row.ijson, {});
+      for(const [iid, val] of Object.entries(infrastructures)){
+        const entry = curr[iid] || {};
+        entry.built = val;
+        curr[iid] = entry;
+      }
+      tasks.push(cb => db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?',[JSON.stringify(curr), id], cb));
+    }
+    const invUpdates = { ...(inventaire || {}) };
+    if(esclaves !== undefined) invUpdates.esclaves = esclaves;
+    if(Object.keys(invUpdates).length){
+      const set = Object.keys(invUpdates).map(k=>`${k}=?`).join(',');
+      const vals = Object.values(invUpdates);
+      vals.push(row.inventaire_id);
+      tasks.push(cb => db.run(`UPDATE inventaire SET ${set} WHERE id=?`, vals, cb));
+    }
+    if(religion_id !== undefined || culture_id !== undefined){
+      const set = [];
+      const vals = [];
+      if(religion_id !== undefined){ set.push('religion_pop_id=?'); vals.push(religion_id); }
+      if(culture_id !== undefined){ set.push('culture_id=?'); vals.push(culture_id); }
+      vals.push(row.baronnie_id);
+      tasks.push(cb => db.run(`UPDATE baronies SET ${set.join(',')} WHERE id=?`, vals, cb));
+    }
+    let i = 0;
+    const next = (err2) => {
+      if(err2) return handleError(res, err2);
+      const task = tasks[i++];
+      if(!task) return res.json({ ok: true });
+      task(next);
+    };
+    next();
   });
 });
 
@@ -1674,6 +1741,95 @@ app.post('/api/building/destroy', (req,res)=>{
           db.run('UPDATE seigneuries SET buildings=? WHERE id=?', [JSON.stringify(buildings), srow.id], function(err4){
             if(err4) return handleError(res, err4);
             res.json({ building: { id, built, active }, employment, employmentDetails });
+          });
+        });
+      });
+    });
+  });
+});
+
+app.post('/api/infrastructure/destroy', (req,res)=>{
+  if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const id = parseInt(req.body.id,10);
+  if(!id) return res.status(400).json({ error: 'ID invalide' });
+  const userId = req.session.user.id;
+  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+    if(err) return handleError(res, err);
+    if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const infrastructures = safeParse(srow.infrastructures, {});
+    const entry = infrastructures[id];
+    const built = typeof entry === 'object' ? (entry.built || 0) : (entry || 0);
+    if(!built) return res.status(400).json({ error: 'Aucune infrastructure à détruire' });
+    db.all('SELECT id, label, workers_per_building, effects FROM infrastructure_properties', [], (err2, iprops)=>{
+      if(err2) return handleError(res, err2);
+      const iprop = iprops.find(ip => ip.id === id);
+      if(!iprop) return res.status(400).json({ error: 'Infrastructure introuvable' });
+      let updated = typeof entry === 'object' ? { ...entry } : { built };
+      updated.built = built - 1;
+      try {
+        const effects = iprop.effects ? JSON.parse(iprop.effects) : [];
+        effects.forEach((eff, idx) => {
+          if (eff.type === 'instant_production' && eff.uses_per_month != null) {
+            const key = `effect_${idx}_remaining`;
+            const rem = (entry[key] || 0) - (eff.uses_per_month || 0);
+            if (rem > 0) updated[key] = rem; else delete updated[key];
+          }
+          if (eff.type === 'variable_workers') {
+            const key = `effect_${idx}_workers`;
+            const max = (eff.max_workers || 0) * (updated.built || 0);
+            let assigned = entry[key] || 0;
+            if (assigned > max) assigned = max;
+            if (assigned) updated[key] = assigned; else delete updated[key];
+          }
+        });
+      } catch {}
+      if(updated.built <= 0) {
+        delete infrastructures[id];
+      } else {
+        infrastructures[id] = updated;
+      }
+      db.all('SELECT id, label, workers_per_building, effects FROM building_properties', [], (errB, bprops)=>{
+        if(errB) return handleError(res, errB);
+        const buildings = safeParse(srow.buildings, {});
+        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
+          if(err3) return handleError(res, err3);
+          const slaves = inv ? (inv.esclaves || 0) : 0;
+          const totalPop = srow.population + slaves;
+          let employed = 0;
+          const employmentDetails = [];
+          for(const bp of bprops || []){
+            const info = buildings[bp.id] || { built: 0, active: 0 };
+            const workers = (info.active || 0) * (bp.workers_per_building || 0);
+            employed += workers;
+            if(workers) employmentDetails.push({ label: bp.label || bp.type, amount: workers, source: info.active || 0 });
+          }
+          for(const ip of iprops || []){
+            const inf = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
+            const count = typeof inf === 'object' ? (inf.built || 0) : inf;
+            if(!count) continue;
+            const workers = count * (ip.workers_per_building || 0);
+            if(workers){
+              employed += workers;
+              employmentDetails.push({ label: ip.label || ip.type, amount: workers, source: count });
+            }
+            const infObj = typeof inf === 'object' ? inf : {};
+            const effs = safeParse(ip.effects, []);
+            effs.forEach((ef, eidx) => {
+              if(ef.type === 'variable_workers'){
+                const assigned = infObj[`effect_${eidx}_workers`] || 0;
+                if(assigned){
+                  employed += assigned;
+                  employmentDetails.push({ label: ip.label || ip.type, amount: assigned, source: assigned });
+                }
+              }
+            });
+          }
+          if(employed > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
+          if(slaves) employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });
+          const employment = { employed: Math.max(employed - slaves, 0), slaves };
+          db.run('UPDATE seigneuries SET infrastructures=? WHERE id=?', [JSON.stringify(infrastructures), srow.id], function(err4){
+            if(err4) return handleError(res, err4);
+            res.json({ infrastructure: { id, built: updated.built }, employment, employmentDetails });
           });
         });
       });

--- a/styles.css
+++ b/styles.css
@@ -398,6 +398,33 @@ th.multi-col {
   z-index: 1000;
 }
 
+.destroy-btn,
+.danger {
+  background-color: #c00;
+  color: #fff;
+}
+.destroy-btn:hover,
+.danger:hover {
+  background-color: #a00;
+}
+
+.confirm-dialog::backdrop {
+  background: rgba(0,0,0,0.5);
+}
+
+.confirm-dialog {
+  border: 2px solid #c00;
+  padding: 20px;
+  border-radius: 6px;
+}
+
+.confirm-dialog .dialog-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 10px;
+}
+
 /* Indicateurs de production */
 .prod-positive {
   color: #2e8b57;


### PR DESCRIPTION
## Summary
- Allow admins to disable their privileges via profile page and session flag
- Let admins edit seigneurie population, resources, religion, culture, buildings and infrastructures
- Add red destroy buttons with custom confirmation dialog for both buildings and infrastructures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a5f6ac4b7c832d81f956ce35ec8543