### PR TITLE
Fix admin table display after adding rows

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1222,9 +1222,14 @@ function renderTable(container, rows, opts){
           }
         });
         if (opts.beforeSave) opts.beforeSave(payload, null);
-        const created = await fetchJSON(`/api/${opts.endpoint}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+        const created = await fetchJSON(`/api/${opts.endpoint}`,{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify(payload)
+        });
         showSaveIndicator(addBtn.parentElement);
-        rows.push(created);
+        const newItem = { ...payload, ...created };
+        rows.push(newItem);
         renderBody();
       });
       addTd.appendChild(addBtn);


### PR DESCRIPTION
## Summary
- Merge local payload with API response when adding rows so new entries stay visible without page refresh

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5f8eba4ac832db0a7bcc83c6fb4b9