### PR TITLE
Ensure pending transaction table shows column borders for empty rows

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -2266,7 +2266,10 @@ async function renderPendingTransactions() {
       table.innerHTML += `<tr><td>${resSummary}</td><td>${origin}</td><td>${date}</td><td>${tx.reason || ''}</td><td>${status}</td></tr>`;
     });
     let rows = txs.length;
-    while (rows < 3) { table.innerHTML += '<tr><td colspan="5">&nbsp;</td></tr>'; rows++; }
+    while (rows < 3) {
+      table.innerHTML += '<tr>' + '<td>&nbsp;</td>'.repeat(5) + '</tr>';
+      rows++;
+    }
     timeago.render(table.querySelectorAll('.timeago'), 'fr');
     table.querySelectorAll('.tx-open').forEach(btn => {
       btn.addEventListener('click', () => openTransactionPopup(btn.dataset.id));


### PR DESCRIPTION
## Summary
- Keep column borders when pending transactions table shows placeholder rows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af59a23324832d9eb197bfee155907