### PR TITLE
feat: add trade transaction limits and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **handleError.js** et **logger.js** : gestion des erreurs et du logging.
 - Les pages HTML (`index.html`, `mapEditor.html`, `admin.html`, `gestion.html`, `profile.html`) chargent ces scripts selon leur rôle.
 - Les scripts client communiquent avec l'API du serveur via `fetch`.
+- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état) pour enregistrer les échanges entre seigneuries. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
 
 ## Instructions
 - Garder ce fichier à jour : toute modification importante de l'architecture, des dépendances ou des relations entre scripts doit être répercutée ici.

--- a/admin.js
+++ b/admin.js
@@ -650,6 +650,8 @@ function makeEffectsInput(val, allowedTypes){
       {id:'spell_advanced_discount', name:'Réduc. sort avancé'},
       {id:'spell_range', name:'Portée des sorts'},
       {id:'spell_max_per_month', name:'Sorts max/mois'},
+      {id:'land_transaction_max_per_month', name:'Transactions terrestres max/mois'},
+      {id:'naval_transaction_max_per_month', name:'Transactions navales max/mois'},
       {id:'variable_production', name:'Production ressource variable'},
       {id:'random_luxury', name:'Ressource de luxe aléatoire'}
     ];
@@ -789,7 +791,7 @@ function makeEffectsInput(val, allowedTypes){
         qty.placeholder = 'Quantité';
         qty.value = data.amount ?? '';
         return;
-      }else if(['idh','spell_success','spell_basic_discount','spell_advanced_discount','spell_range','spell_max_per_month'].includes(typeSel.value)){
+      }else if(['idh','spell_success','spell_basic_discount','spell_advanced_discount','spell_range','spell_max_per_month','land_transaction_max_per_month','naval_transaction_max_per_month'].includes(typeSel.value)){
         qty.style.display = '';
       }else if(typeSel.value === 'unlock_page'){
         pageSel.style.display = '';
@@ -876,7 +878,7 @@ function makeEffectsInput(val, allowedTypes){
         if(!isNaN(amt)){
           res.push({type, amount: amt});
         }
-      }else if(['idh','spell_success','spell_basic_discount','spell_advanced_discount','spell_range','spell_max_per_month'].includes(type)){
+      }else if(['idh','spell_success','spell_basic_discount','spell_advanced_discount','spell_range','spell_max_per_month','land_transaction_max_per_month','naval_transaction_max_per_month'].includes(type)){
         const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);
         if(type && !isNaN(amt)){
           res.push({ type, amount: amt });

--- a/effects.js
+++ b/effects.js
@@ -220,4 +220,28 @@ class SpellMaxPerMonthEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect };
+class LandTransactionMaxPerMonthEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.landTxMax = (ctx.landTxMax || 0) + total;
+    if (ctx.landTxMaxDetails) ctx.landTxMaxDetails.push({ label, amount: total, source: count });
+  }
+}
+
+class NavalTransactionMaxPerMonthEffect extends Effect {
+  constructor(amount) {
+    super();
+    this.amount = amount;
+  }
+  apply(ctx, count, label) {
+    const total = this.amount * count;
+    ctx.navalTxMax = (ctx.navalTxMax || 0) + total;
+    if (ctx.navalTxMaxDetails) ctx.navalTxMaxDetails.push({ label, amount: total, source: count });
+  }
+}
+
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect };

--- a/gestion.html
+++ b/gestion.html
@@ -40,6 +40,7 @@
         <div id="tab-ost" class="tab-panel"></div>
         <div id="tab-commerce" class="tab-panel">
           <h2>Chemins commerciaux</h2>
+          <div id="tradeInfo" style="margin-bottom:10px"></div>
           <div class="trade-controls" style="margin-bottom:10px">
             <button id="newTradeRouteBtn" class="control-btn">Nouvelle route</button>
           </div>
