### PR TITLE
Handle refused transactions with claim popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **handleError.js** et **logger.js** : gestion des erreurs et du logging.
 - Les pages HTML (`index.html`, `mapEditor.html`, `admin.html`, `gestion.html`, `profile.html`) chargent ces scripts selon leur rôle.
 - Les scripts client communiquent avec l'API du serveur via `fetch`.
-- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état, raison, décision) pour enregistrer les échanges entre seigneuries. L'origine et la destination y sont stockées via les identifiants de seigneurie, les noms des seigneurs ou baronnies étant résolus dynamiquement. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
+- La base de données contient également une table `trade_transactions` (origine, destination, ressources, type, état, raison, décision, retour) pour enregistrer les échanges entre seigneuries. L'origine et la destination y sont stockées via les identifiants de seigneurie, les noms des seigneurs ou baronnies étant résolus dynamiquement. Les effets `land_transaction_max_per_month` et `naval_transaction_max_per_month` permettent d'augmenter les limites mensuelles de transactions.
 
 ## Instructions
 - Garder ce fichier à jour : toute modification importante de l'architecture, des dépendances ou des relations entre scripts doit être répercutée ici.

--- a/gestion.html
+++ b/gestion.html
@@ -99,6 +99,7 @@
     <div id="txButtons" class="dialog-buttons">
       <button id="txRefuse" class="control-btn danger">Refuser</button>
       <button id="txAccept" class="control-btn">Accepter</button>
+      <button id="txClose" class="control-btn">Fermer</button>
     </div>
   </dialog>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>

--- a/gestion.js
+++ b/gestion.js
@@ -2440,21 +2440,58 @@ async function openTransactionPopup(id) {
     const buttons = document.getElementById('txButtons');
     const refuseBtn = document.getElementById('txRefuse');
     const acceptBtn = document.getElementById('txAccept');
+    const closeBtn = document.getElementById('txClose');
     const items = Object.entries(tx.resources || {}).map(([k,v]) => `<li>${v} ${resourceLabels[k] || k}</li>`).join('');
     const typeLabel = tx.type === 'naval' ? 'cargaison' : 'caravane';
-    content.innerHTML = `
-      <p>Vous avez reçu une ${typeLabel} de ${tx.origin_name} de la Baronnie de ${tx.origin_barony_name} avec la raison suivante :</p>
-      <p>${tx.reason || ''}</p>
-      <p>Elle contient :</p>
-      <ul>${items}</ul>
-      <p>En cas de refus, les ressources seront retournées à l'envoyeur (perdu si maximum d'une ressource dépassée).</p>`;
-    if (tx.state === 'En Attente' && Number(tx.destination_id) === Number(currentSeigneurieId)) {
+    refuseBtn.style.display = 'none';
+    acceptBtn.style.display = 'none';
+    closeBtn.style.display = 'none';
+    if (tx.state === 'Refusée' && Number(tx.origin_id) === Number(currentSeigneurieId)) {
+      let claim = { returned: tx.resources, lost: {} };
+      if (!tx.returned) {
+        try {
+          const cRes = await fetch(`/api/trade_transactions/${id}/claim`, { method: 'POST' });
+          if (cRes.ok) {
+            claim = await cRes.json();
+            await loadAndRender(currentSeigneurieId);
+          }
+        } catch {}
+      }
+      const retItems = Object.entries(claim.returned || {}).map(([k,v]) => `<li>${v} ${resourceLabels[k] || k}</li>`).join('');
+      let lossHtml = '';
+      if (claim.lost && Object.keys(claim.lost).length) {
+        const lossItems = Object.entries(claim.lost).map(([k,v]) => `<li>${v} ${resourceLabels[k] || k}</li>`).join('');
+        lossHtml = `<p>Pertes :</p><ul>${lossItems}</ul>`;
+      }
+      content.innerHTML = `
+        <p>Votre ${typeLabel} à destination de ${tx.dest_name} a été refusée.</p>
+        <p>Les ressources suivantes vous ont été retournées :</p>
+        <ul>${retItems}</ul>
+        ${lossHtml}`;
       buttons.style.display = '';
-      refuseBtn.onclick = async () => { dialog.close(); await decideTx(id, 'refuse'); };
-      acceptBtn.onclick = async () => { dialog.close(); await decideTx(id, 'accept'); };
+      closeBtn.style.display = '';
+      closeBtn.onclick = () => dialog.close();
     } else {
-      buttons.style.display = 'none';
-      refuseBtn.onclick = acceptBtn.onclick = null;
+      content.innerHTML = `
+        <p>Vous avez reçu une ${typeLabel} de ${tx.origin_name} de la Baronnie de ${tx.origin_barony_name} avec la raison suivante :</p>
+        <p>${tx.reason || ''}</p>
+        <p>Elle contient :</p>
+        <ul>${items}</ul>
+        <p>En cas de refus, les ressources seront retournées à l'envoyeur (perdu si maximum d'une ressource dépassée).</p>`;
+      if (tx.state === 'En Attente' && Number(tx.destination_id) === Number(currentSeigneurieId)) {
+        buttons.style.display = '';
+        refuseBtn.style.display = '';
+        acceptBtn.style.display = '';
+        closeBtn.style.display = 'none';
+        refuseBtn.onclick = async () => { dialog.close(); await decideTx(id, 'refuse'); };
+        acceptBtn.onclick = async () => { dialog.close(); await decideTx(id, 'accept'); };
+      } else {
+        buttons.style.display = '';
+        closeBtn.style.display = '';
+        refuseBtn.style.display = 'none';
+        acceptBtn.style.display = 'none';
+        closeBtn.onclick = () => dialog.close();
+      }
     }
     dialog.showModal();
     timeago.render(dialog.querySelectorAll('.timeago'), 'fr');

--- a/server.js
+++ b/server.js
@@ -253,6 +253,7 @@ CREATE TABLE IF NOT EXISTS trade_transactions (
   reason TEXT,
   created_at TEXT DEFAULT CURRENT_TIMESTAMP,
   decision_time TEXT,
+  returned INTEGER DEFAULT 0,
   FOREIGN KEY(origin_id) REFERENCES seigneuries(id),
   FOREIGN KEY(destination_id) REFERENCES seigneuries(id)
 );
@@ -389,6 +390,9 @@ db.exec(initSql, () => {
       }
       if (!rows.some(r => r.name === 'decision_time')) {
         db.run('ALTER TABLE trade_transactions ADD COLUMN decision_time TEXT');
+      }
+      if (!rows.some(r => r.name === 'returned')) {
+        db.run('ALTER TABLE trade_transactions ADD COLUMN returned INTEGER DEFAULT 0');
       }
     }
   });
