### PR TITLE
Use seigneurie IDs for trade transactions and refine popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **handleError.js** et **logger.js** : gestion des erreurs et du logging.
 - Les pages HTML (`index.html`, `mapEditor.html`, `admin.html`, `gestion.html`, `profile.html`) chargent ces scripts selon leur rôle.
 - Les scripts client communiquent avec l'API du serveur via `fetch`.
-- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état, raison, décision) pour enregistrer les échanges entre seigneuries. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
+- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état, raison, décision) pour enregistrer les échanges entre seigneuries. L'origine et la destination y sont stockées via les identifiants de seigneurie, les noms des seigneurs ou baronnies étant résolus dynamiquement. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
 
 ## Instructions
 - Garder ce fichier à jour : toute modification importante de l'architecture, des dépendances ou des relations entre scripts doit être répercutée ici.

--- a/gestion.js
+++ b/gestion.js
@@ -2281,8 +2281,14 @@ async function openTransactionPopup(id) {
     const refuseBtn = document.getElementById('txRefuse');
     const acceptBtn = document.getElementById('txAccept');
     const items = Object.entries(tx.resources || {}).map(([k,v]) => `<li>${v} ${resourceLabels[k] || k}</li>`).join('');
-    content.innerHTML = `<p>Origine: ${tx.origin_name} (${tx.origin_barony_name})</p><p>Date: <span class="timeago" datetime="${tx.created_at}"></span></p><p>Ressources:</p><ul>${items}</ul><p>Raison: ${tx.reason || ''}</p><p>En cas de refus, les ressources seront retournées à l'envoyeur (perdu si maximum d'une ressource dépassée).</p>`;
-    if (tx.state === 'En Attente' && tx.destination_id === currentSeigneurieId) {
+    const typeLabel = tx.type === 'naval' ? 'cargaison' : 'caravane';
+    content.innerHTML = `
+      <p>Vous avez reçu une ${typeLabel} de ${tx.origin_name} de la Baronnie de ${tx.origin_barony_name} avec la raison suivante :</p>
+      <p>${tx.reason || ''}</p>
+      <p>Elle contient :</p>
+      <ul>${items}</ul>
+      <p>En cas de refus, les ressources seront retournées à l'envoyeur (perdu si maximum d'une ressource dépassée).</p>`;
+    if (tx.state === 'En Attente' && Number(tx.destination_id) === Number(currentSeigneurieId)) {
       buttons.style.display = '';
       refuseBtn.onclick = async () => { dialog.close(); await decideTx(id, 'refuse'); };
       acceptBtn.onclick = async () => { dialog.close(); await decideTx(id, 'accept'); };

--- a/server.js
+++ b/server.js
@@ -2481,8 +2481,8 @@ app.get('/api/trade_transactions/:id', (req, res) => {
   if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
   const id = parseInt(req.params.id, 10);
   if (!id) return res.status(400).json({ error: 'Identifiant invalide' });
-  db.get(`SELECT tt.*, so.user_id as origin_user_id, so.name as origin_name, bo.name as origin_barony_name,
-                  sd.user_id as dest_user_id, sd.name as dest_name, bd.name as dest_barony_name
+  db.get(`SELECT tt.*, so.name as origin_name, bo.name as origin_barony_name,
+                  sd.name as dest_name, bd.name as dest_barony_name
           FROM trade_transactions tt
           JOIN seigneuries os ON tt.origin_id=os.id
           JOIN seigneurs so ON os.seigneur_id=so.id
@@ -2493,12 +2493,17 @@ app.get('/api/trade_transactions/:id', (req, res) => {
           WHERE tt.id=?`, [id], (err, row) => {
     if (err) return handleError(res, err);
     if (!row) return res.status(404).json({ error: 'Introuvable' });
-    const uid = req.session.user.id;
-    if (row.origin_user_id !== uid && row.dest_user_id !== uid && !isAdminActive(req.session.user)) {
-      return res.status(403).json({ error: 'Forbidden' });
-    }
-    row.resources = safeParse(row.resources, {});
-    res.json(row);
+    db.all(`SELECT seigneuries.id FROM seigneurs
+            JOIN seigneuries ON seigneuries.seigneur_id=seigneurs.id
+            WHERE seigneurs.user_id=?`, [req.session.user.id], (err2, srows) => {
+      if (err2) return handleError(res, err2);
+      const owned = (srows || []).map(r => r.id);
+      if (!isAdminActive(req.session.user) && !owned.includes(row.origin_id) && !owned.includes(row.destination_id)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      row.resources = safeParse(row.resources, {});
+      res.json(row);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Authorize trade transaction view with seigneurie IDs instead of user IDs
- Reformat trade decision popup and ensure accept/refuse buttons show
- Document that trade transactions store seigneurie identifiers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af57a4df94832dacd329de1e864e23