### PR TITLE
Refactor map filters into shared module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **auth.js** : script inclus sur les pages client pour la connexion, la déconnexion et la navigation conditionnelle.
 - **viewer.js** : affiche la carte en lecture seule.
 - **script.js** : éditeur de carte permettant de modifier les baronnies et d'enregistrer les pixels.
-- **src/mapCore.js** : fonctions communes de rendu/zoom/filtrage utilisées par `viewer.js` et `script.js`.
+- **src/mapCore.js** : fonctions communes de rendu/zoom utilisées par `viewer.js` et `script.js`.
+- **src/mapFilters.js** : gestion des filtres et de la coloration de la carte, partagée par `viewer.js` et `script.js`.
 - **admin.js** : interface d'administration des empires, royaumes, duchés, etc.
 - **gestion.js** : gestion des seigneuries, ressources et sorts côté joueur.
 - **profile.js** : modification du profil utilisateur.

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
   </main>
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
+  <script src="src/mapFilters.js"></script>
   <script src="viewer.js"></script>
   <dialog id="authDialog">
     <form id="loginForm" method="dialog">

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -113,6 +113,7 @@
   <script>window.defaultEditMode = true;</script>
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
+  <script src="src/mapFilters.js"></script>
   <script src="script.js"></script>
   <script src="auth.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -23,6 +23,9 @@
   let seigneurToCounty = {}, seigneurToDuchy = {}, seigneurToKingdom = {}, seigneurToViscounty = {}, seigneurToMarquisate = {}, seigneurToArchduchy = {}, seigneurToEmpire = {};
   let canonicalLandMap = {};
   let baronyAdjacency = {};
+  let mapData = {};
+
+  let filterManager = null;
 
   const baseMap = document.getElementById('baseMap');
   if (mapMode === 'sea' && baseMap) baseMap.src = 'zones_maritimes.png';
@@ -70,6 +73,9 @@
     if (infoPanel) infoPanel.style.display = 'block';
     if (editIdInput) editIdInput.value = id;
     if (editNameInput) editNameInput.value = baronyMeta[id]?.name || '';
+    if (filterManager && filterSelect) {
+      filterManager.applyFilter(filterSelect.value);
+    }
   }
 
   async function fetchData() {
@@ -132,7 +138,7 @@
         baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
       });
     }
-    return {
+    mapData = {
       pixelData,
       baronyMeta,
       seigneurMap,
@@ -158,6 +164,7 @@
       mapHeight,
       mapMode
     };
+    return mapData;
   }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -175,11 +182,16 @@
         fetchData,
         onSelect: handleSelect,
         drawOverlay: () => {},
-        mapMode,
-        updateLegend
+        mapMode
       });
-      if (filterSelect) filterSelect.addEventListener('change', () => core.applyFilter(filterSelect.value));
-      if (randomBtn) randomBtn.addEventListener('click', () => core.randomizeColors());
+      core.ready.then(() => {
+        filterManager = mapFilters.init(core, mapData, { updateLegend });
+        if (filterSelect) {
+          filterSelect.addEventListener('change', () => filterManager.applyFilter(filterSelect.value));
+          filterManager.applyFilter(filterSelect.value);
+        }
+        if (randomBtn) randomBtn.addEventListener('click', () => filterManager.randomizeColors());
+      });
     });
   });
 

--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -27,12 +27,7 @@
 
     // visual state
     let colorMap = {};
-    let currentFilter = '';
     let currentSelectedId = null;
-
-    const terrainColor = [239, 228, 176];
-    const playerColor = [82, 190, 128];
-    const npcColor = [231, 76, 60];
 
     // pan/zoom state
     let scale = 1;
@@ -73,26 +68,7 @@
       return [r, g, b, 100];
     }
 
