### PR TITLE
Améliore l'affichage du panneau de baronnie

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,25 +28,34 @@
     </div>
     <aside id="infoPanel" class="info-panel" style="display:none;">
       <h2>Baronnie sélectionnée</h2>
-      <div><strong>ID :</strong> <span id="infoId"></span></div>
-      <div><strong>Nom :</strong> <span id="infoName"></span></div>
-      <div><strong>Seigneur :</strong> <span id="infoSeigneur"></span></div>
-      <div><strong>Religion :</strong> <span id="infoReligion"></span></div>
-      <div><strong>Culture :</strong> <span id="infoCulture"></span></div>
-      <div><strong>Vicomté :</strong> <span id="infoViscounty"></span></div>
-      <div><strong>Comté :</strong> <span id="infoCounty"></span></div>
-      <div><strong>Marquisat :</strong> <span id="infoMarquisate"></span></div>
-      <div><strong>Duché :</strong> <span id="infoDuchy"></span></div>
-      <div><strong>Archiduché :</strong> <span id="infoArchduchy"></span></div>
-      <div><strong>Royaume :</strong> <span id="infoKingdom"></span></div>
-      <div><strong>Empire :</strong> <span id="infoEmpire"></span></div>
-      <div><strong>Sanctuaires :</strong> <span id="infoSanctuary"></span></div>
-      <div><strong>Prieuré :</strong> <span id="infoPriory"></span></div>
-      <div><strong>Église :</strong> <span id="infoChurch"></span></div>
-      <div><strong>Cathédrale :</strong> <span id="infoCathedral"></span></div>
-      <div><strong>Joueur :</strong> <span id="infoPlayer"></span></div>
-      <div><strong>Évêque :</strong> <span id="infoBishop"></span></div>
-      <div><strong>Terres canoniques :</strong> <span id="infoCanonical"></span></div>
+      <section class="info-group">
+        <h3>Général</h3>
+        <div class="info-row" id="infoIdRow"><strong>ID :</strong> <span id="infoId"></span></div>
+        <div class="info-row" id="infoNameRow"><strong>Nom :</strong> <span id="infoName"></span></div>
+        <div class="info-row" id="infoSeigneurRow"><strong>Seigneur :</strong> <span id="infoSeigneur"></span></div>
+        <div class="info-row" id="infoCultureRow"><strong>Culture :</strong> <span id="infoCulture"></span></div>
+        <div class="info-row" id="infoPlayerRow"><strong>Joueur :</strong> <span id="infoPlayer"></span></div>
+      </section>
+      <section class="info-group">
+        <h3>Hiérarchie féodale</h3>
+        <div class="info-row" id="infoViscountyRow"><strong>Vicomté :</strong> <span id="infoViscounty"></span></div>
+        <div class="info-row" id="infoCountyRow"><strong>Comté :</strong> <span id="infoCounty"></span></div>
+        <div class="info-row" id="infoMarquisateRow"><strong>Marquisat :</strong> <span id="infoMarquisate"></span></div>
+        <div class="info-row" id="infoDuchyRow"><strong>Duché :</strong> <span id="infoDuchy"></span></div>
+        <div class="info-row" id="infoArchduchyRow"><strong>Archiduché :</strong> <span id="infoArchduchy"></span></div>
+        <div class="info-row" id="infoKingdomRow"><strong>Royaume :</strong> <span id="infoKingdom"></span></div>
+        <div class="info-row" id="infoEmpireRow"><strong>Empire :</strong> <span id="infoEmpire"></span></div>
+      </section>
+      <section class="info-group">
+        <h3>Religion</h3>
+        <div class="info-row" id="infoReligionRow"><strong>Religion :</strong> <span id="infoReligion"></span></div>
+        <div class="info-row" id="infoSanctuaryRow"><strong>Sanctuaires :</strong> <ul id="infoSanctuaryList"></ul></div>
+        <div class="info-row" id="infoPrioryRow"><strong>Prieuré :</strong> <span id="infoPriory"></span></div>
+        <div class="info-row" id="infoChurchRow"><strong>Église :</strong> <span id="infoChurch"></span></div>
+        <div class="info-row" id="infoCathedralRow"><strong>Cathédrale :</strong> <span id="infoCathedral"></span></div>
+        <div class="info-row" id="infoBishopRow"><strong>Évêque :</strong> <span id="infoBishop"></span></div>
+        <div class="info-row" id="infoCanonicalRow"><strong>Terres canoniques :</strong> <ul id="infoCanonicalList"></ul></div>
+      </section>
     </aside>
     <aside id="seaInfoPanel" class="info-panel" style="display:none;">
       <h2>Zone maritime sélectionnée</h2>

