### PR TITLE
Fix trade map visibility and color scheme

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -73,6 +73,13 @@
       const buttons = document.querySelectorAll('.tab-btn');
       const panels = document.querySelectorAll('.tab-panel');
 
+      function refreshTradeMap() {
+        if (window.tradeMapCore) {
+          window.tradeMapCore.fitToContainer();
+          window.tradeMapCore.drawAll();
+        }
+      }
+
       let savedTab = localStorage.getItem('gestionActiveTab');
       const availableTabs = Array.from(buttons).filter(btn => btn.style.display !== 'none').map(btn => btn.dataset.tab);
       if (!savedTab || !availableTabs.includes(savedTab)) {
@@ -89,12 +96,14 @@
           btn.classList.add('active');
           document.getElementById('tab-' + tab).classList.add('active');
           localStorage.setItem('gestionActiveTab', tab);
+          if (tab === 'commerce') refreshTradeMap();
         });
       });
 
       panels.forEach(p => {
         p.classList.toggle('active', p.id === 'tab-' + savedTab);
       });
+      if (savedTab === 'commerce') refreshTradeMap();
     });
   </script>
 </body>

--- a/gestion.js
+++ b/gestion.js
@@ -1921,26 +1921,34 @@ async function initTradeMap() {
     }
   });
   await tradeMapCore.ready;
+  const commerceTab = document.getElementById('tab-commerce');
+  if (commerceTab && commerceTab.classList.contains('active')) {
+    tradeMapCore.fitToContainer();
+    tradeMapCore.drawAll();
+  }
 }
 
 async function updateTradeMap(baronyId, routes) {
   await initTradeMap();
   if (!tradeMapCore) return;
-  const bg = [245, 247, 250, 255];
-  const highlight = [128, 0, 128, 255];
+  const bg = [...mapCore.terrainColor, 100];
+  const partnerColor = [128, 0, 128, 100];
+  const currentColor = [255, 237, 0, 180];
   const colorMap = {};
   Object.keys(tradeMapCore.pixelData).forEach(id => {
     colorMap[id] = bg;
   });
-  const ids = new Set();
   if (baronyId) {
-    ids.add(String(baronyId));
-    (tradeAdjacency[baronyId] || []).forEach(id => ids.add(String(id)));
+    (tradeAdjacency[baronyId] || []).forEach(id => {
+      colorMap[String(id)] = partnerColor;
+    });
   }
-  (routes || []).forEach(r => ids.add(String(r.id)));
-  ids.forEach(id => {
-    colorMap[id] = highlight;
+  (routes || []).forEach(r => {
+    colorMap[String(r.id)] = partnerColor;
   });
+  if (baronyId) {
+    colorMap[String(baronyId)] = currentColor;
+  }
   tradeMapCore.setColorMap(colorMap);
 }
 

--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -1,4 +1,6 @@
 (function (global) {
+  const terrainColor = [239, 228, 176];
+
   /**
    * Initialise le rendu de la carte.
    * @param {Object} [opts] Options de configuration.
@@ -304,5 +306,5 @@
       get ready() { return ready; }
     };
   }
-  global.mapCore = { init };
+  global.mapCore = { init, terrainColor };
 })(typeof window !== 'undefined' ? window : global);

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -1,7 +1,7 @@
 (function (global) {
   function init(core, data, options = {}) {
     const updateLegend = options.updateLegend || (() => {});
-    const terrainColor = [239, 228, 176];
+    const terrainColor = mapCore.terrainColor;
     const playerSeigneurColor = [82, 190, 128];
     const playerBishopColor = [46, 134, 193];
     const npcSeigneurColor = [231, 76, 60];

--- a/viewer.js
+++ b/viewer.js
@@ -5,7 +5,7 @@
 
   let mapWidth = 0;
   let mapHeight = 0;
-  const terrainColor = [239, 228, 176];
+  const terrainColor = mapCore.terrainColor;
   const playerColor = [82, 190, 128];
   const npcColor = [231, 76, 60];
 


### PR DESCRIPTION
## Summary
- Recenter trade map when commerce tab activates to prevent hidden map
- Share terrain color constant via mapCore and apply consistent transparency
- Highlight selected barony in yellow-orange and use background color for inaccessible areas

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a88d2a2de8832da8a9598d8e10d5b9