### PR TITLE
Add general and location info to seigneurie summary

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -150,6 +150,7 @@ async function loadAndRender(seigneurieId) {
     const s = data.seigneurie;
     const inv = data.inventaire || {};
     const barony = data.barony || {};
+    const seigneur = data.seigneur || {};
     const isAdmin = currentUser && currentUser.is_admin && currentUser.act_as_admin !== false;
     const idh = data.idh || 0;
     const idhDetails = data.idhDetails || [];
@@ -236,7 +237,16 @@ async function loadAndRender(seigneurieId) {
 
     const summary = document.getElementById('summary');
     summary.innerHTML = `
-      <p><strong>Baronnie :</strong> ${barony.name || 'Aucune'}</p>
+      <div id="infoTables" class="resource-tables">
+        <div class="resource-table-container">
+          <h2>Localisation de Jure</h2>
+          <table id="deJureTable" class="admin-table"></table>
+        </div>
+        <div class="resource-table-container">
+          <h2>Informations générales</h2>
+          <table id="generalInfoTable" class="admin-table"></table>
+        </div>
+      </div>
       <div id="populationSummary"></div>
       <div id="resourceTables" class="resource-tables">
         <div class="resource-table-container">
@@ -248,6 +258,24 @@ async function loadAndRender(seigneurieId) {
           <table id="luxuryResourcesTable" class="admin-table"></table>
         </div>
       </div>
+    `;
+
+    const genTable = document.getElementById('generalInfoTable');
+    genTable.innerHTML = `
+      <tr><th>Info</th><th>Valeur</th></tr>
+      <tr><td>Nom du joueur</td><td>${currentUser ? `${currentUser.first_name || ''} ${currentUser.last_name || ''}`.trim() : ''}</td></tr>
+      <tr><td>Nom du personnage</td><td>${seigneur.name || currentUser?.character_name || ''}</td></tr>
+      <tr><td>Religion</td><td>${seigneur.religion_name || 'Inconnue'}</td></tr>
+      <tr><td>Nom du Suzerain</td><td>${seigneur.overlord_name || 'Aucun'}</td></tr>
+    `;
+
+    const deJureTable = document.getElementById('deJureTable');
+    deJureTable.innerHTML = `
+      <tr><th>Niveau</th><th>Nom</th></tr>
+      <tr><td>Royaume</td><td>${barony.kingdom_name || 'Aucun'}</td></tr>
+      <tr><td>Duché</td><td>${barony.duchy_name || 'Aucun'}</td></tr>
+      <tr><td>Comté</td><td>${barony.county_name || 'Aucun'}</td></tr>
+      <tr><td>Baronnie</td><td>${barony.name || 'Aucune'}</td></tr>
     `;
 
     const popSummary = document.getElementById('populationSummary');

--- a/server.js
+++ b/server.js
@@ -967,6 +967,7 @@ app.get('/api/my_seigneurie', (req, res) => {
               const spellRange = 5 + (effectCtx.spellRangeBonus || 0);
               const spellMax = effectCtx.spellMax || 0;
               res.json({
+                seigneur: seig,
                 seigneurie: s,
                 barony,
                 inventaire,
@@ -1031,7 +1032,7 @@ app.get('/api/my_seigneurie', (req, res) => {
                     effObj.apply(effectCtx, 1, 'Baronnie');
                   }
                 }
-                db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
+                db.get(`SELECT b.*, r.name as religion_name, c.name as culture_name, ct.name as county_name, d.name as duchy_name, k.name as kingdom_name FROM baronies b LEFT JOIN religions r ON b.religion_pop_id=r.id LEFT JOIN cultures c ON b.culture_id=c.id LEFT JOIN counties ct ON b.county_id=ct.id LEFT JOIN duchies d ON ct.duchy_id=d.id LEFT JOIN kingdoms k ON d.kingdom_id=k.id WHERE b.id=?`, [s.baronnie_id], (err4, barony) => {
                   if (err4) return handleError(res, err4);
                   finalize(barony, baronyProps);
                 });
@@ -1045,10 +1046,10 @@ app.get('/api/my_seigneurie', (req, res) => {
     }
 
     if (overrideId) {
-      db.get('SELECT seigneuries.*, seigneurs.name as seigneur_name, seigneurs.religion_id as religion_id FROM seigneuries JOIN seigneurs ON seigneurs.id=seigneuries.seigneur_id WHERE seigneuries.id=?', [overrideId], (err, row) => {
+      db.get('SELECT seigneuries.*, seigneurs.name as seigneur_name, seigneurs.religion_id as religion_id, r.name as religion_name, ov.name as overlord_name FROM seigneuries JOIN seigneurs ON seigneurs.id=seigneuries.seigneur_id LEFT JOIN religions r ON seigneurs.religion_id=r.id LEFT JOIN seigneurs ov ON seigneurs.overlord_id=ov.id WHERE seigneuries.id=?', [overrideId], (err, row) => {
         if (err) return handleError(res, err);
         if (!row) return res.status(404).json({ error: 'Introuvable' });
-        const seig = { id: row.seigneur_id, name: row.seigneur_name, religion_id: row.religion_id };
+        const seig = { id: row.seigneur_id, name: row.seigneur_name, religion_id: row.religion_id, religion_name: row.religion_name, overlord_name: row.overlord_name };
         const s = {
           id: row.id,
           baronnie_id: row.baronnie_id,
@@ -1075,8 +1076,11 @@ app.get('/api/my_seigneurie', (req, res) => {
           });
         }
         ensureSeigneur(seig => {
-          db.get('SELECT * FROM seigneuries WHERE seigneur_id=?', [seig.id], (err, seigneurie) => {
-            if (err) return handleError(res, err);
+          db.get('SELECT s.id, s.name, s.religion_id, r.name as religion_name, o.name as overlord_name FROM seigneurs s LEFT JOIN religions r ON s.religion_id=r.id LEFT JOIN seigneurs o ON s.overlord_id=o.id WHERE s.id=?', [seig.id], (err2, seigRow) => {
+            if (err2) return handleError(res, err2);
+            const fullSeig = seigRow || seig;
+            db.get('SELECT * FROM seigneuries WHERE seigneur_id=?', [seig.id], (err, seigneurie) => {
+              if (err) return handleError(res, err);
             function ensureSeigneurie(cb) {
               if (seigneurie) return cb(seigneurie);
               db.run('INSERT INTO inventaire DEFAULT VALUES', function(err){
@@ -1089,7 +1093,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                   });
               });
             }
-            ensureSeigneurie(s => respond(seig, s));
+            ensureSeigneurie(s => respond(fullSeig, s));
+          });
           });
         });
       });


### PR DESCRIPTION
## Summary
- display player, character, religion and suzerain info in management summary
- show de jure hierarchy (kingdom, duchy, county, barony)
- enrich `/api/my_seigneurie` with seigneur details and realm names

## Testing
- `node --check server.js`
- `node --check gestion.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a622cbca58832db3034ae3eef31bb6