### PR TITLE
Use religion colors for religious building filters

### DIFF
--- a/script.js
+++ b/script.js
@@ -589,7 +589,13 @@
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {
-          if (type === 'religion') {
+          if (
+            type === 'religion' ||
+            type === 'sanctuary' ||
+            type === 'priory' ||
+            type === 'church' ||
+            type === 'cathedral'
+          ) {
             col = hexToRgb(religionMap[groupId]?.color);
           } else if (type === 'culture') {
             col = hexToRgb(cultureMapInfo[groupId]?.color);

--- a/viewer.js
+++ b/viewer.js
@@ -598,7 +598,13 @@
           const hue = Math.floor(Math.random() * 360);
           col = hslToRgb(hue, 65, 65);
         } else {
-          if (type === 'religion') {
+          if (
+            type === 'religion' ||
+            type === 'sanctuary' ||
+            type === 'priory' ||
+            type === 'church' ||
+            type === 'cathedral'
+          ) {
             col = hexToRgb(religionMap[groupId]?.color);
           } else if (type === 'culture') {
             col = hexToRgb(cultureMapInfo[groupId]?.color);


### PR DESCRIPTION
## Summary
- Color Sanctuary, Priory, Church, and Cathedral filters using their religions' colors in map viewer.
- Apply the same religion-based colors for these filters in the map editor.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a60c210580832d9ccafd51502588d0