### PR TITLE
Add per-building toggle for instant production effects

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -256,6 +256,15 @@ function openInstantProductionPopup(initial, onSave) {
   usesDiv.appendChild(usesLabel);
   usesDiv.appendChild(usesInput);
 
+  const perDiv = document.createElement('div');
+  const perLabel = document.createElement('label');
+  perLabel.textContent = 'Par bâtiment';
+  const perInput = document.createElement('input');
+  perInput.type = 'checkbox';
+  perInput.checked = initial.per_building !== false;
+  perDiv.appendChild(perLabel);
+  perDiv.appendChild(perInput);
+
   const costDiv = document.createElement('div');
   const costLabel = document.createElement('label');
   costLabel.textContent = 'Coûts';
@@ -266,6 +275,7 @@ function openInstantProductionPopup(initial, onSave) {
   popup.appendChild(resDiv);
   popup.appendChild(amtDiv);
   popup.appendChild(usesDiv);
+  popup.appendChild(perDiv);
   popup.appendChild(costDiv);
 
   const btnRow = document.createElement('div');
@@ -294,6 +304,7 @@ function openInstantProductionPopup(initial, onSave) {
       resource: resSel.value,
       amount: parseInt(amtInput.value, 10) || 0,
       uses_per_month: parseInt(usesInput.value, 10) || 0,
+      per_building: perInput.checked,
       costs,
     });
     overlay.remove();
@@ -690,8 +701,9 @@ function makeEffectsInput(val, allowedTypes){
           if(d.resource && d.amount){
             const resObj = resourceSelect.find(r=>r.id === d.resource);
             const costCount = d.costs ? Object.keys(d.costs).length : 0;
+            const usesTxt = d.uses_per_month ? `, ${d.uses_per_month}/mois${d.per_building === false ? ' total' : '/bât'}` : '';
             summarySpan.textContent = `${d.amount} ${resObj ? resObj.name : d.resource}` +
-              (d.uses_per_month ? `, ${d.uses_per_month}/mois` : '') +
+              usesTxt +
               (costCount ? `, coûts: ${costCount}` : '');
           }
         }else if(typeSel.value === 'variable_workers'){
@@ -837,7 +849,14 @@ function makeEffectsInput(val, allowedTypes){
         let data = {};
         try{ data = JSON.parse(rw.querySelector('input[data-role="data"]').value || '{}'); }catch(e){ data = {}; }
         if(data.resource && data.amount){
-          res.push({type, resource: data.resource, amount: data.amount, uses_per_month: data.uses_per_month || 0, costs: data.costs || {}});
+          res.push({
+            type,
+            resource: data.resource,
+            amount: data.amount,
+            uses_per_month: data.uses_per_month || 0,
+            per_building: data.per_building !== false,
+            costs: data.costs || {}
+          });
         }
       }else if(type === 'variable_workers'){
         let data = {};

--- a/effects.js
+++ b/effects.js
@@ -91,12 +91,13 @@ class InfraProductionEffect extends Effect {
 }
 
 class InstantProductionEffect extends Effect {
-  constructor(resource, amount, costs = {}, usesPerMonth = 0) {
+  constructor(resource, amount, costs = {}, usesPerMonth = 0, perBuilding = true) {
     super();
     this.resource = resource;
     this.amount = amount;
     this.costs = costs;
     this.usesPerMonth = usesPerMonth;
+    this.perBuilding = perBuilding;
   }
 
   apply(ctx, count, label) {
@@ -107,6 +108,7 @@ class InstantProductionEffect extends Effect {
       amount: this.amount,
       costs: this.costs,
       usesPerMonth: this.usesPerMonth,
+      perBuilding: this.perBuilding,
       source: count
     });
   }

--- a/gestion.js
+++ b/gestion.js
@@ -1167,6 +1167,15 @@ function openInstantProductionPopup(initial, onSave) {
   usesDiv.appendChild(usesLabel);
   usesDiv.appendChild(usesInput);
 
+  const perDiv = document.createElement('div');
+  const perLabel = document.createElement('label');
+  perLabel.textContent = 'Par bâtiment';
+  const perInput = document.createElement('input');
+  perInput.type = 'checkbox';
+  perInput.checked = initial.per_building !== false;
+  perDiv.appendChild(perLabel);
+  perDiv.appendChild(perInput);
+
   const costDiv = document.createElement('div');
   const costLabel = document.createElement('label');
   costLabel.textContent = 'Coûts';
@@ -1177,6 +1186,7 @@ function openInstantProductionPopup(initial, onSave) {
   popup.appendChild(resDiv);
   popup.appendChild(amtDiv);
   popup.appendChild(usesDiv);
+  popup.appendChild(perDiv);
   popup.appendChild(costDiv);
 
   const btnRow = document.createElement('div');
@@ -1205,6 +1215,7 @@ function openInstantProductionPopup(initial, onSave) {
       resource: resSel.value,
       amount: parseInt(amtInput.value, 10) || 0,
       uses_per_month: parseInt(usesInput.value, 10) || 0,
+      per_building: perInput.checked,
       costs,
     });
     overlay.remove();
@@ -1361,8 +1372,9 @@ function makeEffectsInput(val) {
           if(d.resource && d.amount){
             const resObj = resourceSelect.find(r=>r.id === d.resource);
             const costCount = d.costs ? Object.keys(d.costs).length : 0;
+            const usesTxt = d.uses_per_month ? `, ${d.uses_per_month}/mois${d.per_building === false ? ' total' : '/bât'}` : '';
             summarySpan.textContent = `${d.amount} ${resObj ? resObj.name : d.resource}` +
-              (d.uses_per_month ? `, ${d.uses_per_month}/mois` : '') +
+              usesTxt +
               (costCount ? `, coûts: ${costCount}` : '');
           }
         }else if(typeSel.value === 'variable_workers'){
@@ -1508,7 +1520,14 @@ function makeEffectsInput(val) {
         let data = {};
         try{ data = JSON.parse(rw.querySelector('input[data-role="data"]').value || '{}'); }catch(e){ data = {}; }
         if(data.resource && data.amount){
-          res.push({type, resource: data.resource, amount: data.amount, uses_per_month: data.uses_per_month || 0, costs: data.costs || {}});
+          res.push({
+            type,
+            resource: data.resource,
+            amount: data.amount,
+            uses_per_month: data.uses_per_month || 0,
+            per_building: data.per_building !== false,
+            costs: data.costs || {}
+          });
         }
       }else if(type === 'variable_workers'){
         let data = {};

--- a/server.js
+++ b/server.js
@@ -1627,8 +1627,15 @@ app.post('/api/building', (req,res)=>{
         const uses = {};
         (info.effects || []).forEach((eff, idx) => {
           if (eff.type === 'instant_production' && eff.uses_per_month != null) {
-            const existRem = existing[`effect_${idx}_remaining`] || 0;
-            uses[`effect_${idx}_remaining`] = existRem + (eff.uses_per_month * qty);
+            const key = `effect_${idx}_remaining`;
+            const existRem = existing[key] || 0;
+            if (eff.per_building === false) {
+              const builtBefore = existing.built || 0;
+              const add = builtBefore > 0 ? 0 : eff.uses_per_month;
+              if (add || existRem) uses[key] = existRem + add;
+            } else {
+              uses[key] = existRem + (eff.uses_per_month * qty);
+            }
           }
         });
         buildings[bId] = { ...existing, ...uses, ...(props || {}), built: newBuilt, active: newActive };
@@ -1663,8 +1670,15 @@ app.post('/api/infrastructure', (req,res)=>{
         const uses = {};
         (info.effects || []).forEach((eff, idx) => {
           if (eff.type === 'instant_production' && eff.uses_per_month != null) {
-            const existRem = existing[`effect_${idx}_remaining`] || 0;
-            uses[`effect_${idx}_remaining`] = existRem + (eff.uses_per_month * qty);
+            const key = `effect_${idx}_remaining`;
+            const existRem = existing[key] || 0;
+            if (eff.per_building === false) {
+              const builtBefore = existing.built || 0;
+              const add = builtBefore > 0 ? 0 : eff.uses_per_month;
+              if (add || existRem) uses[key] = existRem + add;
+            } else {
+              uses[key] = existRem + (eff.uses_per_month * qty);
+            }
           }
         });
         infrastructures[iId] = { ...existing, ...uses, ...(props || {}), built: newBuilt };
@@ -1774,8 +1788,12 @@ app.post('/api/building/destroy', (req,res)=>{
         effects.forEach((eff, idx) => {
           if (eff.type === 'instant_production' && eff.uses_per_month != null) {
             const key = `effect_${idx}_remaining`;
-            const rem = (binfo[key] || 0) - eff.uses_per_month;
-            if (rem > 0) updated[key] = rem; else delete updated[key];
+            if (eff.per_building === false) {
+              if (built <= 0) delete updated[key];
+            } else {
+              const rem = (binfo[key] || 0) - eff.uses_per_month;
+              if (rem > 0) updated[key] = rem; else delete updated[key];
+            }
           }
         });
       } catch {}
@@ -1856,8 +1874,12 @@ app.post('/api/infrastructure/destroy', (req,res)=>{
         effects.forEach((eff, idx) => {
           if (eff.type === 'instant_production' && eff.uses_per_month != null) {
             const key = `effect_${idx}_remaining`;
-            const rem = (entry[key] || 0) - (eff.uses_per_month || 0);
-            if (rem > 0) updated[key] = rem; else delete updated[key];
+            if (eff.per_building === false) {
+              if ((updated.built || 0) <= 0) delete updated[key];
+            } else {
+              const rem = (entry[key] || 0) - (eff.uses_per_month || 0);
+              if (rem > 0) updated[key] = rem; else delete updated[key];
+            }
           }
           if (eff.type === 'variable_workers') {
             const key = `effect_${idx}_workers`;


### PR DESCRIPTION
## Summary
- allow instant production effects to have shared monthly uses instead of per-building
- expose "Par bâtiment" toggle in effect editors
- adjust server logic to apply or remove uses based on the new flag

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a72211404c832dafb6967c85f3d774