### PR TITLE
Use boolean flags for barony religious buildings

### DIFF
--- a/mapEditor.html
+++ b/mapEditor.html
@@ -81,14 +81,10 @@
       <select id="editSeigneur"></select>
       <label for="editReligionPop">Religion population&nbsp;:</label>
       <select id="editReligionPop"></select>
-      <label for="editSanctuary">Sanctuaire&nbsp;:</label>
-      <select id="editSanctuary"></select>
-      <label for="editPriory">Prieuré&nbsp;:</label>
-      <select id="editPriory"></select>
-      <label for="editChurch">Église&nbsp;:</label>
-      <select id="editChurch"></select>
-      <label for="editCathedral">Cathédrale&nbsp;:</label>
-      <select id="editCathedral"></select>
+      <label><input type="checkbox" id="editSanctuary"> Sanctuaire</label>
+      <label><input type="checkbox" id="editPriory"> Prieuré</label>
+      <label><input type="checkbox" id="editChurch"> Église</label>
+      <label><input type="checkbox" id="editCathedral"> Cathédrale</label>
       <label><input type="checkbox" id="editPlayer"> Joueur</label>
       <label for="editCulture">Culture&nbsp;:</label>
       <select id="editCulture"></select>

--- a/script.js
+++ b/script.js
@@ -180,18 +180,7 @@
     if (editReligionPop) {
       editReligionPop.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
     }
-    if (editSanctuary) {
-      editSanctuary.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
-    }
-    if (editPriory) {
-      editPriory.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
-    }
-    if (editChurch) {
-      editChurch.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
-    }
-    if (editCathedral) {
-      editCathedral.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
-    }
+    // No religion selection needed for buildings; presence is handled via checkboxes
     if (addCanonicalSelect) {
       addCanonicalSelect.innerHTML = blankOpt + religionOptions.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
     }
@@ -556,17 +545,25 @@
         groupId = kingdom ? kingdom.empire_id : null;
         groupName = empireMap[groupId]?.name || '';
       } else if (type === 'sanctuary') {
-        groupId = info.sanctuary_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_sanctuary) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'priory') {
-        groupId = info.priory_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_priory) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'church') {
-        groupId = info.church_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_church) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'cathedral') {
-        groupId = info.cathedral_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_cathedral) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'occupation') {
         if (!info.seigneur_id) {
           groupId = 'unoccupied';
@@ -651,10 +648,10 @@
       if (editCulture) editCulture.value = info.culture_id || '';
       if (editViscounty) editViscounty.value = info.viscounty_id || '';
       if (editCounty) editCounty.value = info.county_id || '';
-      if (editSanctuary) editSanctuary.value = info.sanctuary_religion_id || '';
-      if (editPriory) editPriory.value = info.priory_religion_id || '';
-      if (editChurch) editChurch.value = info.church_religion_id || '';
-      if (editCathedral) editCathedral.value = info.cathedral_religion_id || '';
+      if (editSanctuary) editSanctuary.checked = !!info.has_sanctuary;
+      if (editPriory) editPriory.checked = !!info.has_priory;
+      if (editChurch) editChurch.checked = !!info.has_church;
+      if (editCathedral) editCathedral.checked = !!info.has_cathedral;
       if (editPlayer) editPlayer.checked = !!info.player;
     }).finally(()=>{
       if (currentFilter) applyFilter(currentFilter); else drawAll();
@@ -672,10 +669,10 @@
     const cultureId = editCulture ? parseInt(editCulture.value || '') || null : null;
     const viscountyId = editViscounty ? parseInt(editViscounty.value || '') || null : null;
     const countyId = editCounty ? parseInt(editCounty.value || '') || null : null;
-    const sanctuaryId = editSanctuary ? parseInt(editSanctuary.value || '') || null : null;
-    const prioryId = editPriory ? parseInt(editPriory.value || '') || null : null;
-    const churchId = editChurch ? parseInt(editChurch.value || '') || null : null;
-    const cathedralId = editCathedral ? parseInt(editCathedral.value || '') || null : null;
+    const hasSanctuary = editSanctuary ? editSanctuary.checked : false;
+    const hasPriory = editPriory ? editPriory.checked : false;
+    const hasChurch = editChurch ? editChurch.checked : false;
+    const hasCathedral = editCathedral ? editCathedral.checked : false;
     const playerFlag = editPlayer ? (editPlayer.checked ? 1 : 0) : 0;
     if (newId === '') return;
     if (newId === oldId) {
@@ -690,14 +687,14 @@
           county_id: countyId,
           viscounty_id: viscountyId,
           culture_id: cultureId,
-          sanctuary_religion_id: sanctuaryId,
-          priory_religion_id: prioryId,
-          church_religion_id: churchId,
-          cathedral_religion_id: cathedralId,
+          has_sanctuary: hasSanctuary ? 1 : 0,
+          has_priory: hasPriory ? 1 : 0,
+          has_church: hasChurch ? 1 : 0,
+          has_cathedral: hasCathedral ? 1 : 0,
           player: playerFlag
         });
       }
