### PR TITLE
Use popup to adjust offset in map editor

### DIFF
--- a/mapEditor.html
+++ b/mapEditor.html
@@ -38,10 +38,7 @@
         <option value="occupation">Occupation</option>
       </select>
       <button id="saveToFile" class="control-btn">Enregistrer les pixels</button>
-      <label for="offsetX">Offset :</label>
-      <input type="number" id="offsetX" class="control-btn" value="0">
-      <input type="number" id="offsetY" class="control-btn" value="0">
-      <button id="applyOffset" class="control-btn">Appliquer</button>
+      <button id="offsetBtn" class="control-btn">Offset</button>
       <button id="deleteBarony" class="control-btn">Supprimer</button>
       <button id="selectBarony" class="control-btn">Sélectionner</button>
       <button id="linkBarony" class="control-btn" title="Lier (Ctrl)">Lier</button>

--- a/script.js
+++ b/script.js
@@ -148,9 +148,7 @@
   const toggleEditBtn = document.getElementById('toggleEdit');
   const randomBtn = document.getElementById('randomColors');
   const saveBtn = document.getElementById('saveToFile');
-  const offsetXInput = document.getElementById('offsetX');
-  const offsetYInput = document.getElementById('offsetY');
-  const applyOffsetBtn = document.getElementById('applyOffset');
+  const offsetBtn = document.getElementById('offsetBtn');
   const deleteBtn = document.getElementById('deleteBarony');
   const selectBtn = document.getElementById('selectBarony');
   const linkBtn = document.getElementById('linkBarony');
@@ -314,28 +312,64 @@
 
   // Save pixels to the server
   if (saveBtn) saveBtn.addEventListener('click', () => {
-    const dx = parseInt(offsetXInput.value) || 0;
-    const dy = parseInt(offsetYInput.value) || 0;
-    if (dx !== 0 || dy !== 0) {
-      shiftAllPixels(dx, dy);
-      offsetXInput.value = '0';
-      offsetYInput.value = '0';
-    }
     fetch(API_BASE + pixelEndpoint, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(pixelData)
     });
   });
-  if (applyOffsetBtn) applyOffsetBtn.addEventListener('click', () => {
-    const dx = parseInt(offsetXInput.value) || 0;
-    const dy = parseInt(offsetYInput.value) || 0;
-    if (dx !== 0 || dy !== 0) {
-      shiftAllPixels(dx, dy);
-      offsetXInput.value = '0';
-      offsetYInput.value = '0';
-    }
-  });
+
+  function openOffsetPopup() {
+    const overlay = document.createElement('div');
+    overlay.className = 'popup-overlay';
+    const popup = document.createElement('div');
+    popup.className = 'popup';
+
+    const xDiv = document.createElement('div');
+    const xLabel = document.createElement('label');
+    xLabel.textContent = 'Décalage X';
+    const xInput = document.createElement('input');
+    xInput.type = 'number';
+    xInput.value = '0';
+    xDiv.appendChild(xLabel);
+    xDiv.appendChild(xInput);
+
+    const yDiv = document.createElement('div');
+    const yLabel = document.createElement('label');
+    yLabel.textContent = 'Décalage Y';
+    const yInput = document.createElement('input');
+    yInput.type = 'number';
+    yInput.value = '0';
+    yDiv.appendChild(yLabel);
+    yDiv.appendChild(yInput);
+
+    const btnRow = document.createElement('div');
+    const applyBtn = document.createElement('button');
+    applyBtn.type = 'button';
+    applyBtn.textContent = 'Appliquer';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Annuler';
+    btnRow.appendChild(applyBtn);
+    btnRow.appendChild(cancelBtn);
+
+    popup.appendChild(xDiv);
+    popup.appendChild(yDiv);
+    popup.appendChild(btnRow);
+    overlay.appendChild(popup);
+    document.body.appendChild(overlay);
+
+    cancelBtn.addEventListener('click', () => overlay.remove());
+    applyBtn.addEventListener('click', () => {
+      const dx = parseInt(xInput.value) || 0;
+      const dy = parseInt(yInput.value) || 0;
+      if (dx !== 0 || dy !== 0) {
+        shiftAllPixels(dx, dy);
+      }
+      overlay.remove();
+    });
+  }
+  if (offsetBtn) offsetBtn.addEventListener('click', openOffsetPopup);
   if (linkBtn) linkBtn.addEventListener('click', () => {
     if (currentSelectedId) linkMode = 'link';
   });


### PR DESCRIPTION
## Summary
- Replace inline offset inputs with a single button in the map editor
- Show a popup with X/Y fields to shift pixels

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a746a84c68832da297edb83efae680