### PR TITLE
Ensure trade transactions use selected seigneurie as origin

### DIFF
--- a/gestion.js
+++ b/gestion.js
@@ -2377,10 +2377,12 @@ function showTradeDialog(seigneurName, methods) {
 
 async function sendTransaction(baronyId, resources, reason, method) {
   try {
+    const payload = { target_barony_id: baronyId, resources, type: method, reason };
+    if (currentSeigneurieId) payload.seigneurie_id = currentSeigneurieId;
     const res = await fetch('/api/send_transaction', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ target_barony_id: baronyId, resources, type: method, reason })
+      body: JSON.stringify(payload)
     });
     if (res.ok) {
       await loadAndRender(currentSeigneurieId);


### PR DESCRIPTION
## Summary
- Ensure sendTransaction includes the current seigneurie id so resource transfers originate from the viewed seigneurie

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68afaee8ec54832d8f0372edc473611b