@@ -66,6 +67,14 @@
     <div class="dialog-buttons">
       <button id="confirmCancel" class="control-btn">Annuler</button>
       <button id="confirmOk" class="control-btn danger">Confirmer</button>
+    </div>
+  </dialog>
+  <dialog id="tradeDialog" class="confirm-dialog">
+    <div id="tradeList"></div>
+    <div style="margin-top:10px"><button id="tradeAddRow" class="control-btn">+</button></div>
+    <div class="dialog-buttons">
+      <button id="tradeCancel" class="control-btn">Annuler</button>
+      <button id="tradeSend" class="control-btn">Envoyer</button>
     </div>
   </dialog>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>

--- a/gestion.js
+++ b/gestion.js
@@ -244,12 +244,16 @@ async function loadAndRender(seigneurieId) {
     const spellRange = data.spellRange || 5;
     const spellMax = data.spellMax || 0;
     const spellsCast = data.spellsCast || 0;
+    const landTxMax = data.landTxMax || 0;
+    const navalTxMax = data.navalTxMax || 0;
+    const landTransactions = data.landTransactions || 0;
+    const navalTransactions = data.navalTransactions || 0;
     const spellSuccessDetails = data.spellSuccessDetails || [];
     const basicSpellDiscountDetails = data.basicSpellDiscountDetails || [];
     const advancedSpellDiscountDetails = data.advancedSpellDiscountDetails || [];
     const spellRangeDetails = data.spellRangeDetails || [];
     const spellMaxDetails = data.spellMaxDetails || [];
-    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails, productionDetails, spellSuccess, basicSpellDiscount, advancedSpellDiscount, spellRange, spellMax, spellsCast, spellSuccessDetails, basicSpellDiscountDetails, advancedSpellDiscountDetails, spellRangeDetails, spellMaxDetails, inv, capacities, isAdmin, baronyProps };
+    gameState = { s, employment, buildings, infrastructures, bpMap, ipMap, buildingBonuses, buildingBonusDetails, productionDetails, spellSuccess, basicSpellDiscount, advancedSpellDiscount, spellRange, spellMax, spellsCast, landTxMax, navalTxMax, landTransactions, navalTransactions, spellSuccessDetails, basicSpellDiscountDetails, advancedSpellDiscountDetails, spellRangeDetails, spellMaxDetails, inv, capacities, isAdmin, baronyProps };
 
     await renderTradeRoutes(barony.id);
 
