### PR TITLE
refactor: share header across pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Ce dépôt propose un serveur Express/Node.js avec une base SQLite et plusieurs 
 - **admin.js** : interface d'administration des empires, royaumes, duchés, etc.
 - **gestion.js** : gestion des seigneuries, ressources et sorts côté joueur.
 - **profile.js** : modification du profil utilisateur.
+- **renderHeader.js** : insère le fragment HTML du header commun côté client.
 - **handleError.js** et **logger.js** : gestion des erreurs et du logging.
 - Les pages HTML (`index.html`, `mapEditor.html`, `admin.html`, `gestion.html`, `profile.html`) chargent ces scripts selon leur rôle.
 - Les scripts client communiquent avec l'API du serveur via `fetch`.

--- a/admin.html
+++ b/admin.html
@@ -6,12 +6,10 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="app-header">
-    <h1>Administration</h1>
-    <div id="controls" class="controls-row">
-      <span id="authArea" class="auth-area"></span>
-    </div>
-  </header>
+  <script src="renderHeader.js"></script>
+  <script>
+    renderHeader('Administration');
+  </script>
   <div id="saveIndicator" class="save-indicator">✔️</div>
   <main>
     <div class="tab-container" style="overflow:auto;flex:1">

--- a/gestion.html
+++ b/gestion.html
@@ -6,12 +6,10 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="app-header">
-    <h1>Gestion de la seigneurie</h1>
-    <div id="controls" class="controls-row">
-      <span id="authArea" class="auth-area"></span>
-    </div>
-  </header>
+  <script src="renderHeader.js"></script>
+  <script>
+    renderHeader('Gestion de la seigneurie');
+  </script>
   <main class="gestion-main">
     <div class="tab-container" style="overflow:auto;flex:1">
       <div class="tab-buttons">

--- a/index.html
+++ b/index.html
@@ -6,19 +6,28 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="app-header">
-    <h1>Carte des baronnies</h1>
-    <nav class="tabs">
-      <a href="index.html">Baronnies</a>
-      <a href="index.html?mode=sea">Carte Maritime</a>
-    </nav>
-    <div id="controls" class="controls-row">
-      <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
-      <label for="filterSelect">Filtre :</label>
-      <select id="filterSelect" class="control-btn"></select>
-      <span id="authArea" class="auth-area"></span>
-    </div>
-  </header>
+  <script src="renderHeader.js"></script>
+  <script>
+    renderHeader('Carte des baronnies', () => {
+      const header = document.querySelector('.app-header');
+      header.insertAdjacentHTML('beforeend', `
+        <nav class="tabs">
+          <a href="index.html">Baronnies</a>
+          <a href="index.html?mode=sea">Carte Maritime</a>
+        </nav>
+      `);
+      const controls = document.getElementById('controls');
+      controls.insertAdjacentHTML('afterbegin', `
+        <button id="randomBtn" class="control-btn">Couleurs aléatoires</button>
+        <label for="filterSelect">Filtre :</label>
+        <select id="filterSelect" class="control-btn"></select>
+      `);
+    }).then(() => {
+      const script = document.createElement('script');
+      script.src = 'viewer.js';
+      document.body.appendChild(script);
+    });
+  </script>
   <main>
     <div id="mapContainer" class="map-container">
       <div id="panZoomGroup" class="panzoom-group">
@@ -50,7 +59,6 @@
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
   <script src="src/mapFilters.js"></script>
-    <script src="viewer.js"></script>
     <dialog id="authDialog">
     <form id="loginForm" method="dialog">
       <h3>Connexion</h3>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,6 @@
+<header class="app-header">
+  <h1 id="headerTitle"></h1>
+  <div id="controls" class="controls-row">
+    <span id="authArea" class="auth-area"></span>
+  </div>
+</header>

--- a/profile.html
+++ b/profile.html
@@ -6,12 +6,10 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="app-header">
-    <h1>Profil</h1>
-    <div id="controls" class="controls-row">
-      <span id="authArea" class="auth-area"></span>
-    </div>
-  </header>
+  <script src="renderHeader.js"></script>
+  <script>
+    renderHeader('Profil');
+  </script>
   <main class="profile-main">
     <form id="profileForm" class="profile-form">
       <div class="tabs">

--- a/renderHeader.js
+++ b/renderHeader.js
@@ -1,0 +1,8 @@
+async function renderHeader(title, extra) {
+  const res = await fetch('partials/header.html');
+  const html = await res.text();
+  document.body.insertAdjacentHTML('afterbegin', html);
+  const titleEl = document.getElementById('headerTitle');
+  if (titleEl) titleEl.textContent = title || '';
+  if (typeof extra === 'function') extra();
+}


### PR DESCRIPTION
## Summary
- add reusable `partials/header.html` and loader `renderHeader.js`
- include shared header via fetch in admin, gestion, profile and index pages
- dynamically populate index-specific navigation and controls before loading viewer

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0a4a0a4c4832d8f50d2195b346bc8