### PR TITLE
feat: track bishop-controlled baronies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **script.js** : éditeur de carte permettant de modifier les baronnies et d'enregistrer les pixels.
 - **src/mapCore.js** : fonctions communes de rendu/zoom utilisées par `viewer.js` et `script.js`.
 - **src/mapFilters.js** : gestion des filtres et de la coloration de la carte, partagée par `viewer.js` et `script.js`.
-- La base de données inclut désormais une table `sanctuaries` (avec un statut actif/inactif) et les colonnes `priory_religion_id`, `church_religion_id`, `cathedral_religion_id` dans la table `baronies`.
+- La base de données inclut désormais une table `sanctuaries` (avec un statut actif/inactif) et les colonnes `priory_religion_id`, `church_religion_id`, `cathedral_religion_id`, `player` et `bishop` dans la table `baronies`.
 - **admin.js** : interface d'administration des empires, royaumes, duchés, etc.
 - **gestion.js** : gestion des seigneuries, ressources et sorts côté joueur.
 - **profile.js** : modification du profil utilisateur.

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
       <div><strong>Église :</strong> <span id="infoChurch"></span></div>
       <div><strong>Cathédrale :</strong> <span id="infoCathedral"></span></div>
       <div><strong>Joueur :</strong> <span id="infoPlayer"></span></div>
+      <div><strong>Évêque :</strong> <span id="infoBishop"></span></div>
       <div><strong>Terres canoniques :</strong> <span id="infoCanonical"></span></div>
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -100,6 +100,7 @@
       <select id="editCathedralReligion"><option value="">Aucune</option></select>
 
       <label class="checkbox-label"><input type="checkbox" id="editPlayer"> Joueur</label>
+      <label class="checkbox-label"><input type="checkbox" id="editBishop"> Évêque</label>
       <label for="editCulture">Culture&nbsp;:</label>
       <select id="editCulture"><option value="">Aucune</option></select>
       <label for="editViscounty">Vicomté de jure&nbsp;:</label>

--- a/script.js
+++ b/script.js
@@ -51,6 +51,7 @@
   const editViscountySelect = document.getElementById('editViscounty');
   const editCountySelect = document.getElementById('editCounty');
   const editPlayerCheckbox = document.getElementById('editPlayer');
+  const editBishopCheckbox = document.getElementById('editBishop');
 
   function updateLegend(groups) {
     if (!legendDiv) return;
@@ -202,6 +203,11 @@
       saveBaronyFields({ player: editPlayerCheckbox.checked ? 1 : 0 });
     });
   }
