### PR TITLE
feat: edit sanctuaries and canonical lands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **script.js** : éditeur de carte permettant de modifier les baronnies et d'enregistrer les pixels.
 - **src/mapCore.js** : fonctions communes de rendu/zoom utilisées par `viewer.js` et `script.js`.
 - **src/mapFilters.js** : gestion des filtres et de la coloration de la carte, partagée par `viewer.js` et `script.js`.
-- La base de données inclut désormais une table `sanctuaries` (avec un statut actif/inactif) et les colonnes `priory_religion_id`, `church_religion_id`, `cathedral_religion_id`, `player` et `bishop` dans la table `baronies`.
+- La base de données inclut désormais une table `sanctuaries` (avec un statut actif/inactif), une table `canonical_lands` (relation entre deux baronnies) et les colonnes `priory_religion_id`, `church_religion_id`, `cathedral_religion_id`, `player` et `bishop` dans la table `baronies`.
 - **admin.js** : interface d'administration des empires, royaumes, duchés, etc.
 - **gestion.js** : gestion des seigneuries, ressources et sorts côté joueur.
 - **profile.js** : modification du profil utilisateur.

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -87,10 +87,7 @@
       <select id="editReligionPop"></select>
 
       <label>Sanctuaires&nbsp;:</label>
-      <div id="sanctuaryList"></div>
-      <select id="sanctuaryReligion"><option value="">Religion</option></select>
-      <label class="checkbox-label"><input type="checkbox" id="sanctuaryActive"> Actif</label>
-      <button id="addSanctuary" class="control-btn">Ajouter</button>
+      <button id="editSanctuaries" class="control-btn">Gérer</button>
 
       <label for="editPrioryReligion">Prieuré&nbsp;:</label>
       <select id="editPrioryReligion"><option value="">Aucun</option></select>
@@ -108,9 +105,7 @@
       <label for="editCounty">Comté de jure&nbsp;:</label>
       <select id="editCounty"><option value="">Aucun</option></select>
       <label>Terres canoniques&nbsp;:</label>
-      <div id="canonicalList"></div>
-      <select id="addCanonicalSelect"></select>
-      <button id="addCanonical" class="control-btn">Ajouter</button>
+      <button id="editCanonical" class="control-btn">Gérer</button>
     </aside>
     <aside id="seaInfoPanel" class="info-panel" style="display: none;">
       <h2>Zone maritime sélectionnée</h2>

--- a/script.js
+++ b/script.js
@@ -42,7 +42,8 @@
   const editIdInput = document.getElementById('editId');
   const editNameInput = document.getElementById('editName');
   const editReligionPopSelect = document.getElementById('editReligionPop');
-  const sanctuaryReligionSelect = document.getElementById('sanctuaryReligion');
+  const editSanctuariesBtn = document.getElementById('editSanctuaries');
+  const editCanonicalBtn = document.getElementById('editCanonical');
   const editPrioryReligionSelect = document.getElementById('editPrioryReligion');
   const editChurchReligionSelect = document.getElementById('editChurchReligion');
   const editCathedralReligionSelect = document.getElementById('editCathedralReligion');
