### PR TITLE
feat: add tag effect for buildings

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -54,7 +54,7 @@ const baronyPropLabels = {
   effects:'Effets'
 };
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','tags','description'];
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','effects','description'];
 const buildingPropLabels = {
   label:'Nom',
   produces:'Ressource produite',
@@ -64,10 +64,10 @@ const buildingPropLabels = {
   workers_per_building:'Travailleurs/bâtiment',
   absolute_restrictions:'Restrictions absolues',
   infra_restrictions:'Requis',
-  tags:'Tags',
+  effects:'Effets',
   description:'Description'
 };
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','tags','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
 const infraPropLabels = {
   label:'Nom',
   type:'Type',
@@ -77,7 +77,6 @@ const infraPropLabels = {
   costs:'Coûts',
   absolute_restrictions:'Restrictions absolues',
   restrictions:'Requis',
-  tags:'Tags',
   description:'Description',
 };
 const typeSelect = [{id:'civil',name:'Civil'},{id:'militaire',name:'Militaire'},{id:'commercial',name:'Commercial'}];
@@ -653,6 +652,7 @@ function makeEffectsInput(val, allowedTypes){
       {id:'spell_max_per_month', name:'Sorts max/mois'},
       {id:'land_transaction_max_per_month', name:'Transactions terrestres max/mois'},
       {id:'naval_transaction_max_per_month', name:'Transactions navales max/mois'},
+      {id:'tag', name:'Tag'},
       {id:'variable_production', name:'Production ressource variable'},
       {id:'random_luxury', name:'Ressource de luxe aléatoire'}
     ];
@@ -771,6 +771,19 @@ function makeEffectsInput(val, allowedTypes){
         editBtn.style.display = '';
         if(data.resource){ dataInput.value = JSON.stringify(data); updateSummary(); }
         else { dataInput.value = ''; updateSummary(); }
+      }else if(typeSel.value === 'tag'){
+        tagsSelect.forEach(o=>{
+          const op = document.createElement('option');
+          op.value = o.id;
+          op.textContent = o.name;
+          if(String(o.id) === String(data.tag)) op.selected = true;
+          targetSel.appendChild(op);
+        });
+        targetSel.style.display = '';
+        qty.style.display = '';
+        qty.placeholder = 'Nombre';
+        qty.value = data.amount ?? '';
+        return;
       }else if(typeSel.value === 'variable_production'){
         resourceSelect.forEach(o=>{
           const op = document.createElement('option');
@@ -878,6 +891,12 @@ function makeEffectsInput(val, allowedTypes){
         const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);
         if(!isNaN(amt)){
           res.push({type, amount: amt});
+        }
+      }else if(type === 'tag'){
+        const tag = rw.querySelector('select[data-role="target"]').value;
+        const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10) || 1;
+        if(tag){
+          res.push({ type, tag: parseInt(tag,10), amount: amt });
         }
       }else if(['idh','spell_success','spell_basic_discount','spell_advanced_discount','spell_range','spell_max_per_month','land_transaction_max_per_month','naval_transaction_max_per_month'].includes(type)){
         const amt = parseInt(rw.querySelector('input[data-role="qty"]').value,10);
@@ -1136,56 +1155,6 @@ function renderTable(container, rows, opts){
           return JSON.stringify({ tag: parseInt(tagSel.value,10), per: p });
         }
         return sel.value || null;
-      };
-      return container;
-    }
-    if(field === 'tags'){
-      const container = document.createElement('div');
-      const list = document.createElement('div');
-      container.appendChild(list);
-      const addBtn = document.createElement('button');
-      addBtn.type = 'button';
-      addBtn.textContent = '+';
-      container.appendChild(addBtn);
-      function addRow(tag = ''){
-        const row = document.createElement('div');
-        row.className = 'tag-row';
-        const sel = document.createElement('select');
-        const blank = document.createElement('option');
-        blank.value = '';
-        sel.appendChild(blank);
-        tagsSelect.forEach(o=>{
-          const op = document.createElement('option');
-          op.value = o.id;
-          op.textContent = o.name;
-          if(String(o.id) === String(tag)) op.selected = true;
-          sel.appendChild(op);
-        });
-        const removeBtn = document.createElement('button');
-        removeBtn.type = 'button';
-        removeBtn.textContent = '-';
-        removeBtn.addEventListener('click', ()=> row.remove());
-        row.appendChild(sel);
-        row.appendChild(removeBtn);
-        list.appendChild(row);
-      }
-      addBtn.addEventListener('click', ()=> addRow());
-      try {
-        const arr = JSON.parse(val || '[]');
-        if(Array.isArray(arr) && arr.length){
-          arr.forEach(t=> addRow(t));
-        } else {
-          addRow();
-        }
-      } catch {
-        addRow();
-      }
-      container.getValue = ()=>{
-        const res = [];
-        list.querySelectorAll('select').forEach(sel=>{
-          if(sel.value) res.push(parseInt(sel.value,10));
-        });
-        return JSON.stringify(res);
       };
       return container;
     }
@@ -1584,7 +1553,8 @@ async function loadBatiments(){
     endpoint:'building_properties',
     fields:buildingPropFields,
     labels:buildingPropLabels,
-    selects:{produces: resourceSelect}
+    selects:{produces: resourceSelect},
+    allowedEffectTypes:['tag']
   });
   const infraPropsById = infraProps.slice().sort((a,b)=>a.id - b.id);
   renderTable(document.getElementById('tableInfraProps'), infraPropsById, {

--- a/effects.js
+++ b/effects.js
@@ -149,6 +149,18 @@ class VariableWorkersEffect extends Effect {
   }
 }
 
+class TagEffect extends Effect {
+  constructor(tag, amount = 1) {
+    super();
+    this.tag = tag;
+    this.amount = amount;
+  }
+  apply(ctx, count) {
+    if (!ctx.tagCounts) ctx.tagCounts = {};
+    ctx.tagCounts[this.tag] = (ctx.tagCounts[this.tag] || 0) + this.amount * count;
+  }
+}
+
 class UnlockPageEffect extends Effect {
   constructor(page) {
     super();
@@ -244,4 +256,4 @@ class NavalTransactionMaxPerMonthEffect extends Effect {
   }
 }
 
-module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect };
+module.exports = { Effect, StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, InstantProductionEffect, IDHEffect, VariableWorkersEffect, TagEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect };

--- a/gestion.js
+++ b/gestion.js
@@ -223,18 +223,24 @@ async function loadAndRender(seigneurieId) {
     Object.entries(buildings).forEach(([bid, info]) => {
       const bp = bpMap[String(bid)];
       if (!bp) return;
-      const tags = safeParse(bp.tags, []);
-      tags.forEach(tid => {
-        tagCounts[tid] = (tagCounts[tid] || 0) + (info.built || 0);
+      const effs = safeParse(bp.effects, []);
+      effs.forEach(ef => {
+        if (ef.type === 'tag' && ef.tag) {
+          const amt = parseInt(ef.amount, 10) || 1;
+          tagCounts[ef.tag] = (tagCounts[ef.tag] || 0) + (info.built || 0) * amt;
+        }
       });
     });
     Object.entries(infrastructures).forEach(([iid, entry]) => {
       const ip = ipMap[String(iid)];
       if (!ip) return;
-      const tags = safeParse(ip.tags, []);
       const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
-      tags.forEach(tid => {
-        tagCounts[tid] = (tagCounts[tid] || 0) + builtCount;
+      const effs = safeParse(ip.effects, []);
+      effs.forEach(ef => {
+        if (ef.type === 'tag' && ef.tag) {
+          const amt = parseInt(ef.amount, 10) || 1;
+          tagCounts[ef.tag] = (tagCounts[ef.tag] || 0) + builtCount * amt;
+        }
       });
     });
 

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const logger = require('./logger');
 const handleError = require('./handleError');
 const { consumeResources } = require('./services/buildingService');
 const { sendNotification } = require('./services/notificationService');
-const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect } = require('./effects');
+const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, TagEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect } = require('./effects');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -291,7 +291,7 @@ CREATE TABLE IF NOT EXISTS building_properties (
   workers_per_building INTEGER DEFAULT 1,
   absolute_restrictions TEXT,
   infra_restrictions TEXT,
-  tags TEXT,
+  effects TEXT,
   description TEXT
 );
 CREATE TABLE IF NOT EXISTS infrastructure_properties (
@@ -304,7 +304,6 @@ CREATE TABLE IF NOT EXISTS infrastructure_properties (
   costs TEXT,
   absolute_restrictions TEXT,
   restrictions TEXT,
-  tags TEXT,
   description TEXT
 );
 CREATE TABLE IF NOT EXISTS spells (
@@ -461,22 +460,19 @@ db.exec(initSql, () => {
     if (!rows.some(r => r.name === 'absolute_restrictions')) {
       db.run('ALTER TABLE building_properties ADD COLUMN absolute_restrictions TEXT');
     }
-    if (!rows.some(r => r.name === 'infra_restrictions')) {
-      db.run('ALTER TABLE building_properties ADD COLUMN infra_restrictions TEXT');
-    }
-    if (!rows.some(r => r.name === 'tags')) {
-      db.run('ALTER TABLE building_properties ADD COLUMN tags TEXT');
-    }
-  });
-  db.all("PRAGMA table_info(infrastructure_properties)", (err, rows) => {
-    if (err || !rows) return;
-    if (!rows.some(r => r.name === 'absolute_restrictions')) {
-      db.run('ALTER TABLE infrastructure_properties ADD COLUMN absolute_restrictions TEXT');
-    }
-    if (!rows.some(r => r.name === 'tags')) {
-      db.run('ALTER TABLE infrastructure_properties ADD COLUMN tags TEXT');
-    }
-  });
+      if (!rows.some(r => r.name === 'infra_restrictions')) {
+        db.run('ALTER TABLE building_properties ADD COLUMN infra_restrictions TEXT');
+      }
+      if (!rows.some(r => r.name === 'effects')) {
+        db.run('ALTER TABLE building_properties ADD COLUMN effects TEXT');
+      }
+    });
+    db.all("PRAGMA table_info(infrastructure_properties)", (err, rows) => {
+      if (err || !rows) return;
+      if (!rows.some(r => r.name === 'absolute_restrictions')) {
+        db.run('ALTER TABLE infrastructure_properties ADD COLUMN absolute_restrictions TEXT');
+      }
+    });
   db.all("PRAGMA table_info(barony_properties)", (err, rows) => {
     if (err || !rows) return;
     if (!rows.some(r => r.name === 'effects')) {
@@ -940,7 +936,8 @@ app.get('/api/my_seigneurie', (req, res) => {
               spellRangeDetails: [{ label: 'Base', amount: 5, source: 1 }],
               spellMaxDetails: [{ label: 'Base', amount: 0, source: 1 }],
               landTxMaxDetails: [{ label: 'Base', amount: 0, source: 1 }],
-              navalTxMaxDetails: [{ label: 'Base', amount: 0, source: 1 }]
+              navalTxMaxDetails: [{ label: 'Base', amount: 0, source: 1 }],
+              tagCounts: {}
             };
             for (const ip of infraList) {
               effectCtx.currentInfraId = ip.id;
@@ -994,6 +991,9 @@ app.get('/api/my_seigneurie', (req, res) => {
                   if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                 } else if (def.type === 'naval_transaction_max_per_month') {
                   effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
+                  if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+                } else if (def.type === 'tag') {
+                  effObj = new TagEffect(def.tag, def.amount || 1);
                   if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
                 } else if (def.type === 'variable_workers') {
                   const max = (def.max_workers || 0) * count;
@@ -1169,6 +1169,8 @@ app.get('/api/my_seigneurie', (req, res) => {
                     effObj = new LandTransactionMaxPerMonthEffect(def.amount || 0);
                   } else if (def.type === 'naval_transaction_max_per_month') {
                     effObj = new NavalTransactionMaxPerMonthEffect(def.amount || 0);
+                  } else if (def.type === 'tag') {
+                    effObj = new TagEffect(def.tag, def.amount || 1);
                   }
                   if (effObj) {
                     effObj.apply(effectCtx, 1, 'Baronnie');
@@ -1369,7 +1371,7 @@ app.put('/api/tags/:id', requireAdmin, (req,res)=>{
   update('tags', tagFields)(req,res);
 });
 
-const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','tags','description'];
+const buildingPropFields = ['label','produces','production','costs','max','workers_per_building','absolute_restrictions','infra_restrictions','effects','description'];
 app.get('/api/building_properties', (req,res)=>{
   list('building_properties')(req,res);
 });
@@ -1380,7 +1382,7 @@ app.put('/api/building_properties/:id', requireAdmin, (req,res)=>{
   update('building_properties', buildingPropFields)(req,res);
 });
 
-const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','tags','description'];
+const infraPropFields = ['label','type','max','workers_per_building','effects','costs','absolute_restrictions','restrictions','description'];
 app.get('/api/infrastructure_properties', (req,res)=>{
   list('infrastructure_properties')(req,res);
 });
@@ -1544,17 +1546,31 @@ function safeParse(json, fallback){
 }
 
 function checkTagRestrictions(db, buildings, infrastructures, tagConds, cb) {
-  db.all('SELECT id, tags FROM building_properties', [], (err, bRows) => {
+  db.all('SELECT id, effects FROM building_properties', [], (err, bRows) => {
     if (err) return cb(err);
     const bTags = {};
     (bRows || []).forEach(r => {
-      bTags[r.id] = safeParse(r.tags, []);
+      const effs = safeParse(r.effects, []);
+      const tagMap = {};
+      effs.forEach(ef => {
+        if (ef.type === 'tag' && ef.tag) {
+          tagMap[ef.tag] = (tagMap[ef.tag] || 0) + (parseInt(ef.amount, 10) || 1);
+        }
+      });
+      bTags[r.id] = tagMap;
     });
-    db.all('SELECT id, tags FROM infrastructure_properties', [], (err2, iRows) => {
+    db.all('SELECT id, effects FROM infrastructure_properties', [], (err2, iRows) => {
       if (err2) return cb(err2);
       const iTags = {};
       (iRows || []).forEach(r => {
-        iTags[r.id] = safeParse(r.tags, []);
+        const effs = safeParse(r.effects, []);
+        const tagMap = {};
+        effs.forEach(ef => {
+          if (ef.type === 'tag' && ef.tag) {
+            tagMap[ef.tag] = (tagMap[ef.tag] || 0) + (parseInt(ef.amount, 10) || 1);
+          }
+        });
+        iTags[r.id] = tagMap;
       });
       for (const cond of tagConds) {
         const tagId = parseInt(cond.tag || cond.tag_id, 10);
@@ -1562,16 +1578,18 @@ function checkTagRestrictions(db, buildings, infrastructures, tagConds, cb) {
         const val = parseInt(cond.value, 10) || 0;
         let count = 0;
         for (const [bid, info] of Object.entries(buildings)) {
-          const tags = bTags[bid] || bTags[String(bid)] || [];
-          if (tags.includes(tagId)) {
-            count += info.built || 0;
+          const tagMap = bTags[bid] || bTags[String(bid)] || {};
+          const amt = tagMap[tagId];
+          if (amt) {
+            count += (info.built || 0) * amt;
           }
         }
         for (const [iid, entry] of Object.entries(infrastructures)) {
-          const tags = iTags[iid] || iTags[String(iid)] || [];
-          const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
-          if (tags.includes(tagId)) {
-            count += builtCount;
+          const tagMap = iTags[iid] || iTags[String(iid)] || {};
+          const amt = tagMap[tagId];
+          if (amt) {
+            const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
+            count += builtCount * amt;
           }
         }
         if (cmp === '>=' && count < val) return cb(new Error('Restriction non satisfaite'));
@@ -1657,30 +1675,46 @@ function canConstruct(db, srow, id, qty, cb){
         if (!tagLimit || !tagLimit.tag) return next();
         const tagId = parseInt(tagLimit.tag || tagLimit.tag_id, 10);
         const per = parseInt(tagLimit.per || tagLimit.value, 10) || 1;
-        db.all('SELECT id, tags FROM building_properties', [], (errB, bRows) => {
+        db.all('SELECT id, effects FROM building_properties', [], (errB, bRows) => {
           if (errB) return cb(errB);
           const bTags = {};
           (bRows || []).forEach(r => {
-            bTags[r.id] = safeParse(r.tags, []);
+            const effs = safeParse(r.effects, []);
+            const tagMap = {};
+            effs.forEach(ef => {
+              if (ef.type === 'tag' && ef.tag) {
+                tagMap[ef.tag] = (tagMap[ef.tag] || 0) + (parseInt(ef.amount, 10) || 1);
+              }
+            });
+            bTags[r.id] = tagMap;
           });
-          db.all('SELECT id, tags FROM infrastructure_properties', [], (errI, iRows) => {
+          db.all('SELECT id, effects FROM infrastructure_properties', [], (errI, iRows) => {
             if (errI) return cb(errI);
             const iTags = {};
             (iRows || []).forEach(r => {
-              iTags[r.id] = safeParse(r.tags, []);
+              const effs = safeParse(r.effects, []);
+              const tagMap = {};
+              effs.forEach(ef => {
+                if (ef.type === 'tag' && ef.tag) {
+                  tagMap[ef.tag] = (tagMap[ef.tag] || 0) + (parseInt(ef.amount, 10) || 1);
+                }
+              });
+              iTags[r.id] = tagMap;
             });
             let count = 0;
             for (const [bid, info] of Object.entries(buildings)) {
-              const tags = bTags[bid] || bTags[String(bid)] || [];
-              if (tags.includes(tagId)) {
-                count += info.built || 0;
+              const tagMap = bTags[bid] || bTags[String(bid)] || {};
+              const amt = tagMap[tagId];
+              if (amt) {
+                count += (info.built || 0) * amt;
               }
             }
             for (const [iid, entry] of Object.entries(infrastructures)) {
-              const tags = iTags[iid] || iTags[String(iid)] || [];
-              const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
-              if (tags.includes(tagId)) {
-                count += builtCount;
+              const tagMap = iTags[iid] || iTags[String(iid)] || {};
+              const amt = tagMap[tagId];
+              if (amt) {
+                const builtCount = typeof entry === 'object' ? (entry.built || 0) : entry;
+                count += builtCount * amt;
               }
             }
             max = Math.min(max, count * per);


### PR DESCRIPTION
## Summary
- replace tag column with Tag effects for building and infrastructure properties
- add Tag effect implementation and update tag restriction logic
- compute tag counts from Tag effects in client

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af5495a5a0832d96d4aceaa69f78a8