### PR TITLE
Add tag-based building limits and commercial infrastructures

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -80,7 +80,7 @@ const infraPropLabels = {
   tags:'Tags',
   description:'Description',
 };
-const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'}];
+const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'},{id:'commercial',name:'Commercial'}];
 const resourceSelect = Object.entries(inventaireLabels).map(([id, name]) => ({ id, name }));
 const pageSelect = [{id:'magie', name:'Magie'}];
 let buildingPropsSelect = [];
@@ -90,7 +90,8 @@ const dataCache = {};
 const tabLoaded = {};
 const maxOptions = [
   ...Array.from({length:10}, (_,i)=>({ id:String(i+1), name:String(i+1) })),
-  ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f }))
+  ...baronyPropIntFields.map(f=>({ id:f, name:baronyPropLabels[f] || f })),
+  { id:'tag', name:'Par tag' }
 ];
 
 const spellFields = ['label','type','costs','effects','description'];
@@ -1079,6 +1080,65 @@ function renderTable(container, rows, opts){
     if(field === 'effects'){
       return makeEffectsInput(val, opts && opts.allowedEffectTypes);
     }
+    if(field === 'max'){
+      let isTag = false, tag = '', per = '';
+      try {
+        const obj = JSON.parse(val || '');
+        if (obj && obj.tag) {
+          isTag = true;
+          tag = obj.tag || obj.tag_id || '';
+          per = obj.per || obj.value || '';
+        }
+      } catch {}
+      const container = document.createElement('div');
+      const sel = document.createElement('select');
+      const blank = document.createElement('option');
+      blank.value = '';
+      sel.appendChild(blank);
+      maxOptions.forEach(o=>{
+        const op = document.createElement('option');
+        op.value = o.id;
+        op.textContent = o.name;
+        if(!isTag && String(o.id) === String(val)) op.selected = true;
+        sel.appendChild(op);
+      });
+      const tagSel = document.createElement('select');
+      const tagBlank = document.createElement('option');
+      tagBlank.value = '';
+      tagSel.appendChild(tagBlank);
+      tagsSelect.forEach(o=>{
+        const op = document.createElement('option');
+        op.value = o.id;
+        op.textContent = o.name;
+        if(String(o.id) === String(tag)) op.selected = true;
+        tagSel.appendChild(op);
+      });
+      const qty = document.createElement('input');
+      qty.type = 'number';
+      qty.min = '0';
+      qty.style.width = '6em';
+      qty.value = per;
+      container.appendChild(sel);
+      container.appendChild(tagSel);
+      container.appendChild(qty);
+      function update(){
+        const show = sel.value === 'tag';
+        tagSel.style.display = show ? '' : 'none';
+        qty.style.display = show ? '' : 'none';
+      }
+      sel.addEventListener('change', update);
+      if(isTag){ sel.value = 'tag'; }
+      update();
+      container.getValue = ()=>{
+        if(sel.value === 'tag'){
+          if(!tagSel.value) return null;
+          const p = parseInt(qty.value,10) || 1;
+          return JSON.stringify({ tag: parseInt(tagSel.value,10), per: p });
+        }
+        return sel.value || null;
+      };
+      return container;
+    }
     if(field === 'tags'){
       const container = document.createElement('div');
       const list = document.createElement('div');
@@ -1524,7 +1584,7 @@ async function loadBatiments(){
     endpoint:'building_properties',
     fields:buildingPropFields,
     labels:buildingPropLabels,
-    selects:{produces: resourceSelect, max: maxOptions}
+    selects:{produces: resourceSelect}
   });
   const infraPropsById = infraProps.slice().sort((a,b)=>a.id - b.id);
   renderTable(document.getElementById('tableInfraProps'), infraPropsById, {

--- a/gestion.html
+++ b/gestion.html
@@ -39,6 +39,8 @@
         </div>
         <div id="tab-ost" class="tab-panel"></div>
         <div id="tab-commerce" class="tab-panel">
+          <h2>Infrastructures Commerciales</h2>
+          <div id="commercialInfra"></div>
           <h2>Chemins commerciaux</h2>
           <div id="tradeInfo" style="margin-bottom:10px"></div>
           <div class="trade-controls" style="margin-bottom:10px">

--- a/gestion.js
+++ b/gestion.js
@@ -438,6 +438,7 @@ async function loadAndRender(seigneurieId) {
     const prodDiv = document.getElementById('productionInfra');
     const civilDiv = document.getElementById('civilInfra');
     const miliDiv = document.getElementById('militaryInfra');
+    const commercialDiv = document.getElementById('commercialInfra');
     const freePop = s.population + employment.slaves - employment.employed;
     if (prodDiv) {
       let html = '<table class="admin-table" id="buildingsTable">';
@@ -471,7 +472,7 @@ async function loadAndRender(seigneurieId) {
         const active = info.active || 0;
         const workersPer = bp.workers_per_building || 0;
 
-        let maxVal = '';
+        let maxVal = Infinity;
         if (bp.max !== undefined && bp.max !== null && bp.max !== '') {
           const parsed = parseInt(bp.max, 10);
           if (!isNaN(parsed) && parsed > 0) {
@@ -481,6 +482,19 @@ async function loadAndRender(seigneurieId) {
             if (!isNaN(dyn) && dyn > 0) maxVal = dyn;
           }
         }
+        try {
+          const obj = JSON.parse(bp.max || '');
+          if (obj && typeof obj === 'object' && obj.tag) {
+            const tagId = obj.tag || obj.tag_id;
+            const per = obj.per || obj.value || 1;
+            const count = tagCounts[tagId] || 0;
+            const computed = count * per;
+            if (!isNaN(computed)) {
+              maxVal = Math.min(maxVal, computed);
+            }
+          }
+        } catch {}
+        const maxValDisplay = maxVal === Infinity ? '' : maxVal;
 
         let costHtml = '';
         let hasResources = true;
@@ -562,8 +576,8 @@ async function loadAndRender(seigneurieId) {
         }
 
         let maxReached = false;
-        if (maxVal !== '') {
-          const maxNum = parseInt(maxVal, 10);
+        if (maxValDisplay !== '') {
+          const maxNum = parseInt(maxValDisplay, 10);
           if (!isNaN(maxNum) && built >= maxNum) {
             maxReached = true;
           }
@@ -580,7 +594,7 @@ async function loadAndRender(seigneurieId) {
         const empTotal = workersPer * active;
 
         const builtField = isAdmin ? `<input type="number" class="building-built-input" data-id="${bp.id}" value="${built}" style="width:6em">` : built;
-        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${workersPer}</td><td>${restrHtml}</td><td>${builtField}</td><td>${maxVal}</td>`;
+        html += `<tr data-id="${bp.id}"><td>${bp.label || bp.type}</td><td>${prod}</td><td>${workersPer}</td><td>${restrHtml}</td><td>${builtField}</td><td>${maxValDisplay}</td>`;
         if (built > 0) {
           let maxActivate = built;
           if (bp.workers_per_building) {
@@ -620,6 +634,12 @@ async function loadAndRender(seigneurieId) {
     if (miliDiv) {
       miliDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='militaire'), infrastructures, inv, 'militaryInfraTable', isAdmin);
       const table = document.getElementById('militaryInfraTable');
+      table.addEventListener('click', handleInfraTableClick);
+      table.addEventListener('change', handleInfraTableChange);
+    }
+    if (commercialDiv) {
+      commercialDiv.innerHTML = buildInfraTable(infraProps.filter(i=>i.type==='commercial'), infrastructures, inv, 'commercialInfraTable', isAdmin);
+      const table = document.getElementById('commercialInfraTable');
       table.addEventListener('click', handleInfraTableClick);
       table.addEventListener('change', handleInfraTableChange);
     }

--- a/server.js
+++ b/server.js
@@ -1590,6 +1590,7 @@ function canConstruct(db, srow, id, qty, cb){
     const costObj = safeParse(bprops.costs, {});
     const absReq = safeParse(bprops.absolute_restrictions, []);
     const infraReq = safeParse(bprops.infra_restrictions, {});
+    const maxObj = safeParse(bprops.max, null);
     const effects = safeParse(bprops.effects, []);
     const costs = {};
     Object.entries(costObj).forEach(([res, val]) => {
@@ -1599,6 +1600,7 @@ function canConstruct(db, srow, id, qty, cb){
       if (err2) return cb(err2);
       const barProps = props || {};
       let max = Infinity;
+      let tagLimit = null;
       if (bprops.max != null && bprops.max !== '') {
         const parsed = parseInt(bprops.max, 10);
         if (!isNaN(parsed) && parsed > 0) {
@@ -1606,6 +1608,8 @@ function canConstruct(db, srow, id, qty, cb){
         } else if (barProps[bprops.max] != null) {
           const dyn = parseInt(barProps[bprops.max], 10);
           if (!isNaN(dyn) && dyn > 0) max = dyn;
+        } else if (maxObj && typeof maxObj === 'object' && maxObj.tag) {
+          tagLimit = maxObj;
         }
       }
       if (Array.isArray(absReq)) {
@@ -1649,13 +1653,48 @@ function canConstruct(db, srow, id, qty, cb){
           cb(null, { costs, built, active, buildings, infrastructures, effects });
         });
       };
+      const applyTagLimit = (next) => {
+        if (!tagLimit || !tagLimit.tag) return next();
+        const tagId = parseInt(tagLimit.tag || tagLimit.tag_id, 10);
+        const per = parseInt(tagLimit.per || tagLimit.value, 10) || 1;
+        db.all('SELECT id, tags FROM building_properties', [], (errB, bRows) => {
+          if (errB) return cb(errB);
+          const bTags = {};
+          (bRows || []).forEach(r => {
+            bTags[r.id] = safeParse(r.tags, []);
+          });
+          db.all('SELECT id, tags FROM infrastructure_properties', [], (errI, iRows) => {
+            if (errI) return cb(errI);
+            const iTags = {};
+            (iRows || []).forEach(r => {
+              iTags[r.id] = safeParse(r.tags, []);
+            });
+            let count = 0;
+            for (const [bid, info] of Object.entries(buildings)) {
+              const tags = bTags[bid] || bTags[String(bid)] || [];
+              if (tags.includes(tagId)) {
+                count += info.built || 0;
+              }
+            }
+            for (const [iid, entry] of Object.entries(infrastructures)) {
+              const tags = iTags[iid] || iTags[String(iid)] || [];
+              const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
+              if (tags.includes(tagId)) {
+                count += builtCount;
+              }
+            }
+            max = Math.min(max, count * per);
+            next();
+          });
+        });
+      };
       if (Array.isArray(infraReq.tags) && infraReq.tags.length) {
         checkTagRestrictions(db, buildings, infrastructures, infraReq.tags, err3 => {
           if (err3) return cb(err3);
-          finalize();
+          applyTagLimit(finalize);
         });
       } else {
-        finalize();
+        applyTagLimit(finalize);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Allow building limits to depend on counts of specific tags via new `max` JSON setting
- Support new `commercial` infrastructure type with management UI
- Display commercial infrastructures and tag-based caps in gestion

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af48333ebc832db8dbe0967f7d1114