### PR TITLE
Séparation des filtres terre/mer et support d'édition maritime

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,32 +15,7 @@
     <div id="controls" class="controls-row">
       <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
       <label for="filterSelect">Filtre :</label>
-      <select id="filterSelect" class="control-btn">
-        <option value="">Aucun</option>
-        <option value="religion">Religion</option>
-        <option value="sanctuary">Sanctuaire</option>
-        <option value="priory">Prieuré</option>
-        <option value="church">Église</option>
-        <option value="cathedral">Cathédrale</option>
-        <option value="canonical">Terres canoniques</option>
-        <option value="culture">Culture</option>
-        <option value="viscounty">Vicomté de jure</option>
-        <option value="viscounty_defacto">Vicomté de facto</option>
-        <option value="county">Comté de jure</option>
-        <option value="county_defacto">Comté de facto</option>
-        <option value="marquisate">Marquisat de jure</option>
-        <option value="marquisate_defacto">Marquisat de facto</option>
-        <option value="duchy">Duché de jure</option>
-        <option value="duchy_defacto">Duché de facto</option>
-        <option value="archduchy">Archiduché de jure</option>
-        <option value="archduchy_defacto">Archiduché de facto</option>
-        <option value="kingdom">Royaume de jure</option>
-        <option value="kingdom_defacto">Royaume de facto</option>
-        <option value="empire">Empire de jure</option>
-        <option value="empire_defacto">Empire de facto</option>
-        <option value="distance">Distance</option>
-        <option value="occupation">Occupation</option>
-      </select>
+      <select id="filterSelect" class="control-btn"></select>
       <span id="authArea" class="auth-area"></span>
     </div>
   </header>
@@ -72,6 +47,11 @@
       <div><strong>Joueur :</strong> <span id="infoPlayer"></span></div>
       <div><strong>Évêque :</strong> <span id="infoBishop"></span></div>
       <div><strong>Terres canoniques :</strong> <span id="infoCanonical"></span></div>
+    </aside>
+    <aside id="seaInfoPanel" class="info-panel" style="display:none;">
+      <h2>Zone maritime sélectionnée</h2>
+      <div><strong>ID :</strong> <span id="seaInfoId"></span></div>
+      <div><strong>Nom :</strong> <span id="seaInfoName"></span></div>
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>
   </main>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -15,28 +15,7 @@
     <div id="controls" class="controls-row">
       <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
       <label for="filterSelect">Filtre&nbsp;:</label>
-      <select id="filterSelect" class="control-btn">
-        <option value="">Aucun</option>
-        <option value="religion">Religion</option>
-        <option value="sanctuary">Sanctuaire</option>
-        <option value="priory">Prieuré</option>
-        <option value="church">Église</option>
-        <option value="cathedral">Cathédrale</option>
-        <option value="canonical">Terres canoniques</option>
-        <option value="culture">Culture</option>
-        <option value="viscounty">Vicomté</option>
-        <option value="county">Comté de jure</option>
-        <option value="county_defacto">Comté de facto</option>
-        <option value="marquisate">Marquisat</option>
-        <option value="duchy">Duché de jure</option>
-        <option value="duchy_defacto">Duché de facto</option>
-        <option value="archduchy">Archiduché</option>
-        <option value="kingdom">Royaume de jure</option>
-        <option value="kingdom_defacto">Royaume de facto</option>
-        <option value="empire">Empire</option>
-        <option value="distance">Distance</option>
-        <option value="occupation">Occupation</option>
-      </select>
+      <select id="filterSelect" class="control-btn"></select>
       <button id="saveToFile" class="control-btn">Enregistrer les pixels</button>
       <button id="offsetBtn" class="control-btn">Offset</button>
       <button id="deleteBarony" class="control-btn">Supprimer</button>

--- a/script.js
+++ b/script.js
@@ -34,13 +34,58 @@
   const filterSelect = document.getElementById('filterSelect');
   const randomBtn = document.getElementById('randomBtn');
   const legendDiv = document.getElementById('legend');
