### PR TITLE
feat: review pending resource transactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **handleError.js** et **logger.js** : gestion des erreurs et du logging.
 - Les pages HTML (`index.html`, `mapEditor.html`, `admin.html`, `gestion.html`, `profile.html`) chargent ces scripts selon leur rôle.
 - Les scripts client communiquent avec l'API du serveur via `fetch`.
-- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état) pour enregistrer les échanges entre seigneuries. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
+- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état, raison, décision) pour enregistrer les échanges entre seigneuries. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
 
 ## Instructions
 - Garder ce fichier à jour : toute modification importante de l'architecture, des dépendances ou des relations entre scripts doit être répercutée ici.

--- a/gestion.html
+++ b/gestion.html
@@ -74,9 +74,17 @@
   <dialog id="tradeDialog" class="confirm-dialog">
     <div id="tradeList"></div>
     <div style="margin-top:10px"><button id="tradeAddRow" class="control-btn">+</button></div>
+    <textarea id="tradeReason" placeholder="Raison" style="width:100%;margin-top:10px"></textarea>
     <div class="dialog-buttons">
       <button id="tradeCancel" class="control-btn">Annuler</button>
       <button id="tradeSend" class="control-btn">Envoyer</button>
+    </div>
+  </dialog>
+  <dialog id="txDialog" class="confirm-dialog">
+    <div id="txContent"></div>
+    <div id="txButtons" class="dialog-buttons">
+      <button id="txRefuse" class="control-btn danger">Refuser</button>
+      <button id="txAccept" class="control-btn">Accepter</button>
     </div>
   </dialog>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>

--- a/gestion.js
+++ b/gestion.js
@@ -61,6 +61,8 @@ let tagLabels = {};
 let tagCounts = {};
 let currentUser = null;
 let currentSeigneurieId = null;
+const params = new URLSearchParams(location.search);
+let transactionToOpen = params.get('transactionId');
 
 function showConfirm(message){
   return new Promise(resolve => {
@@ -267,7 +269,13 @@ async function loadAndRender(seigneurieId) {
           <table id="deJureTable" class="admin-table"></table>
         </div>
       </div>
-      <div id="populationSummary"></div>
+      <div id="popAndTx" class="resource-tables">
+        <div id="populationSummary" class="resource-table-container"></div>
+        <div class="resource-table-container">
+          <h2>Transactions en Attente</h2>
+          <table id="pendingTxTable" class="admin-table"></table>
+        </div>
+      </div>
       <div id="resourceTables" class="resource-tables">
         <div class="resource-table-container">
           <h2>Ressources de base</h2>
@@ -380,6 +388,13 @@ async function loadAndRender(seigneurieId) {
           alert('Erreur lors de la mise à jour des taxes');
         }
       });
+    }
+
+    await renderPendingTransactions();
+    if (transactionToOpen) {
+      openTransactionPopup(transactionToOpen);
+      transactionToOpen = null;
+      history.replaceState({}, '', location.pathname);
     }
 
     const ostPanel = document.getElementById('tab-ost');
@@ -2138,9 +2153,9 @@ async function renderTradeRoutes(baronyId) {
 }
 
 async function openTradeDialog(baronyId) {
-  const resources = await showTradeDialog();
-  if (!resources) return;
-  await sendTransaction(baronyId, resources);
+  const result = await showTradeDialog();
+  if (!result) return;
+  await sendTransaction(baronyId, result.resources, result.reason);
 }
 
 function showTradeDialog() {
@@ -2150,7 +2165,9 @@ function showTradeDialog() {
     const addBtn = document.getElementById('tradeAddRow');
     const cancelBtn = document.getElementById('tradeCancel');
     const sendBtn = document.getElementById('tradeSend');
+    const reasonInput = document.getElementById('tradeReason');
     list.innerHTML = '';
+    if (reasonInput) reasonInput.value = '';
     function addRow() {
       const row = document.createElement('div');
       const sel = document.createElement('select');
@@ -2196,19 +2213,20 @@ function showTradeDialog() {
         alert('Quantités invalides');
         return;
       }
+      const reason = reasonInput ? reasonInput.value.trim() : '';
       dialog.close();
-      resolve(res);
+      resolve({ resources: res, reason });
     };
     dialog.showModal();
   });
 }
 
