### PR TITLE
Add trade route creation and improve trade map layout

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -40,6 +40,9 @@
         <div id="tab-ost" class="tab-panel"></div>
         <div id="tab-commerce" class="tab-panel">
           <h2>Chemins commerciaux</h2>
+          <div class="trade-controls" style="margin-bottom:10px">
+            <button id="newTradeRouteBtn" class="control-btn">Nouvelle route</button>
+          </div>
           <div id="tradeSection" class="trade-section">
             <div id="tradeMap" class="trade-map">
               <img id="tradeBaseMap" src="Asgaria.png" alt="Carte" />
@@ -75,8 +78,10 @@
 
       function refreshTradeMap() {
         if (window.tradeMapCore) {
-          window.tradeMapCore.fitToContainer();
-          window.tradeMapCore.drawAll();
+          requestAnimationFrame(() => {
+            window.tradeMapCore.resetView();
+            window.tradeMapCore.drawAll();
+          });
         }
       }
 

--- a/gestion.js
+++ b/gestion.js
@@ -68,7 +68,7 @@ function showConfirm(message){
     const msgEl = document.getElementById('confirmMessage');
     const okBtn = document.getElementById('confirmOk');
     const cancelBtn = document.getElementById('confirmCancel');
-    msgEl.textContent = message;
+    msgEl.innerHTML = message;
     const clean = result => {
       okBtn.removeEventListener('click', onOk);
       cancelBtn.removeEventListener('click', onCancel);
@@ -134,6 +134,8 @@ async function init() {
   const sid = params.get('seigneurie_id');
   await loadAndRender(sid);
   await setupAdminSelector(sid);
+  const newRouteBtn = document.getElementById('newTradeRouteBtn');
+  if (newRouteBtn) newRouteBtn.addEventListener('click', startTradeRouteCreation);
 }
 
 async function loadAndRender(seigneurieId) {
@@ -1889,6 +1891,12 @@ function showSpellResult(success, spell, amount, error, randomLuxury) {
 
 let tradeMapCore = null;
 let tradeAdjacency = {};
+let tradeBaronies = null;
+let seigneurNameMap = {};
+let newRouteMode = false;
+let eligibleTargets = {};
+let currentTradeBaronyId = null;
+let currentTradeRoutes = [];
 
 async function initTradeMap() {
   if (tradeMapCore) return;
@@ -1905,6 +1913,8 @@ async function initTradeMap() {
     canvas,
     enablePan: false,
     enableZoom: false,
+    staticMap: true,
+    onSelect: handleTradeMapSelect,
     fetchData: async () => {
       const [pixels, connections] = await Promise.all([
         fetch('/api/barony_pixels').then(r => r.json()),
@@ -1923,7 +1933,7 @@ async function initTradeMap() {
   await tradeMapCore.ready;
   const commerceTab = document.getElementById('tab-commerce');
   if (commerceTab && commerceTab.classList.contains('active')) {
-    tradeMapCore.fitToContainer();
+    tradeMapCore.resetView();
     tradeMapCore.drawAll();
   }
 }
@@ -1952,6 +1962,98 @@ async function updateTradeMap(baronyId, routes) {
   tradeMapCore.setColorMap(colorMap);
 }
 
+function computeDistances(start) {
+  const dist = { [start]: 0 };
+  const queue = [start];
+  while (queue.length) {
+    const cur = queue.shift();
+    (tradeAdjacency[cur] || []).forEach(n => {
+      if (dist[n] == null) {
+        dist[n] = dist[cur] + 1;
+        queue.push(n);
+      }
+    });
+  }
+  return dist;
+}
+
+async function startTradeRouteCreation() {
+  if (newRouteMode) {
+    newRouteMode = false;
+    eligibleTargets = {};
+    await updateTradeMap(currentTradeBaronyId, currentTradeRoutes);
+    return;
+  }
+  if (!currentTradeBaronyId) return;
+  if (!tradeBaronies) {
+    try {
+      const [barRes, seiRes] = await Promise.all([
+        fetch('/api/baronies'),
+        fetch('/api/seigneurs')
+      ]);
+      const barData = barRes.ok ? await barRes.json() : [];
+      const seigs = seiRes.ok ? await seiRes.json() : [];
+      seigneurNameMap = Object.fromEntries(seigs.map(s => [s.id, s.name]));
+      tradeBaronies = barData.map(b => ({
+        id: b.id,
+        name: b.name,
+        seigneur_id: b.seigneur_id,
+        seigneur_name: seigneurNameMap[b.seigneur_id]
+      }));
+    } catch {
+      return;
+    }
+  }
+  const dists = computeDistances(currentTradeBaronyId);
+  const existing = new Set(currentTradeRoutes.map(r => r.id));
+  eligibleTargets = {};
+  tradeBaronies.forEach(b => {
+    if (!b.seigneur_id) return;
+    if (b.id === currentTradeBaronyId) return;
+    if (existing.has(b.id)) return;
+    if (dists[b.id] == null) return;
+    eligibleTargets[b.id] = { ...b, distance: dists[b.id] };
+  });
+  if (!Object.keys(eligibleTargets).length) {
+    alert('Aucune baronnie disponible');
+    return;
+  }
+  newRouteMode = true;
+  const cm = { ...tradeMapCore.colorMap };
+  Object.keys(eligibleTargets).forEach(id => {
+    cm[id] = [0, 170, 255, 100];
+  });
+  tradeMapCore.setColorMap(cm);
+  tradeMapCore.currentSelectedId = null;
+}
+
+async function handleTradeMapSelect(id) {
+  if (!newRouteMode || !id || !eligibleTargets[id]) return;
+  const target = eligibleTargets[id];
+  const cost = target.distance * 3;
+  const msg = `Vous allez construire une route commerciale vers la baronnie de <strong>${target.name} (#${target.id})</strong> gérée par ${target.seigneur_name}<br><br>Cela vous coutera <strong>${cost} Or</strong>`;
+  const ok = await showConfirm(msg);
+  if (!ok) return;
+  try {
+    const res = await fetch('/api/trade_routes/build', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ barony_id: target.id })
+    });
+    if (res.ok) {
+      await renderTradeRoutes(currentTradeBaronyId);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || 'Construction impossible');
+    }
+  } catch {
+    alert('Construction impossible');
+  }
+  newRouteMode = false;
+  eligibleTargets = {};
+  await updateTradeMap(currentTradeBaronyId, currentTradeRoutes);
+}
+
 async function renderTradeRoutes(baronyId) {
   const container = document.getElementById('tradeRoutes');
   if (!container) return;
@@ -1961,9 +2063,11 @@ async function renderTradeRoutes(baronyId) {
     await updateTradeMap(null, []);
     return;
   }
+  currentTradeBaronyId = baronyId;
   try {
     const res = await fetch(`/api/trade_partners?barony_id=${baronyId}`);
     const routes = res.ok ? await res.json() : [];
+    currentTradeRoutes = routes;
     await updateTradeMap(baronyId, routes);
     if (!routes.length) {
       container.textContent = 'Aucune route commerciale';

--- a/server.js
+++ b/server.js
@@ -2251,6 +2251,58 @@ app.delete('/api/trade_routes', requireAdmin, (req,res)=>{
   });
 });
 
+app.post('/api/trade_routes/build', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const targetId = parseInt(req.body.barony_id, 10);
+  if (!targetId) return res.status(400).json({ error: 'ID invalide' });
+  getSeigneurie(req, 'seigneuries.id as id, seigneuries.baronnie_id, seigneuries.inventaire_id', (err, srow) => {
+    if (err) return handleError(res, err);
+    if (!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const startId = srow.baronnie_id;
+    if (startId === targetId) return res.status(400).json({ error: 'Baronnie identique' });
+    db.get('SELECT seigneur_id, name FROM baronies WHERE id=?', [targetId], (err2, brow) => {
+      if (err2) return handleError(res, err2);
+      if (!brow || !brow.seigneur_id) return res.status(400).json({ error: 'Baronnie invalide' });
+      const [id1, id2] = startId < targetId ? [startId, targetId] : [targetId, startId];
+      db.get('SELECT 1 FROM trade_routes WHERE barony_id_1=? AND barony_id_2=?', [id1, id2], (err3, ex) => {
+        if (err3) return handleError(res, err3);
+        if (ex) return res.status(400).json({ error: 'Route existante' });
+        db.all('SELECT barony_id_1, barony_id_2 FROM barony_connections', [], (err4, rows) => {
+          if (err4) return handleError(res, err4);
+          const adj = {};
+          rows.forEach(r => {
+            (adj[r.barony_id_1] = adj[r.barony_id_1] || []).push(r.barony_id_2);
+            (adj[r.barony_id_2] = adj[r.barony_id_2] || []).push(r.barony_id_1);
+          });
+          const queue = [[startId, 0]];
+          const visited = new Set([startId]);
+          let dist = null;
+          while (queue.length) {
+            const [cur, d] = queue.shift();
+            if (cur === targetId) { dist = d; break; }
+            (adj[cur] || []).forEach(n => {
+              if (!visited.has(n)) { visited.add(n); queue.push([n, d + 1]); }
+            });
+          }
+          if (dist == null) return res.status(400).json({ error: 'Inaccessible' });
+          const cost = dist * 3;
+          db.get('SELECT or_ FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inv) => {
+            if (err5) return handleError(res, err5);
+            if (!inv || (inv.or_ || 0) < cost) return res.status(400).json({ error: 'Ressources insuffisantes' });
+            consumeResources(db, srow.id, { or_: cost }, err6 => {
+              if (err6) return handleError(res, err6);
+              db.run('INSERT OR IGNORE INTO trade_routes (barony_id_1, barony_id_2) VALUES (?,?)', [id1, id2], function(err7){
+                if (err7) return handleError(res, err7);
+                res.json({ added: this.changes, cost, distance: dist });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
 // Maritime zones CRUD
 const maritimeZoneFields = ['name'];
 app.get('/api/maritime_zones', (req,res)=>{ list('maritime_zones')(req,res); });

--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -26,7 +26,8 @@
       fetchData = async () => ({}),
       onSelect = () => {},
       drawOverlay = () => {},
-      mapMode = 'land'
+      mapMode = 'land',
+      staticMap = false
     } = opts;
 
     const canvas = passedCanvas || document.getElementById(mapId);
@@ -80,6 +81,13 @@
 
     function applyTransform() {
       group.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+    }
+
+    function resetView() {
+      scale = 1;
+      offsetX = 0;
+      offsetY = 0;
+      applyTransform();
     }
 
     function centerMap() {
@@ -230,7 +238,7 @@
     }
 
 
-    const positionMap = (!enablePan && !enableZoom) ? centerMap : fitToContainer;
+    const positionMap = staticMap ? resetView : (!enablePan && !enableZoom) ? centerMap : fitToContainer;
 
     if (enableZoom) {
       canvas.addEventListener('wheel', handleWheel, { passive: false });
@@ -282,6 +290,7 @@
       selectBarony,
       drawAll,
       fitToContainer,
+      resetView,
       drawPixel: (x, y, id) => {
         if (!colorMap[id]) {
           colorMap[id] = generateColor(id);

--- a/styles.css
+++ b/styles.css
@@ -575,7 +575,7 @@ th.multi-col {
 }
 
 .trade-map {
-  flex: 1;
+  flex: 2;
   position: relative;
   aspect-ratio: 4 / 3;
 }


### PR DESCRIPTION
## Summary
- enlarge trade map view and add static map support
- allow players to create new trade routes with server-side validation
- highlight available baronies and confirm cost before building routes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a893f47b3c832d9c8c923ba7ad7b0b