+  const landFilters = [
+    { value: '', label: 'Aucun' },
+    { value: 'religion', label: 'Religion' },
+    { value: 'sanctuary', label: 'Sanctuaire' },
+    { value: 'priory', label: 'Prieuré' },
+    { value: 'church', label: 'Église' },
+    { value: 'cathedral', label: 'Cathédrale' },
+    { value: 'canonical', label: 'Terres canoniques' },
+    { value: 'culture', label: 'Culture' },
+    { value: 'viscounty', label: 'Vicomté de jure' },
+    { value: 'viscounty_defacto', label: 'Vicomté de facto' },
+    { value: 'county', label: 'Comté de jure' },
+    { value: 'county_defacto', label: 'Comté de facto' },
+    { value: 'marquisate', label: 'Marquisat de jure' },
+    { value: 'marquisate_defacto', label: 'Marquisat de facto' },
+    { value: 'duchy', label: 'Duché de jure' },
+    { value: 'duchy_defacto', label: 'Duché de facto' },
+    { value: 'archduchy', label: 'Archiduché de jure' },
+    { value: 'archduchy_defacto', label: 'Archiduché de facto' },
+    { value: 'kingdom', label: 'Royaume de jure' },
+    { value: 'kingdom_defacto', label: 'Royaume de facto' },
+    { value: 'empire', label: 'Empire de jure' },
+    { value: 'empire_defacto', label: 'Empire de facto' },
+    { value: 'distance', label: 'Distance' },
+    { value: 'occupation', label: 'Occupation' }
+  ];
+  const seaFilters = [
+    { value: '', label: 'Aucun' },
+    { value: 'distance', label: 'Distance' }
+  ];
+  function populateFilters() {
+    if (!filterSelect) return;
+    const filters = mapMode === 'sea' ? seaFilters : landFilters;
+    filterSelect.innerHTML = '';
+    filters.forEach(f => {
+      const opt = document.createElement('option');
+      opt.value = f.value;
+      opt.textContent = f.label;
+      filterSelect.appendChild(opt);
+    });
+  }
+  populateFilters();
 
   const linkBtn = document.getElementById('linkBarony');
   const unlinkBtn = document.getElementById('unlinkBarony');
 
   const infoPanel = document.getElementById('infoPanel');
+  const seaInfoPanel = document.getElementById('seaInfoPanel');
   const editIdInput = document.getElementById('editId');
   const editNameInput = document.getElementById('editName');
+  const seaEditIdInput = document.getElementById('seaEditId');
+  const seaEditNameInput = document.getElementById('seaEditName');
   const editReligionPopSelect = document.getElementById('editReligionPop');
   const editSanctuariesBtn = document.getElementById('editSanctuaries');
   const editCanonicalBtn = document.getElementById('editCanonical');
@@ -391,10 +436,14 @@
       const sourceId = pendingLinkId;
       const targetId = id;
       const method = pendingAction === 'link' ? 'POST' : 'DELETE';
-      fetch(`${API_BASE}/api/barony_connections`, {
+      const connectionEndpoint = mapMode === 'sea' ? '/api/maritime_zone_connections' : '/api/barony_connections';
+      const body = mapMode === 'sea'
+        ? { zone_id_1: sourceId, zone_id_2: targetId }
+        : { barony_id_1: sourceId, barony_id_2: targetId };
+      fetch(`${API_BASE}${connectionEndpoint}`, {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ barony_id_1: sourceId, barony_id_2: targetId })
+        body: JSON.stringify(body)
       }).then(() => {
         if (pendingAction === 'link') {
           if (!baronyAdjacency[sourceId]) baronyAdjacency[sourceId] = [];
@@ -413,6 +462,21 @@
     }
 
     currentSelectedId = id;
+    if (mapMode === 'sea') {
+      if (!id) {
+        if (seaInfoPanel) seaInfoPanel.style.display = 'none';
+        return;
+      }
+      if (seaInfoPanel) seaInfoPanel.style.display = 'block';
+      if (infoPanel) infoPanel.style.display = 'none';
+      if (seaEditIdInput) seaEditIdInput.value = id;
+      if (seaEditNameInput) seaEditNameInput.value = baronyMeta[id]?.name || '';
+      if (filterManager && filterSelect && filterSelect.value === 'distance') {
+        filterManager.applyFilter('distance');
+      }
+      return;
+    }
+
     if (!id) {
       if (infoPanel) infoPanel.style.display = 'none';
       return;
@@ -506,6 +570,15 @@
         baronyAdjacency[c.barony_id_1].push(c.barony_id_2);
         baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
       });
+    } else {
+      const connections = await fetch(API_BASE + '/api/maritime_zone_connections').then(r => r.json());
+      baronyAdjacency = {};
+      connections.forEach(c => {
+        if (!baronyAdjacency[c.zone_id_1]) baronyAdjacency[c.zone_id_1] = [];
+        if (!baronyAdjacency[c.zone_id_2]) baronyAdjacency[c.zone_id_2] = [];
+        baronyAdjacency[c.zone_id_1].push(c.zone_id_2);
+        baronyAdjacency[c.zone_id_2].push(c.zone_id_1);
+      });
     }
     mapData = {
       pixelData,
@@ -567,24 +640,33 @@
   });
 
   // Basic editing: updating name/id