-async function sendTransaction(baronyId, resources) {
+async function sendTransaction(baronyId, resources, reason) {
   try {
     const res = await fetch('/api/send_transaction', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ target_barony_id: baronyId, resources, type: 'land' })
+      body: JSON.stringify({ target_barony_id: baronyId, resources, type: 'land', reason })
     });
     if (res.ok) {
       await loadAndRender(currentSeigneurieId);
@@ -2218,6 +2236,80 @@ async function sendTransaction(baronyId, resources) {
     }
   } catch {
     alert('Transaction impossible');
+  }
+}
+
+async function renderPendingTransactions() {
+  const table = document.getElementById('pendingTxTable');
+  if (!table) return;
+  try {
+    const res = await fetch('/api/trade_transactions');
+    const txs = res.ok ? await res.json() : [];
+    table.innerHTML = '<tr><th>Ressources</th><th>Origine</th><th>Date</th><th>Raison</th><th></th></tr>';
+    txs.forEach(tx => {
+      const resSummary = Object.entries(tx.resources || {}).map(([k,v]) => `${v} ${resourceLabels[k] || k}`).join(', ');
+      const origin = `${tx.origin_name} (${tx.origin_barony_name})`;
+      const date = `<span class="timeago" datetime="${tx.created_at}"></span>`;
+      let status;
+      if (tx.state === 'En Attente') {
+        status = `<button class="tx-open" data-id="${tx.id}">...</button>`;
+      } else {
+        const label = tx.state === 'Approuvée' ? 'Approuvée' : 'Refusée';
+        status = `<span title="${tx.decision_time ? new Date(tx.decision_time).toLocaleString() : ''}">${label}</span>`;
+      }
+      table.innerHTML += `<tr><td>${resSummary}</td><td>${origin}</td><td>${date}</td><td>${tx.reason || ''}</td><td>${status}</td></tr>`;
+    });
+    let rows = txs.length;
+    while (rows < 3) { table.innerHTML += '<tr><td colspan="5">&nbsp;</td></tr>'; rows++; }
+    timeago.render(table.querySelectorAll('.timeago'), 'fr');
+    table.querySelectorAll('.tx-open').forEach(btn => {
+      btn.addEventListener('click', () => openTransactionPopup(btn.dataset.id));
+    });
+  } catch {
+    table.innerHTML = '<tr><td colspan="5">Erreur</td></tr>';
+  }
+}
+
+async function openTransactionPopup(id) {
+  try {
+    const res = await fetch(`/api/trade_transactions/${id}`);
+    if (!res.ok) throw new Error('Erreur');
+    const tx = await res.json();
+    const dialog = document.getElementById('txDialog');
+    const content = document.getElementById('txContent');
+    const buttons = document.getElementById('txButtons');
+    const refuseBtn = document.getElementById('txRefuse');
+    const acceptBtn = document.getElementById('txAccept');
+    const items = Object.entries(tx.resources || {}).map(([k,v]) => `<li>${v} ${resourceLabels[k] || k}</li>`).join('');
+    content.innerHTML = `<p>Origine: ${tx.origin_name} (${tx.origin_barony_name})</p><p>Date: <span class="timeago" datetime="${tx.created_at}"></span></p><p>Ressources:</p><ul>${items}</ul><p>Raison: ${tx.reason || ''}</p><p>En cas de refus, les ressources seront retournées à l'envoyeur (perdu si maximum d'une ressource dépassée).</p>`;
+    if (tx.state === 'En Attente' && tx.destination_id === currentSeigneurieId) {
+      buttons.style.display = '';
+      refuseBtn.onclick = async () => { dialog.close(); await decideTx(id, 'refuse'); };
+      acceptBtn.onclick = async () => { dialog.close(); await decideTx(id, 'accept'); };
+    } else {
+      buttons.style.display = 'none';
+      refuseBtn.onclick = acceptBtn.onclick = null;
+    }
+    dialog.showModal();
+    timeago.render(dialog.querySelectorAll('.timeago'), 'fr');
+  } catch {}
+}
+
+async function decideTx(id, action) {
+  try {
+    const res = await fetch(`/api/trade_transactions/${id}/decision`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action })
+    });
+    if (res.ok) {
+      await loadAndRender(currentSeigneurieId);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || 'Erreur');
+    }
+  } catch {
+    alert('Erreur');
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -250,7 +250,9 @@ CREATE TABLE IF NOT EXISTS trade_transactions (
   resources TEXT,
   type TEXT,
   state TEXT,
+  reason TEXT,
   created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  decision_time TEXT,
   FOREIGN KEY(origin_id) REFERENCES seigneuries(id),
   FOREIGN KEY(destination_id) REFERENCES seigneuries(id)
 );
@@ -378,6 +380,16 @@ db.exec(initSql, () => {
       }
       if (!rows.some(r => r.name === 'naval_transaction_month')) {
         db.run("ALTER TABLE seigneuries ADD COLUMN naval_transaction_month TEXT");
+      }
+    }
+  });
+  db.all("PRAGMA table_info(trade_transactions)", (err, rows) => {
+    if (!err && rows) {
+      if (!rows.some(r => r.name === 'reason')) {
+        db.run('ALTER TABLE trade_transactions ADD COLUMN reason TEXT');
+      }
+      if (!rows.some(r => r.name === 'decision_time')) {
+        db.run('ALTER TABLE trade_transactions ADD COLUMN decision_time TEXT');
       }
     }
   });