-    function hslToRgb(h, s, l) {
-      s /= 100; l /= 100;
-      const k = n => (n + h / 30) % 12;
-      const a = s * Math.min(l, 1 - l);
-      const f = n => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
-      return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))];
-    }
-
-    function hexToRgb(hex) {
-      if (!hex) return null;
-      const m = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
-      return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : null;
-    }
-
-    function initColorMap() {
-      colorMap = {};
-      Object.keys(baronyMeta).forEach(id => {
-        colorMap[id] = generateColor(id);
-      });
-    }
+    // color map is expected to be provided externally
 
     function drawAll() {
       const imageData = ctx.createImageData(mapWidth, mapHeight);
@@ -101,8 +77,8 @@
       for (let y = 0; y < mapHeight; y++) {
         for (let x = 0; x < mapWidth; x++) {
           const id = pixelMap[y][x];
-          if (id && (colorMap[id] || (currentFilter === 'canonical' && canonicalPatterns[id]))) {
-            if (currentFilter === 'canonical' && canonicalPatterns[id]) {
+          if (id && (colorMap[id] || canonicalPatterns[id])) {
+            if (canonicalPatterns[id]) {
               const cols = canonicalPatterns[id];
               const col = cols[(x + y) % cols.length];
               data[idx++] = col[0];
@@ -126,16 +102,6 @@
       }
       ctx.putImageData(imageData, 0, 0);
       drawOverlay(ctx, scale, offsetX, offsetY);
-    }
-
-    function randomizeColors() {
-      Object.keys(baronyMeta).forEach(id => {
-        const hue = Math.floor(Math.random() * 360);
-        const [r, g, b] = hslToRgb(hue, 65, 65);
-        colorMap[id] = [r, g, b, 100];
-      });
-      if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
-      drawAll();
     }
 
     function handleWheel(e) {
@@ -188,13 +154,13 @@
       }
       currentSelectedId = id;
       if (!id) {
-        if (currentFilter) applyFilter(currentFilter); else drawAll();
+        drawAll();
         onSelect(id);
         return;
       }
       if (!colorMap[id]) colorMap[id] = generateColor(id);
       colorMap[id][3] = 180;
-      if (currentFilter) applyFilter(currentFilter); else drawAll();
+      drawAll();
       onSelect(id);
     }
 
@@ -206,262 +172,6 @@
       selectBarony(id);
     }
 
-    function updateLegend(groups) {
-      if (!options.updateLegend) return;
-      options.updateLegend(groups);
-    }
-
-    function applyFilter(type, randomize = false) {
-      if (mapMode === 'sea') {
-        randomizeColors();
-        return;
-      }
-      currentFilter = type || '';
-      canonicalPatterns = {};
-      if (!type) {
-        initColorMap();
-        updateLegend(null);
-        if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
-        drawAll();
-        return;
-      }
-      if (type === 'distance') {
-        colorMap = {};
-        if (!currentSelectedId) {
-          drawAll();
-          return;
-        }
-        const distances = {};
-        const queue = [currentSelectedId];
-        distances[currentSelectedId] = 0;
-        while (queue.length > 0) {
-          const cur = queue.shift();
-          const next = baronyAdjacency[cur] || [];
-          next.forEach(n => {
-            if (distances[n] === undefined) {
-              distances[n] = distances[cur] + 1;
-              queue.push(n);
-            }
-          });
-        }
-        Object.keys(baronyMeta).forEach(id => {
-          const d = distances[id];
-          if (d === undefined) return;
-          const hue = (d * 40) % 360;
-          const [r, g, b] = hslToRgb(hue, 65, 65);
-          colorMap[id] = [r, g, b, 100];
-        });
-        if (currentSelectedId && colorMap[currentSelectedId]) colorMap[currentSelectedId][3] = 180;
-        updateLegend(null);
-        drawAll();
-        return;
-      }
-      const groupColors = {};
-      colorMap = {};
-      Object.entries(baronyMeta).forEach(([id, info]) => {
-        let groupId = null;
-        let groupName = '';
-        if (type === 'canonical') {
-          const rIds = canonicalLandMap[id] || [];
-          if (rIds.length === 0) {
-            colorMap[id] = [...terrainColor, 100];
-            return;
-          }
-          canonicalPatterns[id] = rIds.map(rid => {
-            if (!groupColors[rid]) {
-              const col = hexToRgb(religionMap[rid]?.color) || generateColor(String(rid)).slice(0,3);
-              groupColors[rid] = { color: col, name: religionMap[rid]?.name || 'N/A' };
-            }
-            return groupColors[rid].color;
-          });
-          const first = canonicalPatterns[id][0];
-          colorMap[id] = [first[0], first[1], first[2], 100];
-          return;
-        } else if (type === 'religion') {
-          groupId = info.religion_pop_id;
-          groupName = religionMap[groupId]?.name || '';
-        } else if (type === 'culture') {
-          groupId = info.culture_id;
-          groupName = cultureMapInfo[groupId]?.name || '';
-        } else if (type === 'viscounty') {
-          groupId = info.viscounty_id;
-          groupName = viscountyMap[groupId]?.name || '';
-        } else if (type === 'county') {
-          groupId = info.county_id;
-          groupName = countyMap[groupId]?.name || '';
-        } else if (type === 'marquisate') {
-          const county = countyMap[info.county_id];
-          groupId = county ? county.marquisate_id : null;
-          groupName = marquisateMap[groupId]?.name || '';
-        } else if (type === 'duchy') {
-          const county = countyMap[info.county_id];
-          groupId = county ? county.duchy_id : null;
-          groupName = duchyMap[groupId]?.name || '';
-        } else if (type === 'archduchy') {
-          const county = countyMap[info.county_id];
-          const duchy = county ? duchyMap[county.duchy_id] : null;
-          groupId = duchy ? duchy.archduchy_id : null;
-          groupName = archduchyMap[groupId]?.name || '';
-        } else if (type === 'kingdom') {
-          const county = countyMap[info.county_id];
-          const duchy = county ? duchyMap[county.duchy_id] : null;
-          groupId = duchy ? duchy.kingdom_id : null;
-          groupName = kingdomMap[groupId]?.name || '';
-        } else if (type === 'empire') {
-          const county = countyMap[info.county_id];
-          const duchy = county ? duchyMap[county.duchy_id] : null;
-          const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
-          groupId = kingdom ? kingdom.empire_id : null;
-          groupName = empireMap[groupId]?.name || '';
-        } else if (type === 'viscounty_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const vId = seigneurToViscounty[sid];
-            if (vId) {
-              groupId = vId;
-              groupName = viscountyMap[vId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'county_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const cId = seigneurToCounty[sid];
-            if (cId) {
-              groupId = cId;
-              groupName = countyMap[cId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'marquisate_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const mId = seigneurToMarquisate[sid];
-            if (mId) {
-              groupId = mId;
-              groupName = marquisateMap[mId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'duchy_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const dId = seigneurToDuchy[sid];
-            if (dId) {
-              groupId = dId;
-              groupName = duchyMap[dId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'archduchy_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const aId = seigneurToArchduchy[sid];
-            if (aId) {
-              groupId = aId;
-              groupName = archduchyMap[aId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'kingdom_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const kId = seigneurToKingdom[sid];
-            if (kId) {
-              groupId = kId;
-              groupName = kingdomMap[kId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'empire_defacto') {
-          let sid = info.seigneur_id;
-          while (sid) {
-            const eId = seigneurToEmpire[sid];
-            if (eId) {
-              groupId = eId;
-              groupName = empireMap[eId]?.name || '';
-              break;
-            }
-            sid = seigneurMap[sid]?.overlord_id;
-          }
-        } else if (type === 'sanctuary') {
-          if (info.has_sanctuary) {
-            groupId = info.religion_pop_id;
-            groupName = religionMap[groupId]?.name || '';
-          }
-        } else if (type === 'priory') {
-          if (info.has_priory) {
-            groupId = info.religion_pop_id;
-            groupName = religionMap[groupId]?.name || '';
-          }
-        } else if (type === 'church') {
-          if (info.has_church) {
-            groupId = info.religion_pop_id;
-            groupName = religionMap[groupId]?.name || '';
-          }
-        } else if (type === 'cathedral') {
-          if (info.has_cathedral) {
-            groupId = info.religion_pop_id;
-            groupName = religionMap[groupId]?.name || '';
-          }
-        } else if (type === 'occupation') {
-          if (!info.seigneur_id) {
-            groupId = 'unoccupied';
-            groupName = 'Non occupée';
-          } else if (info.player) {
-            groupId = 'player';
-            groupName = 'Joueur';
-          } else {
-            groupId = 'npc';
-            groupName = 'PNJ';
-          }
-        }
-        if (groupId == null) {
-          colorMap[id] = [...terrainColor, 100];
-          return;
-        }
-        if (!groupColors[groupId]) {
-          let col;
-          if (type === 'occupation') {
-            if (groupId === 'player') col = playerColor;
-            else if (groupId === 'npc') col = npcColor;
-            else col = terrainColor;
-          } else if (randomize) {
-            const hue = Math.floor(Math.random() * 360);
-            col = hslToRgb(hue, 65, 65);
-          } else {
-            if (
-              type === 'religion' ||
-              type === 'sanctuary' ||
-              type === 'priory' ||
-              type === 'church' ||
-              type === 'cathedral'
-            ) {
-              col = hexToRgb(religionMap[groupId]?.color);
-            } else if (type === 'culture') {
-              col = hexToRgb(cultureMapInfo[groupId]?.color);
-            }
-            if (!col) {
-              col = generateColor(String(groupId || 0)).slice(0, 3);
-            }
-          }
-          groupColors[groupId] = { color: col, name: groupName || 'N/A' };
-        }
-        const col = groupColors[groupId].color;
-        colorMap[id] = [col[0], col[1], col[2], 100];
-      });
-      if (currentSelectedId && colorMap[currentSelectedId]) {
-        colorMap[currentSelectedId][3] = 180;
-      }
-      updateLegend(groupColors);
-      drawAll();
-    }
 
     canvas.addEventListener('wheel', handleWheel, { passive: false });
     canvas.addEventListener('mousedown', handlePanStart);
@@ -500,15 +210,12 @@
       seigneurToKingdom = data.seigneurToKingdom || {};
       seigneurToEmpire = data.seigneurToEmpire || {};
       rebuildPixelMap();
-      initColorMap();
       fitToContainer();
-      if (currentFilter) applyFilter(currentFilter); else drawAll();
+      drawAll();
     }
-    load();
+    const ready = load();
 
     return {
-      applyFilter,
-      randomizeColors,
       selectBarony,
       drawAll,
       fitToContainer,
@@ -526,7 +233,9 @@
       get colorMap() { return colorMap; },
       get currentSelectedId() { return currentSelectedId; },
       set currentSelectedId(v) { currentSelectedId = v; },
-      setColorMap: cm => { colorMap = cm; drawAll(); }
+      setColorMap: cm => { colorMap = cm; drawAll(); },
+      setCanonicalPatterns: cp => { canonicalPatterns = cp || {}; },
+      get ready() { return ready; }
     };
   }
   global.mapCore = { init };

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -1,0 +1,322 @@
+(function (global) {
+  function init(core, data, options = {}) {
+    const updateLegend = options.updateLegend || (() => {});
+    const terrainColor = [239, 228, 176];
+    const playerColor = [82, 190, 128];
+    const npcColor = [231, 76, 60];
+    let currentFilter = '';
+    let canonicalPatterns = {};
+    let colorMap = {};
+
+    function generateColor(str) {
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        hash = str.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      const r = (hash >> 16) & 255;
+      const g = (hash >> 8) & 255;
+      const b = hash & 255;
+      return [r, g, b, 100];
+    }
+
+    function hslToRgb(h, s, l) {
+      s /= 100; l /= 100;
+      const k = n => (n + h / 30) % 12;
+      const a = s * Math.min(l, 1 - l);
+      const f = n => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+      return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))];
+    }
+
+    function hexToRgb(hex) {
+      if (!hex) return null;
+      const m = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+      return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : null;
+    }
+
+    function initColorMap() {
+      colorMap = {};
+      Object.keys(data.baronyMeta || {}).forEach(id => {
+        colorMap[id] = generateColor(id);
+      });
+      canonicalPatterns = {};
+      core.setCanonicalPatterns(canonicalPatterns);
+      core.setColorMap(colorMap);
+    }
+
+    function randomizeColors() {
+      applyFilter(currentFilter, true);
+    }
+
+    function applyFilter(type, randomize = false) {
+      if (data.mapMode === 'sea') {
+        colorMap = {};
+        Object.keys(data.baronyMeta || {}).forEach(id => {
+          const hue = Math.floor(Math.random() * 360);
+          const [r, g, b] = hslToRgb(hue, 65, 65);
+          colorMap[id] = [r, g, b, 100];
+        });
+        if (core.currentSelectedId && colorMap[core.currentSelectedId]) colorMap[core.currentSelectedId][3] = 180;
+        updateLegend(null);
+        canonicalPatterns = {};
+        core.setCanonicalPatterns(canonicalPatterns);
+        core.setColorMap(colorMap);
+        return;
+      }
+      currentFilter = type || '';
+      canonicalPatterns = {};
+      if (!type) {
+        initColorMap();
+        updateLegend(null);
+        if (core.currentSelectedId && colorMap[core.currentSelectedId]) {
+          colorMap[core.currentSelectedId][3] = 180;
+          core.setColorMap(colorMap);
+        }
+        return;
+      }
+      if (type === 'distance') {
+        colorMap = {};
+        if (!core.currentSelectedId) {
+          updateLegend(null);
+          core.setCanonicalPatterns({});
+          core.setColorMap(colorMap);
+          return;
+        }
+        const distances = {};
+        const queue = [core.currentSelectedId];
+        distances[core.currentSelectedId] = 0;
+        while (queue.length > 0) {
+          const cur = queue.shift();
+          const next = data.baronyAdjacency[cur] || [];
+          next.forEach(n => {
+            if (distances[n] === undefined) {
+              distances[n] = distances[cur] + 1;
+              queue.push(n);
+            }
+          });
+        }
+        Object.keys(data.baronyMeta).forEach(id => {
+          const d = distances[id];
+          if (d === undefined) return;
+          const hue = (d * 40) % 360;
+          const [r, g, b] = hslToRgb(hue, 65, 65);
+          colorMap[id] = [r, g, b, 100];
+        });
+        if (core.currentSelectedId && colorMap[core.currentSelectedId]) colorMap[core.currentSelectedId][3] = 180;
+        updateLegend(null);
+        core.setCanonicalPatterns({});
+        core.setColorMap(colorMap);
+        return;
+      }
+      const groupColors = {};
+      colorMap = {};
+      Object.entries(data.baronyMeta).forEach(([id, info]) => {
+        let groupId = null;
+        let groupName = '';
+        if (type === 'canonical') {
+          const rIds = data.canonicalLandMap[id] || [];
+          if (rIds.length === 0) {
+            colorMap[id] = [...terrainColor, 100];
+            return;
+          }
+          canonicalPatterns[id] = rIds.map(rid => {
+            if (!groupColors[rid]) {
+              const col = hexToRgb(data.religionMap[rid]?.color) || generateColor(String(rid)).slice(0, 3);
+              groupColors[rid] = { color: col, name: data.religionMap[rid]?.name || 'N/A' };
+            }
+            return groupColors[rid].color;
+          });
+          const first = canonicalPatterns[id][0];
+          colorMap[id] = [first[0], first[1], first[2], 100];
+          return;
+        } else if (type === 'religion') {
+          groupId = info.religion_pop_id;
+          groupName = data.religionMap[groupId]?.name || '';
+        } else if (type === 'culture') {
+          groupId = info.culture_id;
+          groupName = data.cultureMapInfo[groupId]?.name || '';
+        } else if (type === 'viscounty') {
+          groupId = info.viscounty_id;
+          groupName = data.viscountyMap[groupId]?.name || '';
+        } else if (type === 'county') {
+          groupId = info.county_id;
+          groupName = data.countyMap[groupId]?.name || '';
+        } else if (type === 'marquisate') {
+          const county = data.countyMap[info.county_id];
+          groupId = county ? county.marquisate_id : null;
+          groupName = data.marquisateMap[groupId]?.name || '';
+        } else if (type === 'duchy') {
+          const county = data.countyMap[info.county_id];
+          groupId = county ? county.duchy_id : null;
+          groupName = data.duchyMap[groupId]?.name || '';
+        } else if (type === 'archduchy') {
+          const county = data.countyMap[info.county_id];
+          const duchy = county ? data.duchyMap[county.duchy_id] : null;
+          groupId = duchy ? duchy.archduchy_id : null;
+          groupName = data.archduchyMap[groupId]?.name || '';
+        } else if (type === 'kingdom') {
+          const county = data.countyMap[info.county_id];
+          const duchy = county ? data.duchyMap[county.duchy_id] : null;
+          groupId = duchy ? duchy.kingdom_id : null;
+          groupName = data.kingdomMap[groupId]?.name || '';
+        } else if (type === 'empire') {
+          const county = data.countyMap[info.county_id];
+          const duchy = county ? data.duchyMap[county.duchy_id] : null;
+          const kingdom = duchy ? data.kingdomMap[duchy.kingdom_id] : null;
+          groupId = kingdom ? kingdom.empire_id : null;
+          groupName = data.empireMap[groupId]?.name || '';
+        } else if (type === 'viscounty_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const vId = data.seigneurToViscounty[sid];
+            if (vId) {
+              groupId = vId;
+              groupName = data.viscountyMap[vId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'county_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const cId = data.seigneurToCounty[sid];
+            if (cId) {
+              groupId = cId;
+              groupName = data.countyMap[cId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'marquisate_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const mId = data.seigneurToMarquisate[sid];
+            if (mId) {
+              groupId = mId;
+              groupName = data.marquisateMap[mId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'duchy_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const dId = data.seigneurToDuchy[sid];
+            if (dId) {
+              groupId = dId;
+              groupName = data.duchyMap[dId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'archduchy_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const aId = data.seigneurToArchduchy[sid];
+            if (aId) {
+              groupId = aId;
+              groupName = data.archduchyMap[aId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'kingdom_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const kId = data.seigneurToKingdom[sid];
+            if (kId) {
+              groupId = kId;
+              groupName = data.kingdomMap[kId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'empire_defacto') {
+          let sid = info.seigneur_id;
+          while (sid) {
+            const eId = data.seigneurToEmpire[sid];
+            if (eId) {
+              groupId = eId;
+              groupName = data.empireMap[eId]?.name || '';
+              break;
+            }
+            sid = data.seigneurMap[sid]?.overlord_id;
+          }
+        } else if (type === 'sanctuary') {
+          if (info.has_sanctuary) {
+            groupId = info.religion_pop_id;
+            groupName = data.religionMap[groupId]?.name || '';
+          }
+        } else if (type === 'priory') {
+          if (info.has_priory) {
+            groupId = info.religion_pop_id;
+            groupName = data.religionMap[groupId]?.name || '';
+          }
+        } else if (type === 'church') {
+          if (info.has_church) {
+            groupId = info.religion_pop_id;
+            groupName = data.religionMap[groupId]?.name || '';
+          }
+        } else if (type === 'cathedral') {
+          if (info.has_cathedral) {
+            groupId = info.religion_pop_id;
+            groupName = data.religionMap[groupId]?.name || '';
+          }
+        } else if (type === 'occupation') {
+          if (!info.seigneur_id) {
+            groupId = 'unoccupied';
+            groupName = 'Non occupée';
+          } else if (info.player) {
+            groupId = 'player';
+            groupName = 'Joueur';
+          } else {
+            groupId = 'npc';
+            groupName = 'PNJ';
+          }
+        }
+        if (groupId == null) {
+          colorMap[id] = [...terrainColor, 100];
+          return;
+        }
+        if (!groupColors[groupId]) {
+          let col;
+          if (type === 'occupation') {
+            if (groupId === 'player') col = playerColor;
+            else if (groupId === 'npc') col = npcColor;
+            else col = terrainColor;
+          } else if (randomize) {
+            const hue = Math.floor(Math.random() * 360);
+            col = hslToRgb(hue, 65, 65);
+          } else {
+            if (
+              type === 'religion' ||
+              type === 'sanctuary' ||
+              type === 'priory' ||
+              type === 'church' ||
+              type === 'cathedral'
+            ) {
+              col = hexToRgb(data.religionMap[groupId]?.color);
+            } else if (type === 'culture') {
+              col = hexToRgb(data.cultureMapInfo[groupId]?.color);
+            }
+            if (!col) {
+              col = generateColor(String(groupId || 0)).slice(0, 3);
+            }
+          }
+          groupColors[groupId] = { color: col, name: groupName || 'N/A' };
+        }
+        const col = groupColors[groupId].color;
+        colorMap[id] = [col[0], col[1], col[2], 100];
+      });
+      if (core.currentSelectedId && colorMap[core.currentSelectedId]) {
+        colorMap[core.currentSelectedId][3] = 180;
+      }
+      updateLegend(groupColors);
+      core.setCanonicalPatterns(canonicalPatterns);
+      core.setColorMap(colorMap);
+    }
+
+    initColorMap();
+    return { applyFilter, randomizeColors, get currentFilter() { return currentFilter; } };
+  }
+  global.mapFilters = { init };
+})(typeof window !== 'undefined' ? window : global);

--- a/viewer.js
+++ b/viewer.js
@@ -24,6 +24,9 @@
   let seigneurToViscounty = {}, seigneurToCounty = {}, seigneurToMarquisate = {}, seigneurToDuchy = {}, seigneurToArchduchy = {}, seigneurToKingdom = {}, seigneurToEmpire = {};
   let canonicalLandMap = {};
   let baronyAdjacency = {};
+  let mapData = {};
+
+  let filterManager = null;
 
   const baseMap = document.getElementById('baseMap');
   if (mapMode === 'sea' && baseMap) baseMap.src = 'zones_maritimes.png';
@@ -107,6 +110,9 @@
     infoCathedral.textContent = info.has_cathedral ? 'Oui' : 'Non';
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
     infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => religionMap[rid]?.name || '').join(', ');
+    if (filterManager && filterSelect) {
+      filterManager.applyFilter(filterSelect.value);
+    }
   }
 
   async function fetchData() {
@@ -126,7 +132,8 @@
         baronyAdjacency[c.zone_id_1].push(c.zone_id_2);
         baronyAdjacency[c.zone_id_2].push(c.zone_id_1);
       });
-      return { pixelData, baronyMeta, baronyAdjacency, mapWidth, mapHeight, mapMode };
+      mapData = { pixelData, baronyMeta, baronyAdjacency, mapWidth, mapHeight, mapMode };
+      return mapData;
     }
     const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands, connections] = await Promise.all([
       fetch(API_BASE + '/api/baronies').then(r => r.json()),
@@ -184,7 +191,7 @@
       baronyAdjacency[c.barony_id_1].push(c.barony_id_2);
       baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
     });
-    return {
+    mapData = {
       pixelData,
       baronyMeta,
       seigneurMap,
@@ -210,6 +217,7 @@
       mapHeight,
       mapMode
     };
+    return mapData;
   }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -227,11 +235,16 @@
         fetchData,
         onSelect: handleSelect,
         drawOverlay: () => {},
-        mapMode,
-        updateLegend
+        mapMode
       });
-      if (filterSelect) filterSelect.addEventListener('change', () => core.applyFilter(filterSelect.value));
-      if (randomBtn) randomBtn.addEventListener('click', () => core.randomizeColors());
+      core.ready.then(() => {
+        filterManager = mapFilters.init(core, mapData, { updateLegend });
+        if (filterSelect) {
+          filterSelect.addEventListener('change', () => filterManager.applyFilter(filterSelect.value));
+          filterManager.applyFilter(filterSelect.value);
+        }
+        if (randomBtn) randomBtn.addEventListener('click', () => filterManager.randomizeColors());
+      });
     });
   });
 })();


### PR DESCRIPTION
## Summary
- separate filter and coloring logic into new `mapFilters` module
- slim down `mapCore` to rendering concerns and expose color map hooks
- update editor and viewer to initialize filters and load new script

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a75a223fbc832da7090cb64d605196