-  const saveBtn = document.getElementById('saveBarony');
-  function updateBarony() {
+  function updateEntity() {
     if (!currentSelectedId) return;
-    const newId = editIdInput.value.trim();
-    const newName = editNameInput.value.trim();
+    const idInput = mapMode === 'sea' ? seaEditIdInput : editIdInput;
+    const nameInput = mapMode === 'sea' ? seaEditNameInput : editNameInput;
+    const newId = idInput ? idInput.value.trim() : currentSelectedId;
+    const newName = nameInput ? nameInput.value.trim() : '';
     fetch(`${API_BASE}${entityEndpoint}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: currentSelectedId, newId, name: newName })
     }).then(() => {
-      baronyMeta[newId] = { id: newId, name: newName };
+      baronyMeta[newId] = { ...baronyMeta[currentSelectedId], id: newId, name: newName };
       if (newId !== currentSelectedId) {
-        core.colorMap[newId] = core.colorMap[currentSelectedId];
-        delete core.colorMap[currentSelectedId];
-        delete pixelData[currentSelectedId];
+        if (core.colorMap[currentSelectedId]) {
+          core.colorMap[newId] = core.colorMap[currentSelectedId];
+          delete core.colorMap[currentSelectedId];
+        }
+        if (pixelData[currentSelectedId]) {
+          pixelData[newId] = pixelData[currentSelectedId];
+          delete pixelData[currentSelectedId];
+        }
       }
       core.selectBarony(newId);
     });
   }
-  if (saveBtn) saveBtn.addEventListener('click', updateBarony);
+  if (editIdInput) editIdInput.addEventListener('change', updateEntity);
+  if (editNameInput) editNameInput.addEventListener('change', updateEntity);
+  if (seaEditIdInput) seaEditIdInput.addEventListener('change', updateEntity);
+  if (seaEditNameInput) seaEditNameInput.addEventListener('change', updateEntity);
 })();

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -46,12 +46,42 @@
 
     function applyFilter(type, randomize = false) {
       if (data.mapMode === 'sea') {
+        currentFilter = type || '';
         colorMap = {};
-        Object.keys(data.baronyMeta || {}).forEach(id => {
-          const hue = Math.floor(Math.random() * 360);
-          const [r, g, b] = hslToRgb(hue, 65, 65);
-          colorMap[id] = [r, g, b, 100];
-        });
+        if (type === 'distance') {
+          if (!core.currentSelectedId) {
+            updateLegend(null);
+            core.setCanonicalPatterns({});
+            core.setColorMap(colorMap);
+            return;
+          }
+          const distances = {};
+          const queue = [core.currentSelectedId];
+          distances[core.currentSelectedId] = 0;
+          while (queue.length > 0) {
+            const cur = queue.shift();
+            const next = data.baronyAdjacency[cur] || [];
+            next.forEach(n => {
+              if (distances[n] === undefined) {
+                distances[n] = distances[cur] + 1;
+                queue.push(n);
+              }
+            });
+          }
+          Object.keys(data.baronyMeta).forEach(id => {
+            const d = distances[id];
+            if (d === undefined) return;
+            const hue = (d * 40) % 360;
+            const [r, g, b] = hslToRgb(hue, 65, 65);
+            colorMap[id] = [r, g, b, 100];
+          });
+        } else {
+          Object.keys(data.baronyMeta || {}).forEach(id => {
+            const hue = Math.floor(Math.random() * 360);
+            const [r, g, b] = hslToRgb(hue, 65, 65);
+            colorMap[id] = [r, g, b, 100];
+          });
+        }
         if (core.currentSelectedId && colorMap[core.currentSelectedId]) colorMap[core.currentSelectedId][3] = 180;
         updateLegend(null);
         canonicalPatterns = {};

--- a/viewer.js
+++ b/viewer.js
@@ -53,9 +53,55 @@
   const infoPlayer = document.getElementById('infoPlayer');
   const infoBishop = document.getElementById('infoBishop');
   const infoCanonical = document.getElementById('infoCanonical');
+  const seaInfoPanel = document.getElementById('seaInfoPanel');
+  const seaInfoId = document.getElementById('seaInfoId');
+  const seaInfoName = document.getElementById('seaInfoName');
   const legendDiv = document.getElementById('legend');
   const filterSelect = document.getElementById('filterSelect');
   const randomBtn = document.getElementById('randomBtn');
+
+  const landFilters = [
+    { value: '', label: 'Aucun' },
+    { value: 'religion', label: 'Religion' },
+    { value: 'sanctuary', label: 'Sanctuaire' },
+    { value: 'priory', label: 'Prieuré' },
+    { value: 'church', label: 'Église' },
+    { value: 'cathedral', label: 'Cathédrale' },
+    { value: 'canonical', label: 'Terres canoniques' },
+    { value: 'culture', label: 'Culture' },
+    { value: 'viscounty', label: 'Vicomté de jure' },
+    { value: 'viscounty_defacto', label: 'Vicomté de facto' },
+    { value: 'county', label: 'Comté de jure' },
+    { value: 'county_defacto', label: 'Comté de facto' },
+    { value: 'marquisate', label: 'Marquisat de jure' },
+    { value: 'marquisate_defacto', label: 'Marquisat de facto' },
+    { value: 'duchy', label: 'Duché de jure' },
+    { value: 'duchy_defacto', label: 'Duché de facto' },
+    { value: 'archduchy', label: 'Archiduché de jure' },
+    { value: 'archduchy_defacto', label: 'Archiduché de facto' },
+    { value: 'kingdom', label: 'Royaume de jure' },
+    { value: 'kingdom_defacto', label: 'Royaume de facto' },
+    { value: 'empire', label: 'Empire de jure' },
+    { value: 'empire_defacto', label: 'Empire de facto' },
+    { value: 'distance', label: 'Distance' },
+    { value: 'occupation', label: 'Occupation' }
+  ];
+  const seaFilters = [
+    { value: '', label: 'Aucun' },
+    { value: 'distance', label: 'Distance' }
+  ];
+  function populateFilters() {
+    if (!filterSelect) return;
+    const filters = mapMode === 'sea' ? seaFilters : landFilters;
+    filterSelect.innerHTML = '';
+    filters.forEach(f => {
+      const opt = document.createElement('option');
+      opt.value = f.value;
+      opt.textContent = f.label;
+      filterSelect.appendChild(opt);
+    });
+  }
+  populateFilters();
 
   function updateLegend(groups) {
     if (!legendDiv) return;
@@ -81,12 +127,28 @@
   }
 
   function handleSelect(id) {
+    if (mapMode === 'sea') {
+      if (!id) {
+        if (seaInfoPanel) seaInfoPanel.style.display = 'none';
+        return;
+      }
+      const info = baronyMeta[id] || {};
+      if (seaInfoPanel) seaInfoPanel.style.display = 'block';
+      if (infoPanel) infoPanel.style.display = 'none';
+      if (seaInfoId) seaInfoId.textContent = info.id || '';
+      if (seaInfoName) seaInfoName.textContent = info.name || '';
+      if (filterManager && filterSelect && filterSelect.value === 'distance') {
+        filterManager.applyFilter('distance');
+      }
+      return;
+    }
     if (!id) {
-      infoPanel.style.display = 'none';
+      if (infoPanel) infoPanel.style.display = 'none';
       return;
     }
     const info = baronyMeta[id] || {};
-    infoPanel.style.display = 'block';
+    if (infoPanel) infoPanel.style.display = 'block';
+    if (seaInfoPanel) seaInfoPanel.style.display = 'none';
     infoId.textContent = info.id || '';
     infoName.textContent = info.name || '';
     infoSeigneur.textContent = seigneurMap[info.seigneur_id]?.name || '';
@@ -113,7 +175,7 @@
     infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || 'Aucune';
     infoPlayer.textContent = info.player ? 'Oui' : 'Non';
     infoBishop.textContent = info.bishop ? 'Oui' : 'Non';
-      infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || '').join(', ');
+    infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || '').join(', ');
     if (filterManager && filterSelect && filterSelect.value === 'distance') {
       filterManager.applyFilter('distance');
     }


### PR DESCRIPTION
## Summary
- différencie les filtres entre baronnies et zones maritimes dans l'index et l'éditeur
- ajoute un panneau d'information et l'édition pour les zones maritimes
- permet le filtre de distance pour les zones maritimes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7961a106c832db63f22f2aca18feb