### PR TITLE
Reload barony color after property edits

### DIFF
--- a/script.js
+++ b/script.js
@@ -154,6 +154,9 @@
     }).then(res => {
       if (res.ok) {
         baronyMeta[currentSelectedId] = { ...baronyMeta[currentSelectedId], ...fields };
+        if (filterManager && filterSelect && filterSelect.value) {
+          filterManager.applyFilter(filterSelect.value);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- Reapply active map filter whenever a barony property is saved so its color updates immediately in the editor

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a78b2d2dac832d975d7cd910dc92e6