### PR TITLE
Add military resources and OST management tab

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -14,12 +14,16 @@ const luxuryResources = [
   ['encens', 'Encens'], ['vin', 'Vin'], ['pierre_precieuse', 'Pierres précieuses'],
 ];
 
+const militaryResources = [
+  ['hommes_darmes', "Hommes d'armes"], ['chevaux', 'Chevaux'], ['trebuchets', 'Trébuchets'],
+];
+
 const extraResources = [
   ['esclaves', 'Esclaves'], ['prestige', 'Prestige'], ['renommee', 'Renommée'],
 ];
 
-const inventaireFields = [...basicResources, ...luxuryResources, ...extraResources].map(([k]) => k);
-const inventaireLabels = Object.fromEntries([...basicResources, ...luxuryResources, ...extraResources]);
+const inventaireFields = [...basicResources, ...luxuryResources, ...militaryResources, ...extraResources].map(([k]) => k);
+const inventaireLabels = Object.fromEntries([...basicResources, ...luxuryResources, ...militaryResources, ...extraResources]);
 
 const yesNoSelect = [{id:1,name:'Oui'},{id:0,name:'Non'}];
 const baronyPropBoolFields = ['water_access','sea_access','has_or','has_argent','has_fer','has_pierre','has_epices','has_perle','has_encens','has_huiles','has_pierre_precieuses','has_soie','has_sel','has_fourrure','has_teinture','has_ivoire','has_vin'];

--- a/gestion.html
+++ b/gestion.html
@@ -18,6 +18,7 @@
         <button class="tab-btn active" data-tab="sommaire">Sommaire</button>
         <button class="tab-btn" data-tab="infra">Infrastructures Civiles</button>
         <button class="tab-btn" data-tab="infraMili">Infrastructures Militaires</button>
+        <button class="tab-btn" data-tab="ost">Ost</button>
         <button class="tab-btn" data-tab="magie" style="display:none">Magie</button>
         <button class="tab-btn" data-tab="commerce">Commerce</button>
         <button class="tab-btn push-right" data-tab="proprietes">Propriétés</button>
@@ -36,6 +37,7 @@
         <div id="tab-infraMili" class="tab-panel">
           <div id="militaryInfra"></div>
         </div>
+        <div id="tab-ost" class="tab-panel"></div>
         <div id="tab-commerce" class="tab-panel">
           <h2>Chemins commerciaux</h2>
           <div id="tradeRoutes"></div>

--- a/gestion.js
+++ b/gestion.js
@@ -12,10 +12,14 @@ const luxuryResources = [
   ['encens', 'Encens'], ['vin', 'Vin'], ['pierre_precieuse', 'Pierres précieuses']
 ];
 
+const militaryResources = [
+  ['hommes_darmes', "Hommes d'armes"], ['chevaux', 'Chevaux'], ['trebuchets', 'Trébuchets'],
+];
+
 const extraResources = [
   ['esclaves', 'Esclaves'], ['prestige', 'Prestige'], ['renommee', 'Renommée'],
 ];
-const resourceLabels = Object.fromEntries([...basicResources, ...luxuryResources, ...extraResources]);
+const resourceLabels = Object.fromEntries([...basicResources, ...luxuryResources, ...militaryResources, ...extraResources]);
 const resourceSelect = Object.entries(resourceLabels).map(([id, name]) => ({ id, name }));
 const pageSelect = [{ id: 'magie', name: 'Magie' }];
 
