### PR TITLE
feat: link baronies to maritime zones

### DIFF
--- a/mapEditor.html
+++ b/mapEditor.html
@@ -92,6 +92,7 @@
       <input type="text" id="seaEditId">
       <label for="seaEditName">Nom&nbsp;:</label>
       <input type="text" id="seaEditName">
+      <button id="editSeaBaronies" class="control-btn">Associer baronnies</button>
     </aside>
     <div id="legend" class="legend" style="display:none;"></div>
   </main>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,9 @@
   let mapHeight = 0;
 
   let pixelData = {};
+  let seaPixelData = {};
+  let baronyPixelData = {};
+  let maritimeZoneBaronies = {};
   let baronyMeta = {};
   let seigneurMap = {};
   let religionMap = {};
@@ -25,6 +28,10 @@
   let sanctuaryMap = {};
   let baronyAdjacency = {};
   let mapData = {};
+
+  let baronyLinkMode = false;
+  let previousFilter = '';
+  let currentSeaZoneId = null;
 
   let filterManager = null;
 
@@ -62,7 +69,8 @@
   ];
   const seaFilters = [
     { value: '', label: 'Aucun' },
-    { value: 'distance', label: 'Distance' }
+    { value: 'distance', label: 'Distance' },
+    { value: 'baronies', label: 'Baronnies liées' }
   ];
   function populateFilters() {
     if (!filterSelect) return;
@@ -86,6 +94,7 @@
   const editNameInput = document.getElementById('editName');
   const seaEditIdInput = document.getElementById('seaEditId');
   const seaEditNameInput = document.getElementById('seaEditName');
+  const editSeaBaroniesBtn = document.getElementById('editSeaBaronies');
   const editReligionPopSelect = document.getElementById('editReligionPop');
   const editSanctuariesBtn = document.getElementById('editSanctuaries');
   const editCanonicalBtn = document.getElementById('editCanonical');
@@ -120,6 +129,22 @@
       legendDiv.appendChild(item);
     });
     legendDiv.style.display = 'block';
+  }
+
+  function drawOverlay(ctx) {
+    if (mapMode !== 'sea') return;
+    const zoneId = baronyLinkMode ? currentSeaZoneId : core?.currentSelectedId;
+    if (baronyLinkMode && zoneId) {
+      ctx.fillStyle = 'rgba(255,255,0,0.4)';
+      (seaPixelData[zoneId] || []).forEach(([x, y]) => ctx.fillRect(x, y, 1, 1));
+    }
+    const showBaronies = baronyLinkMode || (filterSelect && filterSelect.value === 'baronies');
+    if (showBaronies && zoneId) {
+      ctx.fillStyle = 'rgba(0,0,255,0.4)';
+      (maritimeZoneBaronies[zoneId] || []).forEach(bid => {
+        (baronyPixelData[bid] || []).forEach(([x, y]) => ctx.fillRect(x, y, 1, 1));
+      });
+    }
   }
 
   let core = null;
@@ -431,6 +456,29 @@
     });
   }
 
+  if (editSeaBaroniesBtn) {
+    editSeaBaroniesBtn.addEventListener('click', () => {
+      if (!currentSeaZoneId) return;
+      baronyLinkMode = !baronyLinkMode;
+      if (baronyLinkMode) {
+        previousFilter = filterSelect ? filterSelect.value : '';
+        core.setPixelData(baronyPixelData);
+        const greyMap = {};
+        Object.keys(baronyPixelData).forEach(id => { greyMap[id] = [150, 150, 150, 60]; });
+        core.setColorMap(greyMap);
+        core.selectBarony(null);
+      } else {
+        core.setPixelData(seaPixelData);
+        if (filterManager && filterSelect) {
+          filterManager.applyFilter(filterSelect.value);
+        } else {
+          core.drawAll();
+        }
+      }
+      core.drawAll();
+    });
+  }
+
   function handleSelect(id) {
     if (pendingAction && pendingLinkId && id && id !== pendingLinkId) {
       const sourceId = pendingLinkId;
@@ -461,21 +509,42 @@
       return;
     }
 
-    currentSelectedId = id;
     if (mapMode === 'sea') {
+      if (baronyLinkMode) {
+        if (!id || !currentSeaZoneId) return;
+        const list = maritimeZoneBaronies[currentSeaZoneId] || [];
+        const idx = list.indexOf(id);
+        const method = idx >= 0 ? 'DELETE' : 'POST';
+        fetch(`${API_BASE}/api/maritime_zone_baronies`, {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ zone_id: currentSeaZoneId, barony_id: id })
+        }).then(() => {
+          if (idx >= 0) list.splice(idx, 1); else list.push(id);
+          maritimeZoneBaronies[currentSeaZoneId] = list;
+          core.drawAll();
+        });
+        core.selectBarony(null);
+        return;
+      }
+      currentSelectedId = id;
+      currentSeaZoneId = id;
       if (!id) {
         if (seaInfoPanel) seaInfoPanel.style.display = 'none';
+        core.drawAll();
         return;
       }
       if (seaInfoPanel) seaInfoPanel.style.display = 'block';
       if (infoPanel) infoPanel.style.display = 'none';
       if (seaEditIdInput) seaEditIdInput.value = id;
       if (seaEditNameInput) seaEditNameInput.value = baronyMeta[id]?.name || '';
