### PR TITLE
Improve notification panel layout and add timestamps

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -99,6 +99,8 @@
       </div>
     </div>
   </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
   <script src="auth.js"></script>
   <script src="admin.js"></script>
 </body>

--- a/auth.js
+++ b/auth.js
@@ -54,6 +54,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     panel.id = 'notificationPanel';
     panel.className = 'notif-panel';
     document.body.appendChild(panel);
+
+    const header = document.querySelector('.app-header');
+    function adjustPanel() {
+      const headerHeight = header ? header.offsetHeight : 0;
+      panel.style.top = headerHeight + 'px';
+      panel.style.maxHeight = `calc(100vh - ${headerHeight}px)`;
+      panel.style.right = '0';
+    }
+    adjustPanel();
+    window.addEventListener('resize', adjustPanel);
+
     const badge = notifBtn.querySelector('.badge');
 
     notifBtn.addEventListener('click', () => {
@@ -69,7 +80,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         items.forEach(n => {
           const div = document.createElement('div');
           div.className = 'notification' + (n.is_read ? '' : ' unread');
-          div.textContent = n.message;
+
+          const msgSpan = document.createElement('span');
+          msgSpan.textContent = n.message;
+          div.appendChild(msgSpan);
+
+          const timeEl = document.createElement('time');
+          timeEl.dateTime = n.created_at;
+          timeEl.title = new Date(n.created_at).toLocaleString('fr-FR');
+          timeEl.textContent = timeago.format(n.created_at, 'fr');
+          div.appendChild(timeEl);
+
           div.addEventListener('click', async () => {
             if (!n.is_read) {
               await fetch(`/api/notifications/${n.id}/read`, { method: 'POST' });

--- a/gestion.html
+++ b/gestion.html
@@ -68,6 +68,8 @@
       <button id="confirmOk" class="control-btn danger">Confirmer</button>
     </div>
   </dialog>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
   <script src="auth.js"></script>
   <script src="src/mapCore.js"></script>
   <script src="gestion.js"></script>

--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
   <script src="src/mapFilters.js"></script>
-  <script src="viewer.js"></script>
-  <dialog id="authDialog">
+    <script src="viewer.js"></script>
+    <dialog id="authDialog">
     <form id="loginForm" method="dialog">
       <h3>Connexion</h3>
       <input type="email" name="email" placeholder="Email" required>
@@ -69,7 +69,9 @@
       <button type="submit" class="control-btn">Créer</button>
       <p><a href="#" id="showLogin">Déjà un compte ?</a></p>
     </form>
-  </dialog>
-  <script src="auth.js"></script>
-</body>
+    </dialog>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
+    <script src="auth.js"></script>
+  </body>
 </html>

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -99,8 +99,10 @@
   <script>window.defaultEditMode = true;</script>
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
-  <script src="src/mapFilters.js"></script>
-  <script src="script.js"></script>
-  <script src="auth.js"></script>
-</body>
+    <script src="src/mapFilters.js"></script>
+    <script src="script.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
+    <script src="auth.js"></script>
+  </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -44,6 +44,8 @@
       <label><input type="checkbox" id="adminMode"> Mode administrateur</label>
     </div>
   </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
   <script src="auth.js"></script>
   <script src="profile.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -82,16 +82,16 @@ main {
 }
 
 .notif-panel {
-  position: absolute;
-  top: 60px;
-  right: 10px;
+  position: fixed;
+  top: 0;
+  right: 0;
   background: white;
   color: #333;
   border: 1px solid #ccc;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.15);
   width: 300px;
-  max-height: 400px;
+  min-height: 100px;
   overflow-y: auto;
   display: none;
   z-index: 1000;
@@ -110,6 +110,13 @@ main {
 
 .notification:hover {
   background: #f5f5f5;
+}
+
+.notification time {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #666;
 }
 
 #authDialog form {


### PR DESCRIPTION
## Summary
- Position notification panel flush right below navbar with min height and scrolling
- Display notification timestamps using French timeago with tooltip for exact time
- Load timeago.js on all pages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a92105c514832dbd54b931b56b9588