### PR TITLE
fix randomizeColors recursion loop

### DIFF
--- a/viewer.js
+++ b/viewer.js
@@ -159,6 +159,16 @@
   initColorMap();
 
   function randomizeColors() {
+    if (mapMode === 'sea') {
+      colorMap = {};
+      Object.keys(pixelData).forEach(id => {
+        const hue = Math.floor(Math.random() * 360);
+        const [r, g, b] = hslToRgb(hue, 65, 65);
+        colorMap[id] = [r, g, b, 100];
+      });
+      drawAll();
+      return;
+    }
     if (filterSelect && filterSelect.value) {
       applyFilter(filterSelect.value, true);
       return;


### PR DESCRIPTION
## Summary
- prevent infinite recursion between `randomizeColors` and `applyFilter` on sea maps by handling sea mode inside `randomizeColors`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a74f93b30c832dbdfdefc75702893c