@@ -2089,6 +2093,11 @@ async function renderTradeRoutes(baronyId) {
   }
   currentTradeBaronyId = baronyId;
   try {
+    const info = document.getElementById('tradeInfo');
+    if (info) {
+      const { landTransactions = 0, landTxMax = 0 } = gameState;
+      info.textContent = `Transactions terrestres: ${landTransactions} / ${landTxMax}`;
+    }
     const res = await fetch(`/api/trade_partners?barony_id=${baronyId}`);
     const routes = res.ok ? await res.json() : [];
     currentTradeRoutes = routes;
@@ -2097,11 +2106,98 @@ async function renderTradeRoutes(baronyId) {
       container.textContent = 'Aucune route commerciale';
       return;
     }
-    const rows = routes.map(r => `<tr><td>${r.id}</td><td>${r.name || ''}</td><td>${r.seigneur_name || ''}</td><td>${r.duchy_name || ''}</td></tr>`).join('');
-    container.innerHTML = `<table class="admin-table"><tr><th>#</th><th>Nom</th><th>Propriétaire</th><th>Province (Duché)</th></tr>${rows}</table>`;
+    const rows = routes.map(r => `<tr><td>${r.id}</td><td>${r.name || ''}</td><td>${r.seigneur_name || ''}</td><td>${r.duchy_name || ''}</td><td><button class="trade-btn" data-id="${r.id}">Commercer</button></td></tr>`).join('');
+    container.innerHTML = `<table class="admin-table"><tr><th>#</th><th>Nom</th><th>Propriétaire</th><th>Province (Duché)</th><th></th></tr>${rows}</table>`;
+    container.querySelectorAll('.trade-btn').forEach(btn => {
+      btn.addEventListener('click', () => openTradeDialog(btn.dataset.id));
+    });
   } catch {
     container.textContent = 'Erreur de chargement';
     await updateTradeMap(baronyId, []);
+  }
+}
+
+async function openTradeDialog(baronyId) {
+  const resources = await showTradeDialog();
+  if (!resources) return;
+  await sendTransaction(baronyId, resources);
+}
+
+function showTradeDialog() {
+  return new Promise(resolve => {
+    const dialog = document.getElementById('tradeDialog');
+    const list = document.getElementById('tradeList');
+    const addBtn = document.getElementById('tradeAddRow');
+    const cancelBtn = document.getElementById('tradeCancel');
+    const sendBtn = document.getElementById('tradeSend');
+    list.innerHTML = '';
+    function addRow() {
+      const row = document.createElement('div');
+      const sel = document.createElement('select');
+      const blank = document.createElement('option');
+      blank.value = '';
+      sel.appendChild(blank);
+      resourceSelect.forEach(o => {
+        const op = document.createElement('option');
+        op.value = o.id;
+        op.textContent = o.name;
+        sel.appendChild(op);
+      });
+      const qty = document.createElement('input');
+      qty.type = 'number';
+      qty.min = '0';
+      sel.addEventListener('change', () => {
+        const max = gameState.inv[sel.value] || 0;
+        qty.max = String(max);
+        if (parseInt(qty.value, 10) > max) qty.value = max;
+      });
+      row.appendChild(sel);
+      row.appendChild(qty);
+      list.appendChild(row);
+      sel.dispatchEvent(new Event('change'));
+    }
+    addRow();
+    addBtn.onclick = () => addRow();
+    cancelBtn.onclick = () => { dialog.close(); resolve(null); };
+    sendBtn.onclick = () => {
+      const res = {};
+      let valid = true;
+      list.querySelectorAll('div').forEach(r => {
+        const sel = r.querySelector('select');
+        const inp = r.querySelector('input');
+        const key = sel.value;
+        const val = parseInt(inp.value, 10) || 0;
+        if (key && val > 0) {
+          if (val > (gameState.inv[key] || 0)) valid = false;
+          else res[key] = val;
+        }
+      });
+      if (!valid || !Object.keys(res).length) {
+        alert('Quantités invalides');
+        return;
+      }
+      dialog.close();
+      resolve(res);
+    };
+    dialog.showModal();
+  });
+}
+
+async function sendTransaction(baronyId, resources) {
+  try {
+    const res = await fetch('/api/send_transaction', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_barony_id: baronyId, resources, type: 'land' })
+    });
+    if (res.ok) {
+      await loadAndRender(currentSeigneurieId);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || 'Transaction impossible');
+    }
+  } catch {
+    alert('Transaction impossible');
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -11,14 +11,14 @@ const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
 const { sendNotification } = require('./services/notificationService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
 const VALID_TABLES = new Set([
   'users','religions','cultures','seigneurs','empires','kingdoms','archduchies',
   'duchies','marquisates','counties','viscounties','baronies','barony_pixels',
-  'canonical_lands','inventaire','seigneuries','transactions','barony_properties',
+  'canonical_lands','inventaire','seigneuries','transactions','trade_transactions','barony_properties',
   'building_properties','infrastructure_properties','barony_connections','trade_routes','tags','spells',
   'sanctuaries','maritime_zones','maritime_zone_pixels','maritime_zone_connections','maritime_zone_baronies','notifications'
 ]);
@@ -227,6 +227,10 @@ CREATE TABLE IF NOT EXISTS seigneuries (
   infrastructures TEXT DEFAULT '{}',
   spells_cast INTEGER DEFAULT 0,
   spell_month TEXT,
+  land_transactions INTEGER DEFAULT 0,
+  land_transaction_month TEXT,
+  naval_transactions INTEGER DEFAULT 0,
+  naval_transaction_month TEXT,
   FOREIGN KEY(baronnie_id) REFERENCES baronies(id),
   FOREIGN KEY(seigneur_id) REFERENCES seigneurs(id),
   FOREIGN KEY(inventaire_id) REFERENCES inventaire(id)
@@ -238,6 +242,17 @@ CREATE TABLE IF NOT EXISTS transactions (
   amount INTEGER,
   created_at TEXT DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY(seigneurie_id) REFERENCES seigneuries(id)
+);
+CREATE TABLE IF NOT EXISTS trade_transactions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  origin_id INTEGER,
+  destination_id INTEGER,
+  resources TEXT,
+  type TEXT,
+  state TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(origin_id) REFERENCES seigneuries(id),
+  FOREIGN KEY(destination_id) REFERENCES seigneuries(id)
 );
 CREATE TABLE IF NOT EXISTS barony_properties (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -351,6 +366,18 @@ db.exec(initSql, () => {
       }
       if (!rows.some(r => r.name === 'spell_month')) {
         db.run("ALTER TABLE seigneuries ADD COLUMN spell_month TEXT");
+      }
+      if (!rows.some(r => r.name === 'land_transactions')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN land_transactions INTEGER DEFAULT 0");
+      }
+      if (!rows.some(r => r.name === 'land_transaction_month')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN land_transaction_month TEXT");
+      }
+      if (!rows.some(r => r.name === 'naval_transactions')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN naval_transactions INTEGER DEFAULT 0");
+      }
+      if (!rows.some(r => r.name === 'naval_transaction_month')) {
+        db.run("ALTER TABLE seigneuries ADD COLUMN naval_transaction_month TEXT");
       }
     }
   });
@@ -879,6 +906,12 @@ app.get('/api/my_seigneurie', (req, res) => {
             const currentMonth = new Date().toISOString().slice(0,7);
             let spellsCast = s.spells_cast || 0;
             if (s.spell_month !== currentMonth) spellsCast = 0;
+            let landTransactions = s.land_transactions || 0;
+            let landMonth = s.land_transaction_month;
+            if (landMonth !== currentMonth) landTransactions = 0;
+            let navalTransactions = s.naval_transactions || 0;
+            let navalMonth = s.naval_transaction_month;
+            if (navalMonth !== currentMonth) navalTransactions = 0;
             const buildingProductionBonus = {};
             const buildingProductionBonusDetails = {};
             const effectCtx = {
@@ -899,11 +932,15 @@ app.get('/api/my_seigneurie', (req, res) => {
               advancedSpellDiscount: 0,
               spellRangeBonus: 0,
               spellMax: 0,
+              landTxMax: 0,
+              navalTxMax: 0,
               spellSuccessDetails: [{ label: 'Base', amount: 75, source: 1 }],
               basicSpellDiscountDetails: [{ label: 'Base', amount: 0, source: 1 }],
               advancedSpellDiscountDetails: [{ label: 'Base', amount: 0, source: 1 }],
               spellRangeDetails: [{ label: 'Base', amount: 5, source: 1 }],
-              spellMaxDetails: [{ label: 'Base', amount: 0, source: 1 }]
+              spellMaxDetails: [{ label: 'Base', amount: 0, source: 1 }],
+              landTxMaxDetails: [{ label: 'Base', amount: 0, source: 1 }],
+              navalTxMaxDetails: [{ label: 'Base', amount: 0, source: 1 }]
             };
             for (const ip of infraList) {
               effectCtx.currentInfraId = ip.id;
@@ -951,6 +988,12 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                 } else if (def.type === 'spell_max_per_month') {
                   effObj = new SpellMaxPerMonthEffect(def.amount || 0);
+                  if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                } else if (def.type === 'land_transaction_max_per_month') {
+                  effObj = new LandTransactionMaxPerMonthEffect(def.amount || 0);
+                  if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                } else if (def.type === 'naval_transaction_max_per_month') {
+                  effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
                   if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                 } else if (def.type === 'variable_workers') {
                   const max = (def.max_workers || 0) * count;
@@ -1053,6 +1096,8 @@ app.get('/api/my_seigneurie', (req, res) => {
               const advancedSpellDiscount = effectCtx.advancedSpellDiscount || 0;
               const spellRange = 5 + (effectCtx.spellRangeBonus || 0);
               const spellMax = effectCtx.spellMax || 0;
+              const landTxMax = effectCtx.landTxMax || 0;
+              const navalTxMax = effectCtx.navalTxMax || 0;
               res.json({
                 seigneur: seig,
                 seigneurie: s,
@@ -1077,12 +1122,18 @@ app.get('/api/my_seigneurie', (req, res) => {
                 advancedSpellDiscount,
                 spellRange,
                 spellMax,
+                landTxMax,
+                navalTxMax,
+                landTransactions,
+                navalTransactions,
                 spellsCast,
                 spellSuccessDetails: effectCtx.spellSuccessDetails || [],
                 basicSpellDiscountDetails: effectCtx.basicSpellDiscountDetails || [],
                 advancedSpellDiscountDetails: effectCtx.advancedSpellDiscountDetails || [],
                 spellRangeDetails: effectCtx.spellRangeDetails || [],
-                spellMaxDetails: effectCtx.spellMaxDetails || []
+                spellMaxDetails: effectCtx.spellMaxDetails || [],
+                landTxMaxDetails: effectCtx.landTxMaxDetails || [],
+                navalTxMaxDetails: effectCtx.navalTxMaxDetails || []
               });
             }
             if (s.baronnie_id) {
@@ -1114,6 +1165,10 @@ app.get('/api/my_seigneurie', (req, res) => {
                     effObj = new SpellRangeEffect(def.amount || 0);
                   } else if (def.type === 'spell_max_per_month') {
                     effObj = new SpellMaxPerMonthEffect(def.amount || 0);
+                  } else if (def.type === 'land_transaction_max_per_month') {
+                    effObj = new LandTransactionMaxPerMonthEffect(def.amount || 0);
+                  } else if (def.type === 'naval_transaction_max_per_month') {
+                    effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
                   }
                   if (effObj) {
                     effObj.apply(effectCtx, 1, 'Baronnie');
@@ -2245,6 +2300,100 @@ app.delete('/api/barony_connections', requireAdmin, (req,res)=>{
   db.run('DELETE FROM barony_connections WHERE barony_id_1=? AND barony_id_2=?',[id1,id2],function(err){
     if(err) return handleError(res, err);
     res.json({deleted: this.changes});
+  });
+});
+
+app.post('/api/send_transaction', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const targetBaronyId = parseInt(req.body.target_barony_id, 10);
+  const resources = req.body.resources || {};
+  const txType = req.body.type === 'naval' ? 'naval' : 'land';
+  if (!targetBaronyId || typeof resources !== 'object') return res.status(400).json({ error: 'Données invalides' });
+  getSeigneurie(req, 'seigneuries.id, seigneuries.baronnie_id, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.land_transactions, seigneuries.land_transaction_month, seigneuries.naval_transactions, seigneuries.naval_transaction_month', (err, srow) => {
+    if (err) return handleError(res, err);
+    if (!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const seigneurieId = srow.id;
+    const infrastructures = safeParse(srow.infrastructures, {});
+    const currentMonth = new Date().toISOString().slice(0,7);
+    let count = txType === 'naval' ? (srow.naval_transactions || 0) : (srow.land_transactions || 0);
+    let month = txType === 'naval' ? srow.naval_transaction_month : srow.land_transaction_month;
+    if (month !== currentMonth) { count = 0; month = currentMonth; }
+    db.all('SELECT id, label, effects FROM infrastructure_properties', [], (err2, iprops) => {
+      if (err2) return handleError(res, err2);
+      const effectCtx = { landTxMax:0, navalTxMax:0 };
+      (iprops || []).forEach(ip => {
+        const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
+        const c = typeof entry === 'object' ? (entry.built || 0) : entry;
+        if (!c) return;
+        const effs = safeParse(ip.effects, []);
+        effs.forEach(def => {
+          let effObj = null;
+          if (def.type === 'land_transaction_max_per_month') {
+            effObj = new LandTransactionMaxPerMonthEffect(def.amount || 0);
+          } else if (def.type === 'naval_transaction_max_per_month') {
+            effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
+          }
+          if (effObj) effObj.apply(effectCtx, c, ip.label || ip.type);
+        });
+      });
+      const applyBarony = cb => {
+        if (!srow.baronnie_id) return cb();
+        db.get('SELECT effects FROM barony_properties WHERE barony_id=?', [srow.baronnie_id], (err3, bprops) => {
+          if (err3) return handleError(res, err3);
+          const beffs = safeParse(bprops && bprops.effects, []);
+          beffs.forEach(def => {
+            let effObj = null;
+            if (def.type === 'land_transaction_max_per_month') {
+              effObj = new LandTransactionMaxPerMonthEffect(def.amount || 0);
+            } else if (def.type === 'naval_transaction_max_per_month') {
+              effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
+            }
+            if (effObj) effObj.apply(effectCtx, 1, 'Baronnie');
+          });
+          cb();
+        });
+      };
+      applyBarony(() => {
+        const max = txType === 'naval' ? effectCtx.navalTxMax : effectCtx.landTxMax;
+        if (max && count >= max) return res.status(400).json({ error: 'Limite de transactions atteinte' });
+        db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err4, inv) => {
+          if (err4) return handleError(res, err4);
+          for (const [r, a] of Object.entries(resources)) {
+            const amt = parseInt(a, 10);
+            if (!inventaireFields.includes(r) || amt <= 0 || inv[r] < amt) {
+              return res.status(400).json({ error: 'Ressources insuffisantes' });
+            }
+          }
+          db.get('SELECT id FROM seigneuries WHERE baronnie_id=?', [targetBaronyId], (err5, dest) => {
+            if (err5) return handleError(res, err5);
+            if (!dest) return res.status(400).json({ error: 'Destination invalide' });
+            const entries = Object.entries(resources);
+            let idx = 0;
+            function next() {
+              if (idx >= entries.length) return finish();
+              const [resName, amount] = entries[idx++];
+              performTransaction(db, seigneurieId, resName, -amount, err6 => {
+                if (err6) return handleError(res, err6);
+                next();
+              });
+            }
+            function finish() {
+              const newCount = count + 1;
+              const field = txType === 'naval' ? 'naval_transactions' : 'land_transactions';
+              const monthField = txType === 'naval' ? 'naval_transaction_month' : 'land_transaction_month';
+              db.run(`UPDATE seigneuries SET ${field}=?, ${monthField}=? WHERE id=?`, [newCount, month, seigneurieId], err7 => {
+                if (err7) return handleError(res, err7);
+                db.run('INSERT INTO trade_transactions (origin_id, destination_id, resources, type, state) VALUES (?,?,?,?,?)', [seigneurieId, dest.id, JSON.stringify(resources), txType, 'En Attente'], err8 => {
+                  if (err8) return handleError(res, err8);
+                  res.json({ ok: true });
+                });
+              });
+            }
+            next();
+          });
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add land and naval transaction limit effects
- enable commerce UI to send resources to trade partners
- track resource trades in new trade_transactions table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af423435bc832d9d66f1a6febf60ae