@@ -2347,6 +2359,7 @@ app.post('/api/send_transaction', (req, res) => {
   const targetBaronyId = parseInt(req.body.target_barony_id, 10);
   const resources = req.body.resources || {};
   const txType = req.body.type === 'naval' ? 'naval' : 'land';
+  const reason = req.body.reason || null;
   if (!targetBaronyId || typeof resources !== 'object') return res.status(400).json({ error: 'Données invalides' });
   getSeigneurie(req, 'seigneuries.id, seigneuries.baronnie_id, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures, seigneuries.land_transactions, seigneuries.land_transaction_month, seigneuries.naval_transactions, seigneuries.naval_transaction_month', (err, srow) => {
     if (err) return handleError(res, err);
@@ -2403,35 +2416,137 @@ app.post('/api/send_transaction', (req, res) => {
               return res.status(400).json({ error: 'Ressources insuffisantes' });
             }
           }
-          db.get('SELECT id FROM seigneuries WHERE baronnie_id=?', [targetBaronyId], (err5, dest) => {
+          db.get(`SELECT seigneuries.id, seigneurs.user_id as user_id, seigneurs.name as name, baronies.name as barony_name FROM seigneuries JOIN seigneurs ON seigneurs.id=seigneuries.seigneur_id JOIN baronies ON baronies.id=seigneuries.baronnie_id WHERE seigneuries.baronnie_id=?`, [targetBaronyId], (err5, dest) => {
             if (err5) return handleError(res, err5);
             if (!dest) return res.status(400).json({ error: 'Destination invalide' });
-            const entries = Object.entries(resources);
-            let idx = 0;
-            function next() {
-              if (idx >= entries.length) return finish();
-              const [resName, amount] = entries[idx++];
-              performTransaction(db, seigneurieId, resName, -amount, err6 => {
-                if (err6) return handleError(res, err6);
-                next();
-              });
-            }
-            function finish() {
-              const newCount = count + 1;
-              const field = txType === 'naval' ? 'naval_transactions' : 'land_transactions';
-              const monthField = txType === 'naval' ? 'naval_transaction_month' : 'land_transaction_month';
-              db.run(`UPDATE seigneuries SET ${field}=?, ${monthField}=? WHERE id=?`, [newCount, month, seigneurieId], err7 => {
-                if (err7) return handleError(res, err7);
-                db.run('INSERT INTO trade_transactions (origin_id, destination_id, resources, type, state) VALUES (?,?,?,?,?)', [seigneurieId, dest.id, JSON.stringify(resources), txType, 'En Attente'], err8 => {
-                  if (err8) return handleError(res, err8);
-                  res.json({ ok: true });
+            db.get('SELECT seigneurs.name as name FROM seigneurs JOIN seigneuries ON seigneurs.id=seigneuries.seigneur_id WHERE seigneuries.id=?', [seigneurieId], (errO, originInfo) => {
+              if (errO) return handleError(res, errO);
+              const entries = Object.entries(resources);
+              let idx = 0;
+              function next() {
+                if (idx >= entries.length) return finish();
+                const [resName, amount] = entries[idx++];
+                performTransaction(db, seigneurieId, resName, -amount, err6 => {
+                  if (err6) return handleError(res, err6);
+                  next();
                 });
-              });
-            }
-            next();
+              }
+              function finish() {
+                const newCount = count + 1;
+                const field = txType === 'naval' ? 'naval_transactions' : 'land_transactions';
+                const monthField = txType === 'naval' ? 'naval_transaction_month' : 'land_transaction_month';
+                db.run(`UPDATE seigneuries SET ${field}=?, ${monthField}=? WHERE id=?`, [newCount, month, seigneurieId], err7 => {
+                  if (err7) return handleError(res, err7);
+                  db.run('INSERT INTO trade_transactions (origin_id, destination_id, resources, type, state, reason) VALUES (?,?,?,?,?,?)', [seigneurieId, dest.id, JSON.stringify(resources), txType, 'En Attente', reason], function(err8) {
+                    if (err8) return handleError(res, err8);
+                    const message = `Vous avez reçu une ${txType === 'naval' ? 'cargaison' : 'caravane'} de ressources de ${originInfo ? originInfo.name : ''}`;
+                    sendNotification(db, dest.user_id, message, `/gestion.html?transactionId=${this.lastID}`, () => {
+                      res.json({ ok: true });
+                    });
+                  });
+                });
+              }
+              next();
+            });
           });
         });
       });
+    });
+  });
+});
+
+app.get('/api/trade_transactions', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  getSeigneurie(req, 'seigneuries.id', (err, row) => {
+    if (err) return handleError(res, err);
+    if (!row) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const three = new Date();
+    three.setMonth(three.getMonth() - 3);
+    const sql = `SELECT tt.id, tt.resources, tt.type, tt.state, tt.reason, tt.created_at, tt.decision_time, s.name as origin_name, b.name as origin_barony_name
+                 FROM trade_transactions tt
+                 JOIN seigneuries os ON tt.origin_id=os.id
+                 JOIN seigneurs s ON os.seigneur_id=s.id
+                 JOIN baronies b ON os.baronnie_id=b.id
+                 WHERE tt.destination_id=? AND (tt.state='En Attente' OR (tt.decision_time IS NOT NULL AND tt.decision_time>=?))
+                 ORDER BY tt.created_at DESC`;
+    db.all(sql, [row.id, three.toISOString()], (err2, rows) => {
+      if (err2) return handleError(res, err2);
+      const mapped = (rows || []).map(r => ({ ...r, resources: safeParse(r.resources, {}) }));
+      res.json(mapped);
+    });
+  });
+});
+
+app.get('/api/trade_transactions/:id', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const id = parseInt(req.params.id, 10);
+  if (!id) return res.status(400).json({ error: 'Identifiant invalide' });
+  db.get(`SELECT tt.*, so.user_id as origin_user_id, so.name as origin_name, bo.name as origin_barony_name,
+                  sd.user_id as dest_user_id, sd.name as dest_name, bd.name as dest_barony_name
+          FROM trade_transactions tt
+          JOIN seigneuries os ON tt.origin_id=os.id
+          JOIN seigneurs so ON os.seigneur_id=so.id
+          JOIN baronies bo ON os.baronnie_id=bo.id
+          JOIN seigneuries ds ON tt.destination_id=ds.id
+          JOIN seigneurs sd ON ds.seigneur_id=sd.id
+          JOIN baronies bd ON ds.baronnie_id=bd.id
+          WHERE tt.id=?`, [id], (err, row) => {
+    if (err) return handleError(res, err);
+    if (!row) return res.status(404).json({ error: 'Introuvable' });
+    const uid = req.session.user.id;
+    if (row.origin_user_id !== uid && row.dest_user_id !== uid && !isAdminActive(req.session.user)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    row.resources = safeParse(row.resources, {});
+    res.json(row);
+  });
+});
+
+app.post('/api/trade_transactions/:id/decision', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const id = parseInt(req.params.id, 10);
+  const action = req.body.action;
+  if (!id || !['accept', 'refuse'].includes(action)) return res.status(400).json({ error: 'Données invalides' });
+  getSeigneurie(req, 'seigneuries.id', (err, row) => {
+    if (err) return handleError(res, err);
+    if (!row) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    const seigneurieId = row.id;
+    db.get(`SELECT tt.*, so.user_id as origin_user_id, sd.name as dest_name FROM trade_transactions tt
+            JOIN seigneuries os ON tt.origin_id=os.id
+            JOIN seigneurs so ON os.seigneur_id=so.id
+            JOIN seigneuries ds ON tt.destination_id=ds.id
+            JOIN seigneurs sd ON ds.seigneur_id=sd.id
+            WHERE tt.id=? AND tt.destination_id=?`, [id, seigneurieId], (err2, tx) => {
+      if (err2) return handleError(res, err2);
+      if (!tx) return res.status(404).json({ error: 'Introuvable' });
+      if (tx.state !== 'En Attente') return res.status(400).json({ error: 'Déjà traité' });
+      const resources = safeParse(tx.resources, {});
+      const entries = Object.entries(resources);
+      let idx = 0;
+      function finish() {
+        const newState = action === 'accept' ? 'Approuvée' : 'Refusée';
+        db.run('UPDATE trade_transactions SET state=?, decision_time=CURRENT_TIMESTAMP WHERE id=?', [newState, id], errU => {
+          if (errU) return handleError(res, errU);
+          if (action === 'refuse') {
+            sendNotification(db, tx.origin_user_id, `${tx.dest_name} a refusé vos ressources`, `/gestion.html?transactionId=${id}`, () => {
+              res.json({ ok: true });
+            });
+          } else {
+            res.json({ ok: true });
+          }
+        });
+      }
+      function next() {
+        if (idx >= entries.length) return finish();
+        const [r, a] = entries[idx++];
+        const amt = parseInt(a, 10);
+        const targetId = action === 'accept' ? seigneurieId : tx.origin_id;
+        performTransaction(db, targetId, r, amt, errT => {
+          if (errT) return handleError(res, errT);
+          next();
+        });
+      }
+      next();
     });
   });
 });


### PR DESCRIPTION
## Summary
- add transaction reason input and decision dialog in seigneurie management
- list pending trade transactions with accept/refuse workflow
- extend trade transaction schema with reason and decision time

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af52be24c0832da902f886a24e89ad