### PR TITLE
Swap general info and location tables

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -239,12 +239,12 @@ async function loadAndRender(seigneurieId) {
     summary.innerHTML = `
       <div id="infoTables" class="resource-tables">
         <div class="resource-table-container">
-          <h2>Localisation de Jure</h2>
-          <table id="deJureTable" class="admin-table"></table>
-        </div>
-        <div class="resource-table-container">
           <h2>Informations générales</h2>
           <table id="generalInfoTable" class="admin-table"></table>
+        </div>
+        <div class="resource-table-container">
+          <h2>Localisation de Jure</h2>
+          <table id="deJureTable" class="admin-table"></table>
         </div>
       </div>
       <div id="populationSummary"></div>


### PR DESCRIPTION
## Summary
- reorder summary tables so general info appears before location in management page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62caa91dc832dba96a11b5babc5f0