### PR TITLE
refactor: share breadth-first search

### DIFF
--- a/gestion.html
+++ b/gestion.html
@@ -102,9 +102,10 @@
   </dialog>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/locale/fr.min.js"></script>
-  <script src="auth.js"></script>
-  <script src="src/mapCore.js"></script>
-  <script src="gestion.js"></script>
+<script src="auth.js"></script>
+<script src="src/mapCore.js"></script>
+  <script src="src/bfs.js"></script>
+<script src="gestion.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const buttons = document.querySelectorAll('.tab-btn');

--- a/gestion.js
+++ b/gestion.js
@@ -2091,37 +2091,17 @@ async function updateTradeMap(baronyId, routes) {
 }
 
 function computeDistances(start) {
-  const dist = { [start]: 0 };
-  const queue = [start];
-  while (queue.length) {
-    const cur = queue.shift();
-    (tradeAdjacency[cur] || []).forEach(n => {
-      if (dist[n] == null) {
-        dist[n] = dist[cur] + 1;
-        queue.push(n);
-      }
-    });
-  }
-  return dist;
+  const { distanceMap } = breadthFirst(start, cur => tradeAdjacency[cur] || []);
+  return distanceMap;
 }
 
 function computeSeaReachable(start) {
   if (!gameState.navalTxMax || gameState.navalTxMax <= 0) return new Set();
   if (seaReachCache[start]) return seaReachCache[start];
   const startZones = baronyZones[start] || [];
-  const visited = new Set(startZones);
-  const queue = [...startZones];
-  while (queue.length) {
-    const z = queue.shift();
-    (seaZoneAdjacency[z] || []).forEach(nz => {
-      if (!visited.has(nz)) {
-        visited.add(nz);
-        queue.push(nz);
-      }
-    });
-  }
+  const { distanceMap } = breadthFirst(startZones, z => seaZoneAdjacency[z] || []);
   const res = new Set();
-  visited.forEach(z => {
+  Object.keys(distanceMap).forEach(z => {
     (zoneBaronies[z] || []).forEach(bid => {
       if (bid !== start) res.add(bid);
     });

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
   </main>
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
+  <script src="src/bfs.js"></script>
   <script src="src/mapFilters.js"></script>
     <dialog id="authDialog">
     <form id="loginForm" method="dialog">

--- a/mapEditor.html
+++ b/mapEditor.html
@@ -99,6 +99,7 @@
   <script>window.defaultEditMode = true;</script>
   <script src="pixelData.js"></script>
   <script src="src/mapCore.js"></script>
+  <script src="src/bfs.js"></script>
     <script src="src/mapFilters.js"></script>
     <script src="script.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const { consumeResources } = require('./services/buildingService');
 const { sendNotification } = require('./services/notificationService');
 const { crudRoutes, list, create, update } = require('./src/crudRouter');
 const { StorageEffect, ResourceProductionEffect, BuildingProductionEffect, InfraProductionEffect, IDHEffect, VariableWorkersEffect, TagEffect, UnlockPageEffect, SpellSuccessEffect, SpellBasicDiscountEffect, SpellAdvancedDiscountEffect, SpellRangeEffect, SpellMaxPerMonthEffect, LandTransactionMaxPerMonthEffect, NavalTransactionMaxPerMonthEffect } = require('./effects');
+const { breadthFirst } = require('./src/bfs');
 const app = express();
 const db = new sqlite3.Database('asgaria.db');
 
@@ -2630,16 +2631,8 @@ app.post('/api/trade_routes/build', (req, res) => {
             (adj[r.barony_id_1] = adj[r.barony_id_1] || []).push(r.barony_id_2);
             (adj[r.barony_id_2] = adj[r.barony_id_2] || []).push(r.barony_id_1);
           });
-          const queue = [[startId, 0]];
-          const visited = new Set([startId]);
-          let dist = null;
-          while (queue.length) {
-            const [cur, d] = queue.shift();
-            if (cur === targetId) { dist = d; break; }
-            (adj[cur] || []).forEach(n => {
-              if (!visited.has(n)) { visited.add(n); queue.push([n, d + 1]); }
-            });
-          }
+          const { distanceMap } = breadthFirst(startId, cur => adj[cur] || []);
+          const dist = distanceMap[targetId];
           if (dist == null) return res.status(400).json({ error: 'Inaccessible' });
           const cost = dist * 3;
           db.get('SELECT or_ FROM inventaire WHERE id=?', [srow.inventaire_id], (err5, inv) => {

--- a/src/bfs.js
+++ b/src/bfs.js
@@ -1,0 +1,27 @@
+function breadthFirst(start, getNeighbors) {
+  const distanceMap = {};
+  const queue = [];
+  const starts = Array.isArray(start) ? start : [start];
+  starts.forEach(s => {
+    if (s == null) return;
+    distanceMap[s] = 0;
+    queue.push(s);
+  });
+  while (queue.length) {
+    const cur = queue.shift();
+    const neighbors = (getNeighbors(cur) || []);
+    neighbors.forEach(n => {
+      if (distanceMap[n] == null) {
+        distanceMap[n] = distanceMap[cur] + 1;
+        queue.push(n);
+      }
+    });
+  }
+  return { distanceMap };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { breadthFirst };
+} else {
+  (typeof window !== 'undefined' ? window : global).breadthFirst = breadthFirst;
+}

--- a/src/mapFilters.js
+++ b/src/mapFilters.js
@@ -55,19 +55,7 @@
             core.setColorMap(colorMap);
             return;
           }
-          const distances = {};
-          const queue = [core.currentSelectedId];
-          distances[core.currentSelectedId] = 0;
-          while (queue.length > 0) {
-            const cur = queue.shift();
-            const next = data.baronyAdjacency[cur] || [];
-            next.forEach(n => {
-              if (distances[n] === undefined) {
-                distances[n] = distances[cur] + 1;
-                queue.push(n);
-              }
-            });
-          }
+          const { distanceMap: distances } = breadthFirst(core.currentSelectedId, cur => data.baronyAdjacency[cur] || []);
           Object.keys(data.baronyMeta).forEach(id => {
             const d = distances[id];
             if (d === undefined) return;
@@ -108,19 +96,7 @@
           core.setColorMap(colorMap);
           return;
         }
-        const distances = {};
-        const queue = [core.currentSelectedId];
-        distances[core.currentSelectedId] = 0;
-        while (queue.length > 0) {
-          const cur = queue.shift();
-          const next = data.baronyAdjacency[cur] || [];
-          next.forEach(n => {
-            if (distances[n] === undefined) {
-              distances[n] = distances[cur] + 1;
-              queue.push(n);
-            }
-          });
-        }
+        const { distanceMap: distances } = breadthFirst(core.currentSelectedId, cur => data.baronyAdjacency[cur] || []);
         Object.keys(data.baronyMeta).forEach(id => {
           const d = distances[id];
           if (d === undefined) return;


### PR DESCRIPTION
## Summary
- add reusable `breadthFirst` utility for graph traversal
- use shared BFS in client trade routes and map filters
- use shared BFS for server route distance checks and include script in HTML templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cae4fd7c832d9943c18b4c55433e