### PR TITLE
Afficher le nom du personnage sur le profil et améliorer la page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -12,27 +12,32 @@
       <span id="authArea" class="auth-area"></span>
     </div>
   </header>
-  <main>
+  <main class="profile-main">
     <form id="profileForm" class="profile-form">
-      <label for="email">Courriel</label>
-      <input type="email" id="email" name="email" disabled>
-
-      <label for="first_name">Prénom</label>
-      <input type="text" id="first_name" name="first_name" required>
-
-      <label for="last_name">Nom</label>
-      <input type="text" id="last_name" name="last_name" required>
-
-      <fieldset class="password-group">
-        <legend>Changer le mot de passe</legend>
+      <div class="tabs">
+        <button type="button" class="tab-btn active" data-tab="info">Informations</button>
+        <button type="button" class="tab-btn" data-tab="password">Mot de passe</button>
+      </div>
+      <div id="tab-info" class="tab-content active">
+        <label for="email">Courriel</label>
+        <input type="email" id="email" name="email" disabled>
+        <label for="first_name">Prénom</label>
+        <input type="text" id="first_name" name="first_name" required>
+        <label for="last_name">Nom</label>
+        <input type="text" id="last_name" name="last_name" required>
+        <div id="characterField" style="display:none; flex-direction: column; gap:8px;">
+          <label for="character_name">Personnage</label>
+          <input type="text" id="character_name" name="character_name" disabled>
+        </div>
+      </div>
+      <div id="tab-password" class="tab-content">
         <label for="current_password">Mot de passe actuel</label>
         <input type="password" id="current_password" name="current_password">
         <label for="new_password">Nouveau mot de passe</label>
         <input type="password" id="new_password" name="password">
         <label for="confirm_password">Confirmer le mot de passe</label>
         <input type="password" id="confirm_password" name="confirm_password">
-      </fieldset>
-
+      </div>
       <button type="submit" class="control-btn">Mettre à jour</button>
     </form>
     <div id="adminModeContainer" style="display:none" class="admin-mode">

--- a/profile.js
+++ b/profile.js
@@ -9,6 +9,20 @@ document.addEventListener('DOMContentLoaded', async () => {
   form.email.value = user.email || '';
   form.first_name.value = user.first_name || '';
   form.last_name.value = user.last_name || '';
+  if(user.character_name){
+    const charField = document.getElementById('characterField');
+    const charInput = document.getElementById('character_name');
+    charInput.value = user.character_name;
+    charField.style.display = 'flex';
+  }
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(`tab-${btn.dataset.tab}`).classList.add('active');
+    });
+  });
   if(user.is_admin){
     const container = document.getElementById('adminModeContainer');
     const checkbox = document.getElementById('adminMode');

--- a/server.js
+++ b/server.js
@@ -585,9 +585,13 @@ app.post('/api/logout', async (req, res) => {
   }
 });
 
-app.get('/api/me', async (req, res) => {
+app.get('/api/me', (req, res) => {
   try {
-    res.json(req.session.user || null);
+    if (!req.session.user) return res.json(null);
+    db.get('SELECT name FROM seigneurs WHERE user_id=?', [req.session.user.id], (err, row) => {
+      if (err) return handleError(res, err);
+      res.json({ ...req.session.user, character_name: row ? row.name : null });
+    });
   } catch (error) {
     handleError(res, error);
   }

--- a/styles.css
+++ b/styles.css
@@ -76,28 +76,56 @@ main {
   padding: 6px;
 }
 
+.profile-main {
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+}
+
 .profile-form {
   display: flex;
   flex-direction: column;
-  max-width: 320px;
+  max-width: 400px;
+  width: 100%;
   margin: 20px auto;
-  gap: 8px;
-}
-
-.profile-form fieldset {
-  border: 1px solid #ccc;
-  padding: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.profile-form legend {
-  padding: 0 4px;
+  gap: 20px;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .profile-form input {
-  padding: 6px;
+  padding: 8px;
+}
+
+.tabs {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  border: none;
+  background-color: #e6ebf3;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+}
+
+.tab-btn.active {
+  background-color: #fff;
+  border-bottom: 2px solid white;
+}
+
+.tab-content {
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tab-content.active {
+  display: flex;
 }
 
 /* Boutons généraux */


### PR DESCRIPTION
## Summary
- Affiche le nom du personnage associé à l'utilisateur dans l'endpoint `/api/me`
- Ajoute un champ "Personnage" et une navigation par onglets sur la page profil
- Améliore le style de la page profil avec un espacement accru et des onglets

## Testing
- `node --check server.js`
- `node --check profile.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5fdaf0ea8832d81dd69bd5b2ffb2c