-      if (filterManager && filterSelect && filterSelect.value === 'distance') {
-        filterManager.applyFilter('distance');
+      if (filterManager && filterSelect && (filterSelect.value === 'distance' || filterSelect.value === 'baronies')) {
+        filterManager.applyFilter(filterSelect.value);
       }
+      core.drawAll();
       return;
     }
+    currentSelectedId = id;
 
     if (!id) {
       if (infoPanel) infoPanel.style.display = 'none';
@@ -571,13 +640,24 @@
         baronyAdjacency[c.barony_id_2].push(c.barony_id_1);
       });
     } else {
-      const connections = await fetch(API_BASE + '/api/maritime_zone_connections').then(r => r.json());
+      const [connections, bPixels, zoneBaronies] = await Promise.all([
+        fetch(API_BASE + '/api/maritime_zone_connections').then(r => r.json()),
+        fetch(API_BASE + '/api/barony_pixels').then(r => r.json()),
+        fetch(API_BASE + '/api/maritime_zone_baronies').then(r => r.json())
+      ]);
       baronyAdjacency = {};
       connections.forEach(c => {
         if (!baronyAdjacency[c.zone_id_1]) baronyAdjacency[c.zone_id_1] = [];
         if (!baronyAdjacency[c.zone_id_2]) baronyAdjacency[c.zone_id_2] = [];
         baronyAdjacency[c.zone_id_1].push(c.zone_id_2);
         baronyAdjacency[c.zone_id_2].push(c.zone_id_1);
+      });
+      seaPixelData = pixelData;
+      baronyPixelData = bPixels;
+      maritimeZoneBaronies = {};
+      zoneBaronies.forEach(zb => {
+        if (!maritimeZoneBaronies[zb.zone_id]) maritimeZoneBaronies[zb.zone_id] = [];
+        maritimeZoneBaronies[zb.zone_id].push(zb.barony_id);
       });
     }
     mapData = {
@@ -596,6 +676,8 @@
       canonicalLandMap,
       sanctuaryMap,
       baronyAdjacency,
+      baronyPixels: baronyPixelData,
+      maritimeZoneBaronies,
       seigneurToCounty,
       seigneurToDuchy,
       seigneurToKingdom,
@@ -625,7 +707,7 @@
         canvas: pixelCanvas,
         fetchData,
         onSelect: handleSelect,
-        drawOverlay: () => {},
+        drawOverlay,
         mapMode
       });
       core.ready.then(() => {

--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -289,6 +289,11 @@
         ctx.fillStyle = `rgba(${col[0]},${col[1]},${col[2]},${alpha})`;
         ctx.fillRect(x, y, 1, 1);
       },
+      setPixelData: pd => {
+        pixelData = pd || {};
+        rebuildPixelMap();
+        drawAll();
+      },
       get pixelData() { return pixelData; },
       get pixelMap() { return pixelMap; },
       get colorMap() { return colorMap; },

--- a/viewer.js
+++ b/viewer.js
@@ -10,6 +10,8 @@
   const npcColor = [231, 76, 60];
 
   let pixelData = {};
+  let baronyPixels = {};
+  let maritimeZoneBaronies = {};
   let baronyMeta = {};
   let seigneurMap = {};
   let religionMap = {};
@@ -28,6 +30,7 @@
   let mapData = {};
 
   let filterManager = null;
+  let core = null;
 
   const baseMap = document.getElementById('baseMap');
   if (mapMode === 'sea' && baseMap) baseMap.src = 'zones_maritimes.png';
@@ -103,7 +106,8 @@
   ];
   const seaFilters = [
     { value: '', label: 'Aucun' },
-    { value: 'distance', label: 'Distance' }
+    { value: 'distance', label: 'Distance' },
+    { value: 'baronies', label: 'Baronnies liées' }
   ];
   function populateFilters() {
     if (!filterSelect) return;
@@ -141,6 +145,17 @@
     legendDiv.style.display = 'block';
   }
 
