### PR TITLE
Fix tooltips for magic tab

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -1858,6 +1858,6 @@ function buildTooltipValue(val, details) {
   if (!details || !details.length) return val;
   const rows = details
     .map(d => `<tr><td>${formatDetailLabel(d.label)}</td><td>${spanAmount(d.amount)}</td></tr>`).join('');
-  return `<span class="tooltip">${val}<table class="tooltip-table">${rows}</table></span>`;
+  return `<div class="tooltip">${val}<table class="tooltip-table">${rows}</table></div>`;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -474,6 +474,7 @@ th.multi-col {
   font-weight: bold;
   cursor: help;
   position: relative;
+  display: inline-block;
 }
 
 .tooltip-table {


### PR DESCRIPTION
## Summary
- Ensure magic info tooltips use valid container element
- Display tooltip containers inline so bonus tables show correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a610dfe12c832d9e7776fd1b3910df