### PR TITLE
Fix map color reset on barony selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -431,8 +431,8 @@
     if (editPlayerCheckbox) editPlayerCheckbox.checked = !!baronyMeta[id]?.player;
     if (editBishopCheckbox) editBishopCheckbox.checked = !!baronyMeta[id]?.bishop;
 
-    if (filterManager && filterSelect && filterSelect.value) {
-      filterManager.applyFilter(filterSelect.value);
+    if (filterManager && filterSelect && filterSelect.value === 'distance') {
+      filterManager.applyFilter('distance');
     }
   }
 

--- a/viewer.js
+++ b/viewer.js
@@ -114,8 +114,8 @@
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
     infoBishop.textContent = info.bishop ? 'Oui' : 'Non';
       infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || '').join(', ');
-    if (filterManager && filterSelect && filterSelect.value) {
-      filterManager.applyFilter(filterSelect.value);
+    if (filterManager && filterSelect && filterSelect.value === 'distance') {
+      filterManager.applyFilter('distance');
     }
   }
 


### PR DESCRIPTION
## Summary
- Avoid reapplying color filters on barony selection unless the distance filter is active

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a78e307cfc832d8f9d532a0600687b