@@ -103,13 +104,12 @@
   });
 
   function populateReligionSelects() {
-    const selects = [
-      editReligionPopSelect,
-      sanctuaryReligionSelect,
-      editPrioryReligionSelect,
-      editChurchReligionSelect,
-      editCathedralReligionSelect
-    ].filter(Boolean);
+      const selects = [
+        editReligionPopSelect,
+        editPrioryReligionSelect,
+        editChurchReligionSelect,
+        editCathedralReligionSelect
+      ].filter(Boolean);
     selects.forEach(sel => {
       const placeholder = sel.firstElementChild ? sel.firstElementChild.cloneNode(true) : null;
       sel.innerHTML = '';
@@ -206,6 +206,180 @@
   if (editBishopCheckbox) {
     editBishopCheckbox.addEventListener('change', () => {
       saveBaronyFields({ bishop: editBishopCheckbox.checked ? 1 : 0 });
+    });
+  }
+
+  if (editSanctuariesBtn) {
+    editSanctuariesBtn.addEventListener('click', () => {
+      if (!currentSelectedId) return;
+      const overlay = document.createElement('div');
+      overlay.className = 'popup-overlay';
+      const popup = document.createElement('div');
+      popup.className = 'popup';
+      const list = document.createElement('div');
+
+      function addRow(data = { id: null, religion_id: '', active: 0 }) {
+        const row = document.createElement('div');
+        row.className = 'cost-row';
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        Object.values(religionMap).forEach(r => {
+          const opt = document.createElement('option');
+          opt.value = r.id;
+          opt.textContent = r.name;
+          sel.appendChild(opt);
+        });
+        sel.value = data.religion_id || '';
+        const chk = document.createElement('input');
+        chk.type = 'checkbox';
+        chk.checked = !!data.active;
+
+        sel.addEventListener('change', () => {
+          const rid = parseInt(sel.value, 10);
+          if (!rid) return;
+          if (data.id) {
+            fetch(`${API_BASE}/api/sanctuaries/${data.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ barony_id: currentSelectedId, religion_id: rid, active: data.active ? 1 : 0 })
+            }).then(() => {
+              data.religion_id = rid;
+              if (filterManager && filterSelect && filterSelect.value === 'sanctuary') filterManager.applyFilter('sanctuary');
+            });
+          } else {
+            fetch(`${API_BASE}/api/sanctuaries`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ barony_id: currentSelectedId, religion_id: rid, active: data.active ? 1 : 0 })
+            }).then(r => r.json()).then(res => {
+              data.id = res.id;
+              data.religion_id = rid;
+              if (!sanctuaryMap[currentSelectedId]) sanctuaryMap[currentSelectedId] = [];
+              sanctuaryMap[currentSelectedId].push(data);
+              if (filterManager && filterSelect && filterSelect.value === 'sanctuary') filterManager.applyFilter('sanctuary');
+            });
+          }
+        });
+
+        chk.addEventListener('change', () => {
+          data.active = chk.checked ? 1 : 0;
+          if (!data.id) return;
+          fetch(`${API_BASE}/api/sanctuaries/${data.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ barony_id: currentSelectedId, religion_id: data.religion_id, active: data.active })
+          }).then(() => {
+            if (filterManager && filterSelect && filterSelect.value === 'sanctuary') filterManager.applyFilter('sanctuary');
+          });
+        });
+
+        const delBtn = document.createElement('button');
+        delBtn.textContent = '-';
+        delBtn.addEventListener('click', () => {
+          if (data.id) {
+            fetch(`${API_BASE}/api/sanctuaries/${data.id}`, { method: 'DELETE' });
+          }
+          sanctuaryMap[currentSelectedId] = (sanctuaryMap[currentSelectedId] || []).filter(s => s !== data && s.id !== data.id);
+          row.remove();
+          if (filterManager && filterSelect && filterSelect.value === 'sanctuary') filterManager.applyFilter('sanctuary');
+        });
+
+        row.appendChild(sel);
+        row.appendChild(chk);
+        row.appendChild(delBtn);
+        list.appendChild(row);
+      }
+
+      (sanctuaryMap[currentSelectedId] || []).forEach(s => addRow({ ...s }));
+      const addBtn = document.createElement('button');
+      addBtn.textContent = '+';
+      addBtn.addEventListener('click', () => addRow());
+      const closeBtn = document.createElement('button');
+      closeBtn.textContent = 'Fermer';
+      closeBtn.addEventListener('click', () => overlay.remove());
+      popup.appendChild(list);
+      popup.appendChild(addBtn);
+      popup.appendChild(closeBtn);
+      overlay.appendChild(popup);
+      document.body.appendChild(overlay);
+    });
+  }
+
+  if (editCanonicalBtn) {
+    editCanonicalBtn.addEventListener('click', () => {
+      if (!currentSelectedId) return;
+      const overlay = document.createElement('div');
+      overlay.className = 'popup-overlay';
+      const popup = document.createElement('div');
+      popup.className = 'popup';
+      const list = document.createElement('div');
+
+      function addRow(val = '') {
+        const row = document.createElement('div');
+        row.className = 'cost-row';
+        const sel = document.createElement('select');
+        const blank = document.createElement('option');
+        blank.value = '';
+        sel.appendChild(blank);
+        Object.values(baronyMeta).forEach(b => {
+          const opt = document.createElement('option');
+          opt.value = b.id;
+          opt.textContent = `${b.id} - ${b.name}`;
+          sel.appendChild(opt);
+        });
+        sel.value = val;
+        row.dataset.canonicalId = val;
+        sel.addEventListener('change', () => {
+          const newId = parseInt(sel.value, 10);
+          const oldId = parseInt(row.dataset.canonicalId || '0', 10);
+          if (oldId) {
+            fetch(`${API_BASE}/api/canonical_lands?barony_id=${currentSelectedId}&canonical_barony_id=${oldId}`, { method: 'DELETE' });
+            if (canonicalLandMap[currentSelectedId]) canonicalLandMap[currentSelectedId] = canonicalLandMap[currentSelectedId].filter(id => id !== oldId);
+          }
+          if (newId) {
+            fetch(`${API_BASE}/api/canonical_lands`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ barony_id: currentSelectedId, canonical_barony_id: newId })
+            });
+            if (!canonicalLandMap[currentSelectedId]) canonicalLandMap[currentSelectedId] = [];
+            canonicalLandMap[currentSelectedId].push(newId);
+          }
+          row.dataset.canonicalId = newId;
+          if (filterManager && filterSelect && filterSelect.value === 'canonical') filterManager.applyFilter('canonical');
+        });
+
+        const delBtn = document.createElement('button');
+        delBtn.textContent = '-';
+        delBtn.addEventListener('click', () => {
+          const oldId = parseInt(row.dataset.canonicalId || '0', 10);
+          if (oldId) {
+            fetch(`${API_BASE}/api/canonical_lands?barony_id=${currentSelectedId}&canonical_barony_id=${oldId}`, { method: 'DELETE' });
+            if (canonicalLandMap[currentSelectedId]) canonicalLandMap[currentSelectedId] = canonicalLandMap[currentSelectedId].filter(id => id !== oldId);
+          }
+          row.remove();
+          if (filterManager && filterSelect && filterSelect.value === 'canonical') filterManager.applyFilter('canonical');
+        });
+
+        row.appendChild(sel);
+        row.appendChild(delBtn);
+        list.appendChild(row);
+      }
+
+      (canonicalLandMap[currentSelectedId] || []).forEach(id => addRow(id));
+      const addBtn = document.createElement('button');
+      addBtn.textContent = '+';
+      addBtn.addEventListener('click', () => addRow());
+      const closeBtn = document.createElement('button');
+      closeBtn.textContent = 'Fermer';
+      closeBtn.addEventListener('click', () => overlay.remove());
+      popup.appendChild(list);
+      popup.appendChild(addBtn);
+      popup.appendChild(closeBtn);
+      overlay.appendChild(popup);
+      document.body.appendChild(overlay);
     });
   }
 
