### PR TITLE
Align properties tab to the right in management view

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -18,8 +18,8 @@
         <button class="tab-btn active" data-tab="sommaire">Sommaire</button>
         <button class="tab-btn" data-tab="infra">Infrastructures Civiles</button>
         <button class="tab-btn" data-tab="infraMili">Infrastructures Militaires</button>
-        <button class="tab-btn" data-tab="proprietes">Propriétés</button>
         <button class="tab-btn" data-tab="magie" style="display:none">Magie</button>
+        <button class="tab-btn push-right" data-tab="proprietes">Propriétés</button>
       </div>
       <div class="tab-panels">
         <div id="tab-sommaire" class="tab-panel active">

--- a/styles.css
+++ b/styles.css
@@ -374,6 +374,9 @@ th.multi-col {
   padding-left: 15px;
   margin-bottom: 10px;
 }
+.tab-buttons .push-right {
+  margin-left: auto;
+}
 .tab-btn {
   background-color: #e6ebf3;
   border: 1px solid #c4d0e3;


### PR DESCRIPTION
## Summary
- Move "Propriétés" tab button after the other tabs and push it to the far right
- Add flex helper class to keep remaining tabs grouped on the left

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a63287eb3c832d81f66c3f2edd67c5