### PR TITLE
feat: add user notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@
 Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs interfaces web pour le projet Asgaria (visualisation de la carte, édition, gestion et administration).
 
 ## Scripts et relations principales
-- **server.js** : point d'entrée du serveur. Expose l'API REST, gère l'authentification, les transactions et les effets. Requiert `handleError.js`, `logger.js`, `effects.js`, `transactions.js` et `services/buildingService.js`.
+- **server.js** : point d'entrée du serveur. Expose l'API REST, gère l'authentification, les transactions et les effets. Requiert `handleError.js`, `logger.js`, `effects.js`, `transactions.js`, `services/buildingService.js` et `services/notificationService.js`.
 - **effects.js** : définit les classes d'effets appliquées par le serveur (production, stockage, sorts, etc.).
 - **transactions.js** : applique les débits/crédits de ressources dans la base de données.
 - **services/buildingService.js** : utilitaires pour consommer les ressources lors des constructions.
+- **services/notificationService.js** : utilitaire pour envoyer des notifications aux utilisateurs.
 - **auth.js** : script inclus sur les pages client pour la connexion, la déconnexion et la navigation conditionnelle.
 - **viewer.js** : affiche la carte en lecture seule.
 - **script.js** : éditeur de carte permettant de modifier les baronnies et d'enregistrer les pixels.

--- a/auth.js
+++ b/auth.js
@@ -42,6 +42,52 @@ document.addEventListener('DOMContentLoaded', async () => {
       location.reload();
     });
     authArea.appendChild(logoutBtn);
+
+    const notifBtn = document.createElement('button');
+    notifBtn.className = 'icon-btn bell-btn';
+    notifBtn.innerHTML = `
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
+      <span class="badge" style="display:none"></span>`;
+    authArea.appendChild(notifBtn);
+
+    const panel = document.createElement('div');
+    panel.id = 'notificationPanel';
+    panel.className = 'notif-panel';
+    document.body.appendChild(panel);
+    const badge = notifBtn.querySelector('.badge');
+
+    notifBtn.addEventListener('click', () => {
+      panel.style.display = panel.style.display === 'block' ? 'none' : 'block';
+    });
+
+    async function loadNotifications() {
+      try {
+        const res = await fetch('/api/notifications');
+        const items = await res.json();
+        panel.innerHTML = '';
+        let unread = 0;
+        items.forEach(n => {
+          const div = document.createElement('div');
+          div.className = 'notification' + (n.is_read ? '' : ' unread');
+          div.textContent = n.message;
+          div.addEventListener('click', async () => {
+            if (!n.is_read) {
+              await fetch(`/api/notifications/${n.id}/read`, { method: 'POST' });
+            }
+            panel.style.display = 'none';
+            if (n.link) location.href = n.link;
+          });
+          panel.appendChild(div);
+          if (!n.is_read) unread++;
+        });
+        if (badge) {
+          badge.textContent = unread;
+          badge.style.display = unread ? 'block' : 'none';
+        }
+      } catch {}
+    }
+
+    loadNotifications();
   }
 
   const navButtons = [];

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const luxuryResources = ['fourrure','ivoire','soie','huile','teinture','epices',
 const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
+const { sendNotification } = require('./services/notificationService');
 const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
@@ -19,7 +20,7 @@ const VALID_TABLES = new Set([
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
   'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
   'building_properties','infrastructure_properties','barony_connections','trade_routes','tags','spells',
-  'sanctuaries','maritime_zones','maritime_zone_pixels','maritime_zone_connections','maritime_zone_baronies'
+  'sanctuaries','maritime_zones','maritime_zone_pixels','maritime_zone_connections','maritime_zone_baronies','notifications'
 ]);
 
 // create tables if they do not exist
@@ -302,6 +303,15 @@ CREATE TABLE IF NOT EXISTS spells (
 CREATE TABLE IF NOT EXISTS tags (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   label TEXT UNIQUE
+);
+CREATE TABLE IF NOT EXISTS notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  message TEXT NOT NULL,
+  link TEXT,
+  is_read INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(user_id) REFERENCES users(id)
 );
 `;
 
@@ -601,6 +611,7 @@ app.post('/api/register', async (req, res) => {
           last_name,
           is_admin: 0
         };
+        sendNotification(db, this.lastID, 'Bienvenue sur Asgaria !', '/profile.html');
         res.json({ ok: true });
       }
     );
@@ -658,6 +669,23 @@ app.get('/api/me', (req, res) => {
   } catch (error) {
     handleError(res, error);
   }
+});
+
+app.get('/api/notifications', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  db.all('SELECT id, message, link, is_read, created_at FROM notifications WHERE user_id=? ORDER BY created_at DESC', [req.session.user.id], (err, rows) => {
+    if (err) return handleError(res, err);
+    res.json(rows);
+  });
+});
+
+app.post('/api/notifications/:id/read', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const id = parseInt(req.params.id, 10);
+  db.run('UPDATE notifications SET is_read=1 WHERE id=? AND user_id=?', [id, req.session.user.id], function(err){
+    if (err) return handleError(res, err);
+    res.json({ changes: this.changes });
+  });
 });
 
 app.post('/api/admin_mode', (req,res) => {

--- a/services/notificationService.js
+++ b/services/notificationService.js
@@ -1,0 +1,8 @@
+const sendNotification = (db, userIds, message, link = null, cb = () => {}) => {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  const stmt = db.prepare('INSERT INTO notifications(user_id,message,link) VALUES (?,?,?)');
+  ids.forEach(id => stmt.run(id, message, link));
+  stmt.finalize(cb);
+};
+
+module.exports = { sendNotification };

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,52 @@ main {
   color: white;
 }
 
+.bell-btn {
+  position: relative;
+}
+
+.bell-btn .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #e53935;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 10px;
+}
+
+.notif-panel {
+  position: absolute;
+  top: 60px;
+  right: 10px;
+  background: white;
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  display: none;
+  z-index: 1000;
+}
+
+.notification {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.notification.unread {
+  background: #eef3ff;
+  font-weight: bold;
+}
+
+.notification:hover {
+  background: #f5f5f5;
+}
+
 #authDialog form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- introduce notification service for sending messages to one or many users
- add notifications table and API endpoints
- display modern bell UI with unread badge and links

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a91e64f8e0832d8ee3f42cc575e77b