@@ -312,16 +486,16 @@
       empireMap = {};
       seigneurToEmpire = {};
       empires.forEach(e => { empireMap[e.id] = e; if (e.seigneur_id) seigneurToEmpire[e.seigneur_id] = e.id; });
-      canonicalLandMap = {};
-      canonicalLands.forEach(cl => {
-        if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
-        canonicalLandMap[cl.barony_id].push(cl.religion_id);
-      });
-      sanctuaryMap = {};
-      sanctuaries.forEach(s => {
-        if (!sanctuaryMap[s.barony_id]) sanctuaryMap[s.barony_id] = [];
-        sanctuaryMap[s.barony_id].push({ religion_id: s.religion_id, active: !!s.active });
-      });
+        canonicalLandMap = {};
+        canonicalLands.forEach(cl => {
+          if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
+          canonicalLandMap[cl.barony_id].push(cl.canonical_barony_id);
+        });
+        sanctuaryMap = {};
+        sanctuaries.forEach(s => {
+          if (!sanctuaryMap[s.barony_id]) sanctuaryMap[s.barony_id] = [];
+          sanctuaryMap[s.barony_id].push({ id: s.id, religion_id: s.religion_id, active: !!s.active });
+        });
       baronyAdjacency = {};
       connections.forEach(c => {
         if (!baronyAdjacency[c.barony_id_1]) baronyAdjacency[c.barony_id_1] = [];

--- a/server.js
+++ b/server.js
@@ -136,11 +136,11 @@ CREATE TABLE IF NOT EXISTS sanctuaries (
   FOREIGN KEY(religion_id) REFERENCES religions(id)
 );
 CREATE TABLE IF NOT EXISTS canonical_lands (
-  religion_id INTEGER,
   barony_id INTEGER,
-  PRIMARY KEY(religion_id, barony_id),
-  FOREIGN KEY(religion_id) REFERENCES religions(id),
-  FOREIGN KEY(barony_id) REFERENCES baronies(id)
+  canonical_barony_id INTEGER,
+  PRIMARY KEY(barony_id, canonical_barony_id),
+  FOREIGN KEY(barony_id) REFERENCES baronies(id),
+  FOREIGN KEY(canonical_barony_id) REFERENCES baronies(id)
 );
 CREATE TABLE IF NOT EXISTS barony_connections (
   barony_id_1 INTEGER NOT NULL,
@@ -2156,10 +2156,10 @@ app.post('/api/infrastructure/assign_workers', (req,res) => {
   });
 });
 app.get('/api/canonical_lands', list('canonical_lands'));
-app.post('/api/canonical_lands', create('canonical_lands',['religion_id','barony_id']));
+app.post('/api/canonical_lands', create('canonical_lands',['barony_id','canonical_barony_id']));
 app.delete('/api/canonical_lands', (req, res) => {
-  const { religion_id, barony_id } = req.query;
-  db.run('DELETE FROM canonical_lands WHERE religion_id=? AND barony_id=?', [religion_id, barony_id], function(err){
+  const { barony_id, canonical_barony_id } = req.query;
+  db.run('DELETE FROM canonical_lands WHERE barony_id=? AND canonical_barony_id=?', [barony_id, canonical_barony_id], function(err){
     if(err) return handleError(res, err);
     res.json({deleted: this.changes});
   });

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -115,12 +115,12 @@
             colorMap[id] = [...terrainColor, 100];
             return;
           }
-          canonicalPatterns[id] = rIds.map(rid => {
-            if (!groupColors[rid]) {
-              const col = hexToRgb(data.religionMap[rid]?.color) || generateColor(String(rid)).slice(0, 3);
-              groupColors[rid] = { color: col, name: data.religionMap[rid]?.name || 'N/A' };
+          canonicalPatterns[id] = rIds.map(cid => {
+            if (!groupColors[cid]) {
+              const col = generateColor(String(cid)).slice(0, 3);
+              groupColors[cid] = { color: col, name: data.baronyMeta[cid]?.name || 'N/A' };
             }
-            return groupColors[rid].color;
+            return groupColors[cid].color;
           });
           const first = canonicalPatterns[id][0];
           colorMap[id] = [first[0], first[1], first[2], 100];

--- a/viewer.js
+++ b/viewer.js
@@ -113,7 +113,7 @@
     infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || 'Aucune';
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
     infoBishop.textContent = info.bishop ? 'Oui' : 'Non';
-    infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => religionMap[rid]?.name || '').join(', ');
+      infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || '').join(', ');
     if (filterManager && filterSelect && filterSelect.value) {
       filterManager.applyFilter(filterSelect.value);
     }
@@ -184,11 +184,11 @@
     empireMap = {};
     seigneurToEmpire = {};
     empires.forEach(e => { empireMap[e.id] = e; if (e.seigneur_id) seigneurToEmpire[e.seigneur_id] = e.id; });
-    canonicalLandMap = {};
-    canonicalLands.forEach(cl => {
-      if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
-      canonicalLandMap[cl.barony_id].push(cl.religion_id);
-    });
+      canonicalLandMap = {};
+      canonicalLands.forEach(cl => {
+        if (!canonicalLandMap[cl.barony_id]) canonicalLandMap[cl.barony_id] = [];
+        canonicalLandMap[cl.barony_id].push(cl.canonical_barony_id);
+      });
     sanctuaryMap = {};
     sanctuaries.forEach(s => {
       if (!sanctuaryMap[s.barony_id]) sanctuaryMap[s.barony_id] = [];


### PR DESCRIPTION
## Summary
- allow editing sanctuaries through popup in map editor
- manage canonical lands via popup and link baronies
- update canonical land storage and filters

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a78ae58fcc832d90ae6dd78eb94fde