@@ -257,6 +261,10 @@ async function loadAndRender(seigneurieId) {
           <h2>Ressources de Luxe</h2>
           <table id="luxuryResourcesTable" class="admin-table"></table>
         </div>
+        <div class="resource-table-container">
+          <h2>Ressources Militaires</h2>
+          <table id="militaryResourcesTable" class="admin-table"></table>
+        </div>
       </div>
     `;
 
@@ -358,11 +366,28 @@ async function loadAndRender(seigneurieId) {
       });
     }
 
+    const ostPanel = document.getElementById('tab-ost');
+    if (ostPanel && !document.getElementById('ostMilitaryResourcesTable')) {
+      ostPanel.innerHTML = `
+        <div class="resource-tables">
+          <div class="resource-table-container">
+            <h2>Ressources Militaires</h2>
+            <table id="ostMilitaryResourcesTable" class="admin-table"></table>
+          </div>
+        </div>`;
+    }
+
     const basicTable = document.getElementById('basicResourcesTable');
     const luxuryTable = document.getElementById('luxuryResourcesTable');
+    const militaryTable = document.getElementById('militaryResourcesTable');
+    const ostTable = document.getElementById('ostMilitaryResourcesTable');
 
     basicTable.innerHTML = buildTable(basicResources, true, inv, production, productionDetails, capacities, isAdmin);
     luxuryTable.innerHTML = buildTable(luxuryResources, false, inv, production, productionDetails, capacities, isAdmin);
+    militaryTable.innerHTML = buildTable(militaryResources, true, inv, production, productionDetails, capacities, isAdmin);
+    if (ostTable) {
+      ostTable.innerHTML = buildTable(militaryResources, true, inv, production, productionDetails, capacities, isAdmin);
+    }
 
     if(isAdmin){
       document.querySelectorAll('.resource-input').forEach(inp => {

--- a/server.js
+++ b/server.js
@@ -165,6 +165,9 @@ CREATE TABLE IF NOT EXISTS inventaire (
   maitres_oeuvre INTEGER DEFAULT 0,
   maitre_espions INTEGER DEFAULT 0,
   points_magique INTEGER DEFAULT 0,
+  hommes_darmes INTEGER DEFAULT 0,
+  chevaux INTEGER DEFAULT 0,
+  trebuchets INTEGER DEFAULT 0,
   fourrure INTEGER DEFAULT 0,
   ivoire INTEGER DEFAULT 0,
   soie INTEGER DEFAULT 0,
@@ -772,8 +775,11 @@ app.get('/api/my_seigneurie', (req, res) => {
           let fields = { built: 0, active: 0 };
           const production = {};
           const productionDetails = {};
-          let employed = 0;
+          let employed = inventaire.hommes_darmes || 0;
           const employmentDetails = [];
+          if (inventaire.hommes_darmes) {
+            employmentDetails.push({ label: "Hommes d'armes", amount: inventaire.hommes_darmes, source: inventaire.hommes_darmes });
+          }
           for (const bp of props) {
             const info = buildings[bp.id] || { built: 0, active: 0 };
             const active = info.active || 0;
@@ -796,7 +802,7 @@ app.get('/api/my_seigneurie', (req, res) => {
           db.all('SELECT * FROM infrastructure_properties', [], (errI, iprops) => {
             if (errI) return handleError(res, errI);
             const infraList = iprops || [];
-            const capacities = { vivres: 500, points_magique: 2000 };
+            const capacities = { vivres: 500, points_magique: 2000, hommes_darmes: 0, chevaux: 0, trebuchets: 0 };
             const currentMonth = new Date().toISOString().slice(0,7);
             let spellsCast = s.spells_cast || 0;
             if (s.spell_month !== currentMonth) spellsCast = 0;
@@ -1693,12 +1699,14 @@ app.post('/api/building/activate', (req,res)=>{
       if(qty > built) return res.status(400).json({ error: 'Quantité supérieure au construit' });
       db.all('SELECT id, label, workers_per_building, effects FROM infrastructure_properties', [], (errI, iprops) => {
         if(errI) return handleError(res, errI);
-        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
+        db.get('SELECT esclaves, hommes_darmes FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
           if(err3) return handleError(res, err3);
           const slaves = inv ? (inv.esclaves || 0) : 0;
+          const menAtArms = inv ? (inv.hommes_darmes || 0) : 0;
           const totalPop = srow.population + slaves;
-          let employed = 0;
+          let employed = menAtArms;
           const employmentDetails = [];
+          if (menAtArms) employmentDetails.push({ label: "Hommes d'armes", amount: menAtArms, source: menAtArms });
           for(const bp of bprops || []){
             const info = buildings[bp.id] || { built: 0, active: 0 };
             const active = (bp.id === id) ? qty : (info.active || 0);
@@ -1778,12 +1786,14 @@ app.post('/api/building/destroy', (req,res)=>{
       }
       db.all('SELECT id, label, workers_per_building, effects FROM infrastructure_properties', [], (errI, iprops) => {
         if(errI) return handleError(res, errI);
-        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
+        db.get('SELECT esclaves, hommes_darmes FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
           if(err3) return handleError(res, err3);
           const slaves = inv ? (inv.esclaves || 0) : 0;
+          const menAtArms = inv ? (inv.hommes_darmes || 0) : 0;
           const totalPop = srow.population + slaves;
-          let employed = 0;
+          let employed = menAtArms;
           const employmentDetails = [];
+          if (menAtArms) employmentDetails.push({ label: "Hommes d'armes", amount: menAtArms, source: menAtArms });
           for(const bp of bprops || []){
             const info = buildings[bp.id] || { built: 0, active: 0 };
             const workers = (info.active || 0) * (bp.workers_per_building || 0);
@@ -1866,12 +1876,14 @@ app.post('/api/infrastructure/destroy', (req,res)=>{
       db.all('SELECT id, label, workers_per_building, effects FROM building_properties', [], (errB, bprops)=>{
         if(errB) return handleError(res, errB);
         const buildings = safeParse(srow.buildings, {});
-        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
+        db.get('SELECT esclaves, hommes_darmes FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inv)=>{
           if(err3) return handleError(res, err3);
           const slaves = inv ? (inv.esclaves || 0) : 0;
+          const menAtArms = inv ? (inv.hommes_darmes || 0) : 0;
           const totalPop = srow.population + slaves;
-          let employed = 0;
+          let employed = menAtArms;
           const employmentDetails = [];
+          if (menAtArms) employmentDetails.push({ label: "Hommes d'armes", amount: menAtArms, source: menAtArms });
           for(const bp of bprops || []){
             const info = buildings[bp.id] || { built: 0, active: 0 };
             const workers = (info.active || 0) * (bp.workers_per_building || 0);
@@ -2021,9 +2033,12 @@ app.post('/api/infrastructure/assign_workers', (req,res) => {
             }
           });
         }
-        db.get('SELECT esclaves FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
+        db.get('SELECT esclaves, hommes_darmes FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
           if(err4) return handleError(res, err4);
           const slaves = inv ? (inv.esclaves || 0) : 0;
+          const menAtArms = inv ? (inv.hommes_darmes || 0) : 0;
+          employed += menAtArms;
+          if (menAtArms) employmentDetails.push({ label: "Hommes d'armes", amount: menAtArms, source: menAtArms });
           const totalPop = srow.population + slaves;
           if(employed > totalPop) return res.status(400).json({ error: 'Travailleurs insuffisants' });
           if(slaves) employmentDetails.push({ label: 'Esclaves', amount: -slaves, source: slaves });

--- a/transactions.js
+++ b/transactions.js
@@ -1,5 +1,6 @@
 const inventaireFields = [
   'or_','pierre','fer','lingot_or','antidote','armureries','rhum','grague','vivres','architectes','charpentiers','maitres_oeuvre','maitre_espions','points_magique',
+  'hommes_darmes','chevaux','trebuchets',
   'fourrure','ivoire','soie','huile','teinture','epices','sel','perle','encens','vin','pierre_precieuse','esclaves','prestige','renommee'
 ];
 


### PR DESCRIPTION
## Summary
- add military resources (Hommes d'armes, Chevaux, Trébuchets) to inventories and selectors
- display new military resources table in summary and new Ost tab
- track men-at-arms as workers and extend inventory schema

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a65f2d5d10832d9c37fa32de98912f