+  if (editBishopCheckbox) {
+    editBishopCheckbox.addEventListener('change', () => {
+      saveBaronyFields({ bishop: editBishopCheckbox.checked ? 1 : 0 });
+    });
+  }
 
   function handleSelect(id) {
     if (pendingAction && pendingLinkId && id && id !== pendingLinkId) {
@@ -246,6 +252,7 @@
     if (editViscountySelect) editViscountySelect.value = baronyMeta[id]?.viscounty_id || '';
     if (editCountySelect) editCountySelect.value = baronyMeta[id]?.county_id || '';
     if (editPlayerCheckbox) editPlayerCheckbox.checked = !!baronyMeta[id]?.player;
+    if (editBishopCheckbox) editBishopCheckbox.checked = !!baronyMeta[id]?.bishop;
 
     if (filterManager && filterSelect && filterSelect.value) {
       filterManager.applyFilter(filterSelect.value);

--- a/server.js
+++ b/server.js
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS baronies (
   church_religion_id INTEGER,
   cathedral_religion_id INTEGER,
   player INTEGER DEFAULT 0,
+  bishop INTEGER DEFAULT 0,
   FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id) ON DELETE SET NULL,
   FOREIGN KEY(religion_pop_id) REFERENCES religions(id),
   FOREIGN KEY(county_id) REFERENCES counties(id),
@@ -364,6 +365,9 @@ db.exec(initSql, () => {
     }
     if (!rows.some(r => r.name === 'player')) {
       db.run('ALTER TABLE baronies ADD COLUMN player INTEGER DEFAULT 0');
+    }
+    if (!rows.some(r => r.name === 'bishop')) {
+      db.run('ALTER TABLE baronies ADD COLUMN bishop INTEGER DEFAULT 0');
     }
   });
   db.all("PRAGMA table_info(counties)", (err, rows) => {
@@ -1234,11 +1238,11 @@ app.get('/api/baronies', (req, res) => {
 });
 app.post('/api/baronies', create('baronies',[
   'id','name','seigneur_id','religion_pop_id','county_id','viscounty_id','culture_id',
-  'priory_religion_id','church_religion_id','cathedral_religion_id','player'
+  'priory_religion_id','church_religion_id','cathedral_religion_id','player','bishop'
 ]));
 app.put('/api/baronies/:id', update('baronies',[
   'name','seigneur_id','religion_pop_id','county_id','viscounty_id','culture_id',
-  'priory_religion_id','church_religion_id','cathedral_religion_id','player'
+  'priory_religion_id','church_religion_id','cathedral_religion_id','player','bishop'
 ]));
 app.delete('/api/baronies/:id', (req,res)=>{
   db.run('DELETE FROM baronies WHERE id=?',[req.params.id], function(err){

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -2,8 +2,10 @@
   function init(core, data, options = {}) {
     const updateLegend = options.updateLegend || (() => {});
     const terrainColor = [239, 228, 176];
-    const playerColor = [82, 190, 128];
-    const npcColor = [231, 76, 60];
+    const playerSeigneurColor = [82, 190, 128];
+    const playerBishopColor = [46, 134, 193];
+    const npcSeigneurColor = [231, 76, 60];
+    const npcBishopColor = [155, 89, 182];
     let currentFilter = '';
     let canonicalPatterns = {};
     let colorMap = {};
@@ -272,12 +274,18 @@
           if (!info.seigneur_id) {
             groupId = 'unoccupied';
             groupName = 'Non occupée';
+          } else if (info.player && info.bishop) {
+            groupId = 'player_bishop';
+            groupName = 'Joueur Évêque';
           } else if (info.player) {
-            groupId = 'player';
-            groupName = 'Joueur';
+            groupId = 'player_seigneur';
+            groupName = 'Joueur Seigneur';
+          } else if (info.bishop) {
+            groupId = 'npc_bishop';
+            groupName = 'PNJ Évêque';
           } else {
-            groupId = 'npc';
-            groupName = 'PNJ';
+            groupId = 'npc_seigneur';
+            groupName = 'PNJ Seigneur';
           }
         }
         if (groupId == null) {
@@ -287,8 +295,10 @@
         if (!groupColors[groupId]) {
           let col;
           if (type === 'occupation') {
-            if (groupId === 'player') col = playerColor;
-            else if (groupId === 'npc') col = npcColor;
+            if (groupId === 'player_seigneur') col = playerSeigneurColor;
+            else if (groupId === 'player_bishop') col = playerBishopColor;
+            else if (groupId === 'npc_seigneur') col = npcSeigneurColor;
+            else if (groupId === 'npc_bishop') col = npcBishopColor;
             else col = terrainColor;
           } else if (randomize) {
             const hue = Math.floor(Math.random() * 360);

--- a/viewer.js
+++ b/viewer.js
@@ -51,6 +51,7 @@
   const infoChurch = document.getElementById('infoChurch');
   const infoCathedral = document.getElementById('infoCathedral');
   const infoPlayer = document.getElementById('infoPlayer');
+  const infoBishop = document.getElementById('infoBishop');
   const infoCanonical = document.getElementById('infoCanonical');
   const legendDiv = document.getElementById('legend');
   const filterSelect = document.getElementById('filterSelect');
@@ -111,6 +112,7 @@
     infoChurch.textContent = religionMap[info.church_religion_id]?.name || 'Aucune';
     infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || 'Aucune';
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
+    infoBishop.textContent = info.bishop ? 'Oui' : 'Non';
     infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => religionMap[rid]?.name || '').join(', ');
     if (filterManager && filterSelect && filterSelect.value) {
       filterManager.applyFilter(filterSelect.value);


### PR DESCRIPTION
## Summary
- add `bishop` column to baronies and expose through API
- allow editing bishop flag in map editor and show in map viewer
- refine occupation filter to distinguish player/NPC bishops and seigneurs

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a788a4f0fc832d94bb1cca5456c6f0