### PR TITLE
Enhance random map colors

### DIFF
--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -100,14 +100,17 @@
       });
     }
 
+    function hslToRgb(h, s, l) {
+      s /= 100; l /= 100;
+      const k = n => (n + h / 30) % 12;
+      const a = s * Math.min(l, 1 - l);
+      const f = n => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+      return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))];
+    }
+
     function generateColor(str) {
-      let hash = 0;
-      for (let i = 0; i < str.length; i++) {
-        hash = str.charCodeAt(i) + ((hash << 5) - hash);
-      }
-      const r = (hash >> 16) & 255;
-      const g = (hash >> 8) & 255;
-      const b = hash & 255;
+      const hue = Math.floor(Math.random() * 360);
+      const [r, g, b] = hslToRgb(hue, 65, 65);
       return [r, g, b, 100];
     }
 

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -9,13 +9,8 @@
     let colorMap = {};
 
     function generateColor(str) {
-      let hash = 0;
-      for (let i = 0; i < str.length; i++) {
-        hash = str.charCodeAt(i) + ((hash << 5) - hash);
-      }
-      const r = (hash >> 16) & 255;
-      const g = (hash >> 8) & 255;
-      const b = hash & 255;
+      const hue = Math.floor(Math.random() * 360);
+      const [r, g, b] = hslToRgb(hue, 65, 65);
       return [r, g, b, 100];
     }
 


### PR DESCRIPTION
## Summary
- Use HSL-based random colors for map rendering
- Apply vibrant random palette in filter initialization

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a781f58884832d8c5d50b8dc5e4c5e