### PR TITLE
feat: allow admin to manage any seigneurie

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -315,10 +315,12 @@ async function loadAndRender(seigneurieId) {
       taxSelect.addEventListener('change', async () => {
         const rate = parseInt(taxSelect.value, 10);
         try {
+          const payload = { tax_rate: rate };
+          if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
           const res = await fetch('/api/tax_rate', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tax_rate: rate })
+            body: JSON.stringify(payload)
           });
           if (!res.ok) throw new Error('Erreur');
           await loadAndRender(currentSeigneurieId);
@@ -574,6 +576,7 @@ async function handleBuildingTableClick(e) {
     console.log('[build] Bouton de construction cliqué pour', id);
     let payload = { id, quantity: 1 };
     try {
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/building', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -597,10 +600,12 @@ async function handleBuildingTableClick(e) {
     const ok = await showConfirm('Détruire ce bâtiment ? Les ressources dépensées ne seront pas récupérées. Êtes-vous sûr ?');
     if (!ok) return;
     try {
+      const payload = { id };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/building/destroy', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id })
+        body: JSON.stringify(payload)
       });
       if (resp.ok) {
         await loadAndRender(currentSeigneurieId);
@@ -630,10 +635,12 @@ async function handleBuildingActivationChange(e) {
     }
 
     try {
+      const payload = { id, quantity };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/building/activate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, quantity })
+        body: JSON.stringify(payload)
       });
       console.log('[build] Activation réponse', resp.status);
       if (resp.ok) {
@@ -659,10 +666,12 @@ async function handleInfraTableClick(e) {
     const id = e.target.dataset.id;
     console.log('[infra] Bouton de construction infrastructure cliqué pour', id);
     try {
+      const payload = { id, quantity: 1 };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/infrastructure', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, quantity: 1 })
+        body: JSON.stringify(payload)
       });
       console.log('[infra] Réponse du serveur', resp.status);
       if (resp.ok) {
@@ -683,10 +692,12 @@ async function handleInfraTableClick(e) {
     const nb = parseInt(row.querySelector('.inst-nb').value,10) || 0;
     if(nb <= 0) return;
     try {
+      const payload = { id, index: idx, quantity: nb };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/infrastructure/instant_production', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, index: idx, quantity: nb })
+        body: JSON.stringify(payload)
       });
       console.log('[infra] Conversion instantanée réponse', resp.status);
       if(resp.ok){
@@ -705,10 +716,12 @@ async function handleInfraTableClick(e) {
     const ok = await showConfirm('Détruire cette infrastructure ? Les ressources dépensées ne seront pas récupérées. Êtes-vous sûr ?');
     if(!ok) return;
     try {
+      const payload = { id };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/infrastructure/destroy', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ id })
+        body: JSON.stringify(payload)
       });
       if(resp.ok){
         await loadAndRender(currentSeigneurieId);
@@ -751,10 +764,12 @@ async function handleInfraTableChange(e) {
       return;
     }
     try {
+      const payload = { id, index: idx, quantity: qty };
+      if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
       const resp = await fetch('/api/infrastructure/assign_workers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, index: idx, quantity: qty })
+        body: JSON.stringify(payload)
       });
       if(resp.ok){
         await loadAndRender(currentSeigneurieId);
@@ -1651,10 +1666,12 @@ async function castSpell(id) {
   try {
     const qtyInput = document.querySelector(`input.spell-qty[data-id="${id}"]`);
     const amount = qtyInput ? parseInt(qtyInput.value, 10) || 0 : 0;
+    const payload = { id, amount };
+    if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
     const resp = await fetch('/api/cast_spell', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, amount })
+      body: JSON.stringify(payload)
     });
     const spell = currentSpells.find(s => String(s.id) === String(id));
     if (resp.ok) {

--- a/server.js
+++ b/server.js
@@ -488,6 +488,17 @@ function requireAdmin(req, res, next) {
   next();
 }
 
+function getSeigneurie(req, select, cb) {
+  const user = req.session.user;
+  const overrideRaw = isAdminActive(user) ? (req.query.seigneurie_id || (req.body && req.body.seigneurie_id)) : null;
+  const overrideId = overrideRaw ? parseInt(overrideRaw, 10) : null;
+  const sql = overrideId
+    ? `SELECT ${select} FROM seigneuries WHERE id=?`
+    : `SELECT ${select} FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?`;
+  const param = overrideId ? [overrideId] : [user.id];
+  db.get(sql, param, cb);
+}
+
 function create(table, fields) {
   return (req, res) => {
     if (!VALID_TABLES.has(table)) {
@@ -1062,8 +1073,7 @@ app.post('/api/tax_rate', (req, res) => {
   if (Number.isNaN(rate) || rate < 0 || rate > 12) {
     return res.status(400).json({ error: 'Taux invalide' });
   }
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, row) => {
+  getSeigneurie(req, 'seigneuries.id', (err, row) => {
     if (err) return handleError(res, err);
     if (!row) return res.status(400).json({ error: 'Seigneurie introuvable' });
     db.run('UPDATE seigneuries SET tax_rate=? WHERE id=?', [rate, row.id], err2 => {
@@ -1220,8 +1230,7 @@ app.post('/api/cast_spell', (req,res)=>{
   const spellId = parseInt(req.body.id, 10);
   if (!spellId) return res.status(400).json({ error: 'ID invalide' });
   const requestedAmount = parseInt(req.body.amount, 10) || 0;
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id, seigneuries.baronnie_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.spells_cast, seigneuries.spell_month FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
+  getSeigneurie(req, 'seigneuries.id, seigneuries.baronnie_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.spells_cast, seigneuries.spell_month', (err, srow) => {
     if (err) return handleError(res, err);
     if (!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const seigneurieId = srow.id;
@@ -1555,8 +1564,7 @@ app.post('/api/building', (req,res)=>{
   const bId = parseInt(id,10);
   const qty = parseInt(quantity,10) || 0;
   if(!bId || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures', (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     canConstruct(db, srow, bId, qty, (err2, info)=>{
@@ -1593,8 +1601,7 @@ app.post('/api/infrastructure', (req,res)=>{
   const iId = Number.parseInt(id, 10);
   const qty = Number.parseInt(quantity, 10) || 0;
   if (Number.isNaN(iId) || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.baronnie_id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings', (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     canConstructInfra(db, srow, iId, qty, (err2, info)=>{
@@ -1629,8 +1636,7 @@ app.post('/api/building/activate', (req,res)=>{
   const id = parseInt(req.body.id,10);
   const qty = parseInt(req.body.quantity,10);
   if(!id || isNaN(qty) || qty < 0) return res.status(400).json({ error: 'Quantité invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures', (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const buildings = safeParse(srow.buildings, {});
@@ -1697,8 +1703,7 @@ app.post('/api/building/destroy', (req,res)=>{
   if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
   const id = parseInt(req.body.id,10);
   if(!id) return res.status(400).json({ error: 'ID invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures', (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const buildings = safeParse(srow.buildings, {});
@@ -1780,8 +1785,7 @@ app.post('/api/infrastructure/destroy', (req,res)=>{
   if(!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
   const id = parseInt(req.body.id,10);
   if(!id) return res.status(400).json({ error: 'ID invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow)=>{
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings', (err, srow)=>{
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const infrastructures = safeParse(srow.infrastructures, {});
@@ -1872,8 +1876,7 @@ app.post('/api/infrastructure/instant_production', (req,res)=>{
   const idx = Number.parseInt(index, 10);
   const qty = Number.parseInt(quantity, 10) || 0;
   if (Number.isNaN(iId) || Number.isNaN(idx) || qty <= 0) return res.status(400).json({ error: 'Quantité invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.inventaire_id, seigneuries.infrastructures FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.inventaire_id, seigneuries.infrastructures', (err, srow) => {
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     db.get('SELECT effects FROM infrastructure_properties WHERE id=?', [iId], (err2, iprop) => {
@@ -1924,8 +1927,7 @@ app.post('/api/infrastructure/assign_workers', (req,res) => {
   const idx = Number.parseInt(index, 10);
   const qty = Number.parseInt(quantity, 10) || 0;
   if (Number.isNaN(iId) || Number.isNaN(idx) || qty < 0) return res.status(400).json({ error: 'Quantité invalide' });
-  const userId = req.session.user.id;
-  db.get('SELECT seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings FROM seigneurs JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id WHERE seigneurs.user_id=?', [userId], (err, srow) => {
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.population, seigneuries.inventaire_id, seigneuries.infrastructures, seigneuries.buildings', (err, srow) => {
     if(err) return handleError(res, err);
     if(!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
     const infrastructures = safeParse(srow.infrastructures, {});


### PR DESCRIPTION
## Summary
- let admin override seigneurie context for player-specific routes
- send selected seigneurie id from gestion interface

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a606e4f4dc832da810f9d6177b66f9