-      saveBaronyToServer(oldId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag });
+      saveBaronyToServer(oldId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag });
       return;
     }
     // Si un identifiant existe déjà, échanger les baronnies
@@ -718,8 +715,8 @@
       pixelData[newId] = coordsOld;
       // Mettre à jour les noms : l'ancien id prend l'ancien nom de newId ; le nouvel id prend le nouveau nom saisi
       const tempName = baronyMeta[newId] ? baronyMeta[newId].name : '';
-      baronyMeta[oldId] = { id: oldId, name: tempName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag };
-      baronyMeta[newId] = { id: newId, name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag };
+      baronyMeta[oldId] = { id: oldId, name: tempName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag };
+      baronyMeta[newId] = { id: newId, name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag };
       // Mettre à jour pixelMap
       coordsOld.forEach(([x, y]) => {
         pixelMap[y][x] = newId;
@@ -733,8 +730,8 @@
       colorMap[oldId] = generateColor(oldId);
       drawAll();
       selectBarony(newId);
-      saveBaronyToServer(newId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag });
-      saveBaronyToServer(oldId, { name: tempName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag });
+      saveBaronyToServer(newId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag });
+      saveBaronyToServer(oldId, { name: tempName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag });
       return;
     }
     const coords = pixelData[oldId] || [];
@@ -753,7 +750,7 @@
     colorMap[newId] = generateColor(newId);
     drawAll();
     selectBarony(newId);
-    saveBaronyToServer(newId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, sanctuary_religion_id: sanctuaryId, priory_religion_id: prioryId, church_religion_id: churchId, cathedral_religion_id: cathedralId, player: playerFlag });
+    saveBaronyToServer(newId, { name: newName, seigneur_id: seigneurId, religion_pop_id: relPop, county_id: countyId, viscounty_id: viscountyId, culture_id: cultureId, has_sanctuary: hasSanctuary ? 1 : 0, has_priory: hasPriory ? 1 : 0, has_church: hasChurch ? 1 : 0, has_cathedral: hasCathedral ? 1 : 0, player: playerFlag });
   }
 
   function saveBaronyToServer(id, data) {
@@ -1280,11 +1277,11 @@
       // Enregistrer création pour l’undo
       undoStack.push({ type: 'create', id: newId });
       pixelData[newId] = [];
-      baronyMeta[newId] = { id: newId, name: '', seigneur_id: null, religion_pop_id: null, county_id: null, viscounty_id: null, culture_id: null, sanctuary_religion_id: null, priory_religion_id: null, church_religion_id: null, cathedral_religion_id: null, player: 0 };
+      baronyMeta[newId] = { id: newId, name: '', seigneur_id: null, religion_pop_id: null, county_id: null, viscounty_id: null, culture_id: null, has_sanctuary: 0, has_priory: 0, has_church: 0, has_cathedral: 0, player: 0 };
       colorMap[newId] = generateColor(newId);
       currentSelectedId = newId;
       selectBarony(newId);
-      saveBaronyToServer(newId, { name: '', seigneur_id: null, religion_pop_id: null, county_id: null, viscounty_id: null, culture_id: null, sanctuary_religion_id: null, priory_religion_id: null, church_religion_id: null, cathedral_religion_id: null, player: 0 });
+      saveBaronyToServer(newId, { name: '', seigneur_id: null, religion_pop_id: null, county_id: null, viscounty_id: null, culture_id: null, has_sanctuary: 0, has_priory: 0, has_church: 0, has_cathedral: 0, player: 0 });
       setActiveTool('brush');
     });
   if (brushSizeInput)

--- a/server.js
+++ b/server.js
@@ -111,20 +111,16 @@ CREATE TABLE IF NOT EXISTS baronies (
   county_id INTEGER,
   viscounty_id INTEGER,
   culture_id INTEGER,
-  sanctuary_religion_id INTEGER,
-  priory_religion_id INTEGER,
-  church_religion_id INTEGER,
-  cathedral_religion_id INTEGER,
+  has_sanctuary INTEGER DEFAULT 0,
+  has_priory INTEGER DEFAULT 0,
+  has_church INTEGER DEFAULT 0,
+  has_cathedral INTEGER DEFAULT 0,
   player INTEGER DEFAULT 0,
   FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id) ON DELETE SET NULL,
   FOREIGN KEY(religion_pop_id) REFERENCES religions(id),
   FOREIGN KEY(county_id) REFERENCES counties(id),
   FOREIGN KEY(viscounty_id) REFERENCES viscounties(id),
