### PR TITLE
Fix filter controls IDs to restore map filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
       <a href="index.html?mode=sea">Carte Maritime</a>
     </nav>
     <div id="controls" class="controls-row">
-      <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
-      <label for="colorFilter">Filtre :</label>
-      <select id="colorFilter" class="control-btn">
+      <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
+      <label for="filterSelect">Filtre :</label>
+      <select id="filterSelect" class="control-btn">
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
         <option value="sanctuary">Sanctuaire</option>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -13,9 +13,9 @@
       <a href="mapEditor.html?mode=sea">Carte Maritime</a>
     </nav>
     <div id="controls" class="controls-row">
-      <button id="randomColors" class="control-btn">Couleurs aléatoires</button>
-      <label for="colorFilter">Filtre&nbsp;:</label>
-      <select id="colorFilter" class="control-btn">
+      <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
+      <label for="filterSelect">Filtre&nbsp;:</label>
+      <select id="filterSelect" class="control-btn">
         <option value="">Aucun</option>
         <option value="religion">Religion</option>
         <option value="sanctuary">Sanctuaire</option>


### PR DESCRIPTION
## Summary
- Rename filter dropdown and random color button to IDs expected by `viewer.js` and `script.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a77f768844832d85da71a753c01566