### PR TITLE
Fix color randomization when selecting baronies

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,7 +74,7 @@
     if (infoPanel) infoPanel.style.display = 'block';
     if (editIdInput) editIdInput.value = id;
     if (editNameInput) editNameInput.value = baronyMeta[id]?.name || '';
-    if (filterManager && filterSelect) {
+    if (filterManager && filterSelect && filterSelect.value) {
       filterManager.applyFilter(filterSelect.value);
     }
   }

--- a/viewer.js
+++ b/viewer.js
@@ -112,7 +112,7 @@
     infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || 'Aucune';
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
     infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => religionMap[rid]?.name || '').join(', ');
-    if (filterManager && filterSelect) {
+    if (filterManager && filterSelect && filterSelect.value) {
       filterManager.applyFilter(filterSelect.value);
     }
   }


### PR DESCRIPTION
## Summary
- avoid reapplying filters without a selection to stop color re-randomization in the map viewer and editor

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a783f8df8c832d81403c4bec964866