-  FOREIGN KEY(culture_id) REFERENCES cultures(id),
-  FOREIGN KEY(sanctuary_religion_id) REFERENCES religions(id),
-  FOREIGN KEY(priory_religion_id) REFERENCES religions(id),
-  FOREIGN KEY(church_religion_id) REFERENCES religions(id),
-  FOREIGN KEY(cathedral_religion_id) REFERENCES religions(id)
+  FOREIGN KEY(culture_id) REFERENCES cultures(id)
 );
 CREATE TABLE IF NOT EXISTS barony_pixels (
   barony_id INTEGER PRIMARY KEY REFERENCES baronies(id),
@@ -315,17 +311,17 @@ db.exec(initSql, () => {
     if (!rows.some(r => r.name === 'viscounty_id')) {
       db.run('ALTER TABLE baronies ADD COLUMN viscounty_id INTEGER');
     }
-    if (!rows.some(r => r.name === 'sanctuary_religion_id')) {
-      db.run('ALTER TABLE baronies ADD COLUMN sanctuary_religion_id INTEGER');
+    if (!rows.some(r => r.name === 'has_sanctuary')) {
+      db.run('ALTER TABLE baronies ADD COLUMN has_sanctuary INTEGER DEFAULT 0');
     }
-    if (!rows.some(r => r.name === 'priory_religion_id')) {
-      db.run('ALTER TABLE baronies ADD COLUMN priory_religion_id INTEGER');
+    if (!rows.some(r => r.name === 'has_priory')) {
+      db.run('ALTER TABLE baronies ADD COLUMN has_priory INTEGER DEFAULT 0');
     }
-    if (!rows.some(r => r.name === 'church_religion_id')) {
-      db.run('ALTER TABLE baronies ADD COLUMN church_religion_id INTEGER');
+    if (!rows.some(r => r.name === 'has_church')) {
+      db.run('ALTER TABLE baronies ADD COLUMN has_church INTEGER DEFAULT 0');
     }
-    if (!rows.some(r => r.name === 'cathedral_religion_id')) {
-      db.run('ALTER TABLE baronies ADD COLUMN cathedral_religion_id INTEGER');
+    if (!rows.some(r => r.name === 'has_cathedral')) {
+      db.run('ALTER TABLE baronies ADD COLUMN has_cathedral INTEGER DEFAULT 0');
     }
     if (!rows.some(r => r.name === 'player')) {
       db.run('ALTER TABLE baronies ADD COLUMN player INTEGER DEFAULT 0');
@@ -1147,11 +1143,11 @@ app.get('/api/baronies', (req, res) => {
 });
 app.post('/api/baronies', create('baronies',[
   'id','name','seigneur_id','religion_pop_id','county_id','viscounty_id','culture_id',
-  'sanctuary_religion_id','priory_religion_id','church_religion_id','cathedral_religion_id','player'
+  'has_sanctuary','has_priory','has_church','has_cathedral','player'
 ]));
 app.put('/api/baronies/:id', update('baronies',[
   'name','seigneur_id','religion_pop_id','county_id','viscounty_id','culture_id',
-  'sanctuary_religion_id','priory_religion_id','church_religion_id','cathedral_religion_id','player'
+  'has_sanctuary','has_priory','has_church','has_cathedral','player'
 ]));
 app.delete('/api/baronies/:id', (req,res)=>{
   db.run('DELETE FROM baronies WHERE id=?',[req.params.id], function(err){

--- a/viewer.js
+++ b/viewer.js
@@ -330,10 +330,10 @@
       infoKingdom.textContent = kingdom ? kingdom.name : '';
       const empire = kingdom ? empireMap[kingdom.empire_id] : null;
       infoEmpire.textContent = empire ? empire.name : '';
-      infoSanctuary.textContent = religionMap[info.sanctuary_religion_id]?.name || '';
-      infoPriory.textContent = religionMap[info.priory_religion_id]?.name || '';
-      infoChurch.textContent = religionMap[info.church_religion_id]?.name || '';
-      infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || '';
+      infoSanctuary.textContent = info.has_sanctuary ? religionMap[info.religion_pop_id]?.name || '' : '';
+      infoPriory.textContent = info.has_priory ? religionMap[info.religion_pop_id]?.name || '' : '';
+      infoChurch.textContent = info.has_church ? religionMap[info.religion_pop_id]?.name || '' : '';
+      infoCathedral.textContent = info.has_cathedral ? religionMap[info.religion_pop_id]?.name || '' : '';
       infoPlayer.textContent = info.player ? 'Oui' : 'Non';
       const canon = canonicalLandMap[info.id] || [];
       infoCanonical.textContent = canon.map(rid => religionMap[rid]?.name || '').filter(Boolean).join(', ');
@@ -553,17 +553,25 @@
           sid = seigneurMap[sid]?.overlord_id;
         }
       } else if (type === 'sanctuary') {
-        groupId = info.sanctuary_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_sanctuary) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'priory') {
-        groupId = info.priory_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_priory) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'church') {
-        groupId = info.church_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_church) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'cathedral') {
-        groupId = info.cathedral_religion_id;
-        groupName = religionMap[groupId]?.name || '';
+        if (info.has_cathedral) {
+          groupId = info.religion_pop_id;
+          groupName = religionMap[groupId]?.name || '';
+        }
       } else if (type === 'occupation') {
         if (!info.seigneur_id) {
           groupId = 'unoccupied';


### PR DESCRIPTION
## Summary
- Store barony religious buildings as boolean flags instead of religion IDs
- Update editor UI and logic to toggle presence of Priory, Sanctuary, Church and Cathedral
- Adjust viewer to derive building religion from local population

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`
- `node --check script.js`
- `node --check viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68a605f2a6f8832dac85b4d53c9d3f75