### PR TITLE
Add static trade route map to commerce tab

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -40,7 +40,13 @@
         <div id="tab-ost" class="tab-panel"></div>
         <div id="tab-commerce" class="tab-panel">
           <h2>Chemins commerciaux</h2>
-          <div id="tradeRoutes"></div>
+          <div id="tradeSection" class="trade-section">
+            <div id="tradeMap" class="trade-map">
+              <img id="tradeBaseMap" src="Asgaria.png" alt="Carte" />
+              <canvas id="tradeCanvas"></canvas>
+            </div>
+            <div id="tradeRoutes" class="trade-routes"></div>
+          </div>
         </div>
         <div id="tab-proprietes" class="tab-panel">
           <div id="baronyProps"></div>
@@ -60,6 +66,7 @@
     </div>
   </dialog>
   <script src="auth.js"></script>
+  <script src="src/mapCore.js"></script>
   <script src="gestion.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/gestion.js
+++ b/gestion.js
@@ -1887,17 +1887,76 @@ function showSpellResult(success, spell, amount, error, randomLuxury) {
   document.body.appendChild(overlay);
 }
 
+let tradeMapCore = null;
+let tradeAdjacency = {};
+
+async function initTradeMap() {
+  if (tradeMapCore) return;
+  const base = document.getElementById('tradeBaseMap');
+  const canvas = document.getElementById('tradeCanvas');
+  if (!base || !canvas) return;
+  const baseLoaded = base.complete ? Promise.resolve() : new Promise(res => (base.onload = res));
+  await baseLoaded;
+  canvas.width = base.naturalWidth;
+  canvas.height = base.naturalHeight;
+  canvas.style.width = '100%';
+  canvas.style.height = '100%';
+  tradeMapCore = mapCore.init({
+    canvas,
+    enablePan: false,
+    enableZoom: false,
+    fetchData: async () => {
+      const [pixels, connections] = await Promise.all([
+        fetch('/api/barony_pixels').then(r => r.json()),
+        fetch('/api/barony_connections').then(r => r.json())
+      ]);
+      tradeAdjacency = {};
+      connections.forEach(c => {
+        if (!tradeAdjacency[c.barony_id_1]) tradeAdjacency[c.barony_id_1] = [];
+        if (!tradeAdjacency[c.barony_id_2]) tradeAdjacency[c.barony_id_2] = [];
+        tradeAdjacency[c.barony_id_1].push(c.barony_id_2);
+        tradeAdjacency[c.barony_id_2].push(c.barony_id_1);
+      });
+      return { mapWidth: base.naturalWidth, mapHeight: base.naturalHeight, pixelData: pixels };
+    }
+  });
+  await tradeMapCore.ready;
+}
+
+async function updateTradeMap(baronyId, routes) {
+  await initTradeMap();
+  if (!tradeMapCore) return;
+  const bg = [245, 247, 250, 255];
+  const highlight = [128, 0, 128, 255];
+  const colorMap = {};
+  Object.keys(tradeMapCore.pixelData).forEach(id => {
+    colorMap[id] = bg;
+  });
+  const ids = new Set();
+  if (baronyId) {
+    ids.add(String(baronyId));
+    (tradeAdjacency[baronyId] || []).forEach(id => ids.add(String(id)));
+  }
+  (routes || []).forEach(r => ids.add(String(r.id)));
+  ids.forEach(id => {
+    colorMap[id] = highlight;
+  });
+  tradeMapCore.setColorMap(colorMap);
+}
+
 async function renderTradeRoutes(baronyId) {
   const container = document.getElementById('tradeRoutes');
   if (!container) return;
   container.textContent = '';
   if (!baronyId) {
     container.textContent = 'Aucune baronnie sélectionnée';
+    await updateTradeMap(null, []);
     return;
   }
   try {
     const res = await fetch(`/api/trade_partners?barony_id=${baronyId}`);
     const routes = res.ok ? await res.json() : [];
+    await updateTradeMap(baronyId, routes);
     if (!routes.length) {
       container.textContent = 'Aucune route commerciale';
       return;
@@ -1906,6 +1965,7 @@ async function renderTradeRoutes(baronyId) {
     container.innerHTML = `<table class="admin-table"><tr><th>#</th><th>Nom</th><th>Propriétaire</th><th>Province (Duché)</th></tr>${rows}</table>`;
   } catch {
     container.textContent = 'Erreur de chargement';
+    await updateTradeMap(baronyId, []);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -565,3 +565,31 @@ th.multi-col {
   border: 2px solid #dc3545;
   color: #721c24;
 }
+
+/* Commerce tab */
+.trade-section {
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.trade-map {
+  flex: 1;
+  position: relative;
+  aspect-ratio: 4 / 3;
+}
+
+.trade-map img,
+.trade-map canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.trade-routes {
+  flex: 1;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- Show a static barony map next to the trade routes table in the commerce tab
- Style map and table to share the page width with padding
- Highlight baronies linked by trade routes or adjacent in purple on the static map

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a886b03430832d8ec48de4ba05dad8