--- a/styles.css
+++ b/styles.css
@@ -238,11 +238,27 @@ main {
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   min-width: 200px;
+  max-width: 300px;
+  overflow-wrap: anywhere;
   z-index: 10;
 }
 .info-panel h2 {
   margin-top: 0;
   font-size: 1rem;
+}
+.info-group {
+  margin-bottom: 8px;
+}
+.info-group h3 {
+  margin: 4px 0;
+  font-size: 0.9rem;
+}
+.info-row {
+  margin: 2px 0;
+}
+.info-panel ul {
+  margin: 2px 0 0 16px;
+  padding: 0;
 }
 .info-panel label {
   display: block;

--- a/viewer.js
+++ b/viewer.js
@@ -34,31 +34,76 @@
   const pixelCanvas = document.getElementById('pixelCanvas');
   const mapContainer = document.getElementById('mapContainer');
   const infoPanel = document.getElementById('infoPanel');
+  const infoIdRow = document.getElementById('infoIdRow');
   const infoId = document.getElementById('infoId');
+  const infoNameRow = document.getElementById('infoNameRow');
   const infoName = document.getElementById('infoName');
+  const infoSeigneurRow = document.getElementById('infoSeigneurRow');
   const infoSeigneur = document.getElementById('infoSeigneur');
-  const infoReligion = document.getElementById('infoReligion');
+  const infoCultureRow = document.getElementById('infoCultureRow');
   const infoCulture = document.getElementById('infoCulture');
-  const infoViscounty = document.getElementById('infoViscounty');
-  const infoCounty = document.getElementById('infoCounty');
-  const infoMarquisate = document.getElementById('infoMarquisate');
-  const infoDuchy = document.getElementById('infoDuchy');
-  const infoArchduchy = document.getElementById('infoArchduchy');
-  const infoKingdom = document.getElementById('infoKingdom');
-  const infoEmpire = document.getElementById('infoEmpire');
-  const infoSanctuary = document.getElementById('infoSanctuary');
-  const infoPriory = document.getElementById('infoPriory');
-  const infoChurch = document.getElementById('infoChurch');
-  const infoCathedral = document.getElementById('infoCathedral');
+  const infoPlayerRow = document.getElementById('infoPlayerRow');
   const infoPlayer = document.getElementById('infoPlayer');
+  const infoViscountyRow = document.getElementById('infoViscountyRow');
+  const infoViscounty = document.getElementById('infoViscounty');
+  const infoCountyRow = document.getElementById('infoCountyRow');
+  const infoCounty = document.getElementById('infoCounty');
+  const infoMarquisateRow = document.getElementById('infoMarquisateRow');
+  const infoMarquisate = document.getElementById('infoMarquisate');
+  const infoDuchyRow = document.getElementById('infoDuchyRow');
+  const infoDuchy = document.getElementById('infoDuchy');
+  const infoArchduchyRow = document.getElementById('infoArchduchyRow');
+  const infoArchduchy = document.getElementById('infoArchduchy');
+  const infoKingdomRow = document.getElementById('infoKingdomRow');
+  const infoKingdom = document.getElementById('infoKingdom');
+  const infoEmpireRow = document.getElementById('infoEmpireRow');
+  const infoEmpire = document.getElementById('infoEmpire');
+  const infoReligionRow = document.getElementById('infoReligionRow');
+  const infoReligion = document.getElementById('infoReligion');
+  const infoSanctuaryRow = document.getElementById('infoSanctuaryRow');
+  const infoSanctuaryList = document.getElementById('infoSanctuaryList');
+  const infoPrioryRow = document.getElementById('infoPrioryRow');
+  const infoPriory = document.getElementById('infoPriory');
+  const infoChurchRow = document.getElementById('infoChurchRow');
+  const infoChurch = document.getElementById('infoChurch');
+  const infoCathedralRow = document.getElementById('infoCathedralRow');
+  const infoCathedral = document.getElementById('infoCathedral');
+  const infoBishopRow = document.getElementById('infoBishopRow');
   const infoBishop = document.getElementById('infoBishop');
-  const infoCanonical = document.getElementById('infoCanonical');
+  const infoCanonicalRow = document.getElementById('infoCanonicalRow');
+  const infoCanonicalList = document.getElementById('infoCanonicalList');
   const seaInfoPanel = document.getElementById('seaInfoPanel');
   const seaInfoId = document.getElementById('seaInfoId');
   const seaInfoName = document.getElementById('seaInfoName');
   const legendDiv = document.getElementById('legend');
   const filterSelect = document.getElementById('filterSelect');
   const randomBtn = document.getElementById('randomBtn');
+
+  function setRow(row, span, value) {
+    if (!row || !span) return;
+    if (value !== undefined && value !== null && value !== '') {
+      row.style.display = 'block';
+      span.textContent = value;
+    } else {
+      row.style.display = 'none';
+      span.textContent = '';
+    }
+  }
+
+  function setList(row, list, items) {
+    if (!row || !list) return;
+    list.innerHTML = '';
+    if (items && items.length > 0) {
+      row.style.display = 'block';
+      items.forEach(text => {
+        const li = document.createElement('li');
+        li.textContent = text;
+        list.appendChild(li);
+      });
+    } else {
+      row.style.display = 'none';
+    }
+  }
 
   const landFilters = [
     { value: '', label: 'Aucun' },
@@ -149,33 +194,33 @@
     const info = baronyMeta[id] || {};
     if (infoPanel) infoPanel.style.display = 'block';
     if (seaInfoPanel) seaInfoPanel.style.display = 'none';
-    infoId.textContent = info.id || '';
-    infoName.textContent = info.name || '';
-    infoSeigneur.textContent = seigneurMap[info.seigneur_id]?.name || '';
-    infoReligion.textContent = religionMap[info.religion_pop_id]?.name || '';
-    infoCulture.textContent = cultureMapInfo[info.culture_id]?.name || '';
+    setRow(infoIdRow, infoId, info.id);
+    setRow(infoNameRow, infoName, info.name);
+    setRow(infoSeigneurRow, infoSeigneur, seigneurMap[info.seigneur_id]?.name);
+    setRow(infoCultureRow, infoCulture, cultureMapInfo[info.culture_id]?.name);
+    setRow(infoPlayerRow, infoPlayer, info.player ? 'Oui' : '');
     const viscounty = viscountyMap[info.viscounty_id];
-    infoViscounty.textContent = viscounty ? viscounty.name : '';
+    setRow(infoViscountyRow, infoViscounty, viscounty?.name);
     const county = countyMap[info.county_id];
-    infoCounty.textContent = county ? county.name : '';
+    setRow(infoCountyRow, infoCounty, county?.name);
     const marquisate = county ? marquisateMap[county.marquisate_id] : null;
-    infoMarquisate.textContent = marquisate ? marquisate.name : '';
+    setRow(infoMarquisateRow, infoMarquisate, marquisate?.name);
     const duchy = county ? duchyMap[county.duchy_id] : null;
-    infoDuchy.textContent = duchy ? duchy.name : '';
+    setRow(infoDuchyRow, infoDuchy, duchy?.name);
     const archduchy = duchy ? archduchyMap[duchy.archduchy_id] : null;
-    infoArchduchy.textContent = archduchy ? archduchy.name : '';
+    setRow(infoArchduchyRow, infoArchduchy, archduchy?.name);
     const kingdom = duchy ? kingdomMap[duchy.kingdom_id] : null;
-    infoKingdom.textContent = kingdom ? kingdom.name : '';
+    setRow(infoKingdomRow, infoKingdom, kingdom?.name);
     const empire = kingdom ? empireMap[kingdom.empire_id] : null;
-    infoEmpire.textContent = empire ? empire.name : '';
+    setRow(infoEmpireRow, infoEmpire, empire?.name);
+    setRow(infoReligionRow, infoReligion, religionMap[info.religion_pop_id]?.name);
     const sancts = sanctuaryMap[id] || [];
-    infoSanctuary.textContent = sancts.length > 0 ? sancts.map(s => `${religionMap[s.religion_id]?.name || ''}${s.active ? ' (actif)' : ' (inactif)'}`).join(', ') : 'Aucun';
-    infoPriory.textContent = religionMap[info.priory_religion_id]?.name || 'Aucun';
-    infoChurch.textContent = religionMap[info.church_religion_id]?.name || 'Aucune';
-    infoCathedral.textContent = religionMap[info.cathedral_religion_id]?.name || 'Aucune';
-    infoPlayer.textContent = info.player ? 'Oui' : 'Non';
-    infoBishop.textContent = info.bishop ? 'Oui' : 'Non';
-    infoCanonical.textContent = (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || '').join(', ');
+    setList(infoSanctuaryRow, infoSanctuaryList, sancts.map(s => `${religionMap[s.religion_id]?.name || ''}${s.active ? ' (actif)' : ' (inactif)'}`));
+    setRow(infoPrioryRow, infoPriory, religionMap[info.priory_religion_id]?.name);
+    setRow(infoChurchRow, infoChurch, religionMap[info.church_religion_id]?.name);
+    setRow(infoCathedralRow, infoCathedral, religionMap[info.cathedral_religion_id]?.name);
+    setRow(infoBishopRow, infoBishop, info.bishop ? 'Oui' : '');
+    setList(infoCanonicalRow, infoCanonicalList, (canonicalLandMap[id] || []).map(rid => baronyMeta[rid]?.name || ''));
     if (filterManager && filterSelect && filterSelect.value === 'distance') {
       filterManager.applyFilter('distance');
     }


### PR DESCRIPTION
## Summary
- Réorganise le panneau d'information des baronnies en sections thématiques et formatte les listes pour éviter les dépassements.
- Ajoute du style pour limiter la largeur du panneau et harmoniser l'affichage.
- Met à jour `viewer.js` pour masquer automatiquement les éléments vides et gérer les nouvelles listes.

## Testing
- `npm test` *(échoue: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7aca49bd0832d935b513d14821ca6