@@ -1557,6 +1561,27 @@ function safeParse(json, fallback){
   }
 }
 
+function computeCapacities(db, infrastructures, cb){
+  db.all('SELECT id, effects, type, label FROM infrastructure_properties', [], (err, rows) => {
+    if (err) return cb(err);
+    const capacities = { vivres: 500, points_magique: 2000, hommes_darmes: 0, chevaux: 0, trebuchets: 0 };
+    const effectCtx = { capacity: capacities };
+    (rows || []).forEach(ip => {
+      const entry = infrastructures[ip.id] || infrastructures[String(ip.id)] || 0;
+      const count = typeof entry === 'object' ? (entry.built || 0) : entry;
+      if (!count) return;
+      const effects = safeParse(ip.effects, []);
+      effects.forEach(def => {
+        if (def.type === 'storage') {
+          const effObj = new StorageEffect(def.resource, def.amount || 0);
+          if (effObj) effObj.apply(effectCtx, count, ip.label || ip.type);
+        }
+      });
+    });
+    cb(null, capacities);
+  });
+}
+
 function checkTagRestrictions(db, buildings, infrastructures, tagConds, cb) {
   db.all('SELECT id, effects FROM building_properties', [], (err, bRows) => {
     if (err) return cb(err);
@@ -2579,13 +2604,79 @@ app.post('/api/trade_transactions/:id/decision', (req, res) => {
         if (idx >= entries.length) return finish();
         const [r, a] = entries[idx++];
         const amt = parseInt(a, 10);
-        const targetId = action === 'accept' ? seigneurieId : tx.origin_id;
-        performTransaction(db, targetId, r, amt, errT => {
-          if (errT) return handleError(res, errT);
+        if (action === 'accept') {
+          performTransaction(db, seigneurieId, r, amt, errT => {
+            if (errT) return handleError(res, errT);
+            next();
+          });
+        } else {
           next();
-        });
+        }
       }
       next();
+    });
+  });
+});
+
+app.post('/api/trade_transactions/:id/claim', (req, res) => {
+  if (!req.session.user) return res.status(401).json({ error: 'Non autorisé' });
+  const id = parseInt(req.params.id, 10);
+  if (!id) return res.status(400).json({ error: 'Identifiant invalide' });
+  getSeigneurie(req, 'seigneuries.id, seigneuries.inventaire_id, seigneuries.buildings, seigneuries.infrastructures', (err, srow) => {
+    if (err) return handleError(res, err);
+    if (!srow) return res.status(400).json({ error: 'Seigneurie introuvable' });
+    db.get('SELECT * FROM trade_transactions WHERE id=? AND origin_id=?', [id, srow.id], (err2, tx) => {
+      if (err2) return handleError(res, err2);
+      if (!tx || tx.state !== 'Refusée') return res.status(404).json({ error: 'Introuvable' });
+      if (tx.returned) return res.status(400).json({ error: 'Déjà retournée' });
+      const resources = safeParse(tx.resources, {});
+      db.get('SELECT * FROM inventaire WHERE id=?', [srow.inventaire_id], (err3, inventaire) => {
+        if (err3) return handleError(res, err3);
+        const infrastructures = safeParse(srow.infrastructures, {});
+        computeCapacities(db, infrastructures, (err4, capacities) => {
+          if (err4) return handleError(res, err4);
+          const entries = Object.entries(resources);
+          const returned = {};
+          const lost = {};
+          let idx = 0;
+          function finalize(){
+            db.run('UPDATE trade_transactions SET returned=1 WHERE id=?', [id], errU => {
+              if (errU) return handleError(res, errU);
+              res.json({ returned, lost });
+            });
+          }
+          function apply(){
+            if (idx >= entries.length) return finalize();
+            const [r, a] = entries[idx++];
+            const amt = parseInt(a, 10);
+            const cap = capacities[r];
+            const current = inventaire[r] || 0;
+            let toAdd = amt;
+            if (typeof cap === 'number') {
+              const space = cap - current;
+              if (space <= 0) {
+                lost[r] = (lost[r] || 0) + amt;
+                return apply();
+              }
+              if (space < amt) {
+                toAdd = space;
+                lost[r] = amt - space;
+              }
+            }
+            if (toAdd > 0) {
+              performTransaction(db, srow.id, r, toAdd, errT => {
+                if (errT) return handleError(res, errT);
+                inventaire[r] = current + toAdd;
+                returned[r] = (returned[r] || 0) + toAdd;
+                apply();
+              });
+            } else {
+              apply();
+            }
+          }
+          apply();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `returned` flag and claim endpoint to trade transactions, returning resources on demand with capacity checks
- rework transaction popup to handle refused notifications, showing returned resources and losses with a dismiss button
- document new `trade_transactions` column

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af757c4508832da5fbbc3d9bd4ddcc