### PR TITLE
feat: add configurable map initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -178,7 +178,8 @@
       pixelCanvas.height = mapHeight;
       pixelCanvas.style.width = mapWidth + 'px';
       pixelCanvas.style.height = mapHeight + 'px';
-      core = mapCore.init(pixelCanvas, {
+      core = mapCore.init({
+        canvas: pixelCanvas,
         fetchData,
         onSelect: handleSelect,
         drawOverlay: () => {},

--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -1,5 +1,31 @@
 (function (global) {
-  function init(canvas, options = {}) {
+  /**
+   * Initialise le rendu de la carte.
+   * @param {Object} [opts] Options de configuration.
+   * @param {HTMLCanvasElement} [opts.canvas] Canvas cible. Utilisé si `mapId` n'est pas fourni.
+   * @param {string} [opts.mapId='pixelCanvas'] Id du canvas à récupérer dans le DOM.
+   * @param {boolean} [opts.enablePan=true] Active le déplacement de la carte à la souris.
+   * @param {boolean} [opts.enableZoom=true] Active le zoom via la molette.
+   * @param {Function} [opts.fetchData] Fonction asynchrone de récupération des données.
+   * @param {Function} [opts.onSelect] Callback lors de la sélection d'une baronnie.
+   * @param {Function} [opts.drawOverlay] Fonction de dessin d'une surcouche.
+   * @param {string} [opts.mapMode='land'] Mode de carte à charger.
+   */
+  function init(opts = {}) {
+    const {
+      canvas: passedCanvas,
+      mapId = 'pixelCanvas',
+      enablePan = true,
+      enableZoom = true,
+      fetchData = async () => ({}),
+      onSelect = () => {},
+      drawOverlay = () => {},
+      mapMode = 'land'
+    } = opts;
+
+    const canvas = passedCanvas || document.getElementById(mapId);
+    if (!canvas) throw new Error('No canvas element provided or found');
+
     const group = canvas.parentElement;
     const container = group.parentElement;
     const ctx = canvas.getContext('2d');
@@ -36,11 +62,6 @@
     let panning = false;
     let panStartX = 0;
     let panStartY = 0;
-
-    const fetchData = options.fetchData || (async () => ({}));
-    const onSelect = options.onSelect || (() => {});
-    const drawOverlay = options.drawOverlay || (() => {});
-    const mapMode = options.mapMode || 'land';
 
     function applyTransform() {
       group.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
@@ -173,11 +194,15 @@
     }
 
 
-    canvas.addEventListener('wheel', handleWheel, { passive: false });
-    canvas.addEventListener('mousedown', handlePanStart);
-    canvas.addEventListener('mousemove', handlePanMove);
+    if (enableZoom) {
+      canvas.addEventListener('wheel', handleWheel, { passive: false });
+    }
+    if (enablePan) {
+      canvas.addEventListener('mousedown', handlePanStart);
+      canvas.addEventListener('mousemove', handlePanMove);
+      window.addEventListener('mouseup', handlePanEnd);
+    }
     canvas.addEventListener('click', handleCanvasClick);
-    window.addEventListener('mouseup', handlePanEnd);
 
     window.addEventListener('resize', () => {
       fitToContainer();

--- a/viewer.js
+++ b/viewer.js
@@ -231,7 +231,8 @@
       pixelCanvas.height = mapHeight;
       pixelCanvas.style.width = mapWidth + 'px';
       pixelCanvas.style.height = mapHeight + 'px';
-      const core = mapCore.init(pixelCanvas, {
+      const core = mapCore.init({
+        canvas: pixelCanvas,
         fetchData,
         onSelect: handleSelect,
         drawOverlay: () => {},


### PR DESCRIPTION
## Summary
- allow mapCore.init to take options such as mapId, enablePan, and enableZoom with sensible defaults
- hook up pan and zoom listeners only when their features are enabled
- update map initialization calls in viewer and editor scripts

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a77c1bc1a4832d8e92fb984773aae4