### PR TITLE
fix: ensure French timeago in notifications

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -7,6 +7,26 @@ async function getCurrentUser() {
   }
 }
 
+// Register French locale for timeago in case the CDN locale file fails to load
+if (typeof timeago !== 'undefined' && timeago.register) {
+  timeago.register('fr', (number, index) => [
+    ["à l'instant", 'dans un instant'],
+    ['il y a %s secondes', 'dans %s secondes'],
+    ['il y a 1 minute', 'dans 1 minute'],
+    ['il y a %s minutes', 'dans %s minutes'],
+    ['il y a 1 heure', 'dans 1 heure'],
+    ['il y a %s heures', 'dans %s heures'],
+    ['il y a 1 jour', 'dans 1 jour'],
+    ['il y a %s jours', 'dans %s jours'],
+    ['il y a 1 semaine', 'dans 1 semaine'],
+    ['il y a %s semaines', 'dans %s semaines'],
+    ['il y a 1 mois', 'dans 1 mois'],
+    ['il y a %s mois', 'dans %s mois'],
+    ['il y a 1 an', 'dans 1 an'],
+    ['il y a %s ans', 'dans %s ans']
+  ][index]);
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   const user = await getCurrentUser();
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- register French locale for timeago to show notification timestamps in French

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a922b24000832db2897324c20a14ec