### PR TITLE
Fix trade map barony selection

### DIFF
--- a/src/mapCore.js
+++ b/src/mapCore.js
@@ -231,8 +231,8 @@
 
     function handleCanvasClick(e) {
       const rect = canvas.getBoundingClientRect();
-      const x = Math.floor((e.clientX - rect.left) / scale);
-      const y = Math.floor((e.clientY - rect.top) / scale);
+      const x = Math.floor((e.clientX - rect.left) * canvas.width / rect.width);
+      const y = Math.floor((e.clientY - rect.top) * canvas.height / rect.height);
       const id = pixelMap[y] ? pixelMap[y][x] : null;
       selectBarony(id);
     }


### PR DESCRIPTION
## Summary
- correct canvas click coordinate mapping so barony selection aligns with display in commerce tab

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f6d50b84832d969b78c71f61c868