+  function drawOverlay(ctx) {
+    if (mapMode !== 'sea') return;
+    if (!filterSelect || filterSelect.value !== 'baronies') return;
+    const zoneId = core?.currentSelectedId;
+    if (!zoneId) return;
+    ctx.fillStyle = 'rgba(0,0,255,0.4)';
+    (maritimeZoneBaronies[zoneId] || []).forEach(bid => {
+      (baronyPixels[bid] || []).forEach(([x, y]) => ctx.fillRect(x, y, 1, 1));
+    });
+  }
+
   function handleSelect(id) {
     if (mapMode === 'sea') {
       if (!id) {
@@ -152,8 +167,8 @@
       if (infoPanel) infoPanel.style.display = 'none';
       if (seaInfoId) seaInfoId.textContent = info.id || '';
       if (seaInfoName) seaInfoName.textContent = info.name || '';
-      if (filterManager && filterSelect && filterSelect.value === 'distance') {
-        filterManager.applyFilter('distance');
+      if (filterManager && filterSelect && (filterSelect.value === 'distance' || filterSelect.value === 'baronies')) {
+        filterManager.applyFilter(filterSelect.value);
       }
       return;
     }
@@ -206,9 +221,11 @@
     const endpoint = mapMode === 'sea' ? '/api/maritime_zone_pixels' : '/api/barony_pixels';
     pixelData = await fetch(API_BASE + endpoint).then(r => r.json());
     if (mapMode === 'sea') {
-      const [zones, connections] = await Promise.all([
+      const [zones, connections, bPixels, zoneBaronies] = await Promise.all([
         fetch(API_BASE + '/api/maritime_zones').then(r => r.json()),
-        fetch(API_BASE + '/api/maritime_zone_connections').then(r => r.json())
+        fetch(API_BASE + '/api/maritime_zone_connections').then(r => r.json()),
+        fetch(API_BASE + '/api/barony_pixels').then(r => r.json()),
+        fetch(API_BASE + '/api/maritime_zone_baronies').then(r => r.json())
       ]);
       baronyMeta = {};
       zones.forEach(z => { baronyMeta[z.id] = z; });
@@ -219,7 +236,13 @@
         baronyAdjacency[c.zone_id_1].push(c.zone_id_2);
         baronyAdjacency[c.zone_id_2].push(c.zone_id_1);
       });
-      mapData = { pixelData, baronyMeta, baronyAdjacency, mapWidth, mapHeight, mapMode };
+      baronyPixels = bPixels;
+      maritimeZoneBaronies = {};
+      zoneBaronies.forEach(zb => {
+        if (!maritimeZoneBaronies[zb.zone_id]) maritimeZoneBaronies[zb.zone_id] = [];
+        maritimeZoneBaronies[zb.zone_id].push(zb.barony_id);
+      });
+      mapData = { pixelData, baronyMeta, baronyAdjacency, baronyPixels, maritimeZoneBaronies, mapWidth, mapHeight, mapMode };
       return mapData;
     }
     const [baronies, seigneurs, religions, cultures, counties, duchies, kingdoms, viscounties, marquisates, archduchies, empires, canonicalLands, sanctuaries, connections] = await Promise.all([
@@ -325,11 +348,11 @@
       pixelCanvas.height = mapHeight;
       pixelCanvas.style.width = mapWidth + 'px';
       pixelCanvas.style.height = mapHeight + 'px';
-      const core = mapCore.init({
+      core = mapCore.init({
         canvas: pixelCanvas,
         fetchData,
         onSelect: handleSelect,
-        drawOverlay: () => {},
+        drawOverlay,
         mapMode
       });
       core.ready.then(() => {


### PR DESCRIPTION
## Summary
- add maritime barony linking mode in map editor
- show linked baronies with new sea filter
- expose setPixelData helper in map core

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a879959a